### PR TITLE
Add configurable rate limiting - Issue #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The default configuration is intentionally conservative. Applications created fr
 
 For example, a local development configuration may temporarily disable CSP while troubleshooting script or style loading:
 ```json
-{
+"Template": {
   "SecurityHeaders": {
     "EnableContentSecurityPolicy": false
   }
@@ -313,17 +313,97 @@ to reduce the risk of host header spoofing.
 
 ## Rate Limiting
 
-This section will document rate limiting policies used by the template.
+The template includes baseline ASP.NET Core rate limiting support to help protect applications from accidental request floods, scraping, repeated automated requests, and concurrency-heavy operations.
 
-Planned areas:
+Rate limiting is registered through the template service extension:
 
-- Global rate limiting.
-- Endpoint-specific policies.
-- Fixed window policies.
-- Concurrency policies.
-- Authentication-sensitive endpoint protection.
-- Rejection responses.
-- Logging and monitoring rejected requests.
+```csharp
+builder.Services.AddTemplateRateLimiting(builder.Configuration);
+```
+The middleware is applied in the standard template pipeline:
+```csharp
+app.UseRateLimiter();
+```
+`UseRateLimiter()` is intentionally placed after routing so endpoint-specific rate limiting policies can be applied, and before endpoint execution so requests can be rejected before reaching controllers, Razor Pages, or minimal API handlers.
+
+### Default Behavior
+
+The template supports:
+
+- A global fixed-window limiter for baseline request protection.
+- A named fixed-window policy for endpoint-specific use.
+- A named concurrency policy for sensitive or resource-heavy operations.
+- JSON rejection responses.
+- `429 Too Many Requests` responses when limits are exceeded.
+- Logging for rejected requests.
+
+Rejected requests return a response similar to:
+```json
+{
+  "error": "Too many requests.",
+  "statusCode": 429
+}
+```
+Configuration
+
+Rate limiting values can be configured from `appsettings.json`:
+```json
+"Template": {
+  "RateLimiting": {
+    "Enabled": true,
+    "GlobalFixedWindow": {
+      "PermitLimit": 60,
+      "WindowSeconds": 60,
+      "QueueLimit": 0
+    },
+    "FixedWindowPolicy": {
+      "PermitLimit": 60,
+      "WindowSeconds": 60,
+      "QueueLimit": 0
+    },
+    "ConcurrencyPolicy": {
+      "PermitLimit": 10,
+      "QueueLimit": 0
+    }
+  }
+}
+```
+These defaults are intentionally conservative and should be reviewed before production use.
+
+### Endpoint-Specific Policies
+
+Named policies can be applied to specific endpoints when stricter or specialized protection is needed.
+
+Minimal API example:
+```csharp
+app.MapGet("/api/data", () => "Limited endpoint")
+    .RequireRateLimiting("fixed");
+```
+Concurrency-sensitive endpoint example:
+```csharp
+app.MapPost("/admin/export", () => "Export started")
+    .RequireRateLimiting("concurrency");
+```
+Controller or Razor Page handlers can also use rate limiting attributes:
+```csharp
+using Microsoft.AspNetCore.RateLimiting;
+
+[EnableRateLimiting("fixed")]
+public class ReportsController : Controller
+{
+}
+```
+### Middleware Order
+
+The template pipeline applies rate limiting after routing:
+```csharp
+app.UseRouting();
+
+app.UseCors();
+
+app.UseRateLimiter();
+```
+If a future policy depends on the authenticated user identity, rate limiting may need to move after authentication so user-specific partitioning can be applied.
 
 ## Authentication and Authorization
 

--- a/src/Template.Web/Constants/TemplateRateLimitingPolicyNames.cs
+++ b/src/Template.Web/Constants/TemplateRateLimitingPolicyNames.cs
@@ -1,0 +1,17 @@
+namespace Template.Web.Constants;
+
+/// <summary>
+/// Provides centralized names for template rate limiting policies.
+/// </summary>
+public static class TemplateRateLimitingPolicyNames
+{
+    /// <summary>
+    /// Name of the fixed rate limiting policy.
+    /// </summary>
+    public const string Fixed = "fixed";
+
+    /// <summary>
+    /// Name of the concurrency rate limiting policy.
+    /// </summary>
+    public const string Concurrency = "concurrency";
+}

--- a/src/Template.Web/Extensions/RateLimitingServiceExtensions.cs
+++ b/src/Template.Web/Extensions/RateLimitingServiceExtensions.cs
@@ -1,53 +1,177 @@
+using System.Globalization;
 using System.Threading.RateLimiting;
-using Microsoft.AspNetCore.RateLimiting;
+using Template.Web.Constants;
+using Template.Web.Options;
 
 namespace Template.Web.Extensions;
 
 /// <summary>
 /// Provides extension methods to register rate limiting services for the application.
 /// </summary>
-public static class RateLimitingServiceExtensions
+public static partial class RateLimitingServiceExtensions
 {
     /// <summary>
     /// Adds the application's predefined rate limiting policies to the service collection.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the rate limiting services to.</param>
+    /// <param name="configuration">The application configuration source.</param>
+    /// <param name="environment">The current hosting environment.</param>
     /// <returns>The same <see cref="IServiceCollection"/> instance so calls can be chained.</returns>
-    public static IServiceCollection AddTemplateRateLimiting(this IServiceCollection services)
+    public static IServiceCollection AddTemplateRateLimiting(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
     {
-        services.AddRateLimiter(static options =>
+        TemplateRateLimitingOptions rateLimitingOptions = CreateDefaultOptions(environment);
+
+        configuration
+            .GetSection(TemplateRateLimitingOptions.SectionName)
+            .Bind(rateLimitingOptions);
+
+        services.Configure<TemplateRateLimitingOptions>(
+            configuration.GetSection(TemplateRateLimitingOptions.SectionName));
+
+
+        _ = services.AddRateLimiter(options =>
         {
             options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 
             options.OnRejected = async (context, cancellationToken) =>
             {
-                context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-                context.HttpContext.Response.ContentType = "application/json";
+                HttpContext httpContext = context.HttpContext;
+                HttpResponse response = httpContext.Response;
 
-                await context.HttpContext.Response.WriteAsJsonAsync(new
+                TimeSpan? retryAfter = null;
+
+                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfterValue))
+                {
+                    retryAfter = retryAfterValue;
+
+                    response.Headers.RetryAfter =
+                        Math.Ceiling(retryAfterValue.TotalSeconds)
+                            .ToString(CultureInfo.InvariantCulture);
+                }
+
+                ILogger logger = httpContext.RequestServices
+                    .GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("Template.Web.RateLimiting");
+
+                LogRateLimitRejectedRequest(
+                    logger,
+                    httpContext.Request.Method,
+                    httpContext.Request.Path.Value ?? string.Empty,
+                    httpContext.Connection.RemoteIpAddress?.ToString(),
+                    httpContext.GetEndpoint()?.DisplayName,
+                    retryAfter?.TotalSeconds,
+                    httpContext.TraceIdentifier);
+
+                response.StatusCode = StatusCodes.Status429TooManyRequests;
+                response.ContentType = "application/json";
+
+                await response.WriteAsJsonAsync(new
                 {
                     error = "Too many requests.",
-                    statusCode = StatusCodes.Status429TooManyRequests
+                    statusCode = StatusCodes.Status429TooManyRequests,
+                    traceId = httpContext.TraceIdentifier
                 }, cancellationToken);
             };
 
-            options.AddFixedWindowLimiter("fixed", limiterOptions =>
+            if (!rateLimitingOptions.Enabled)
             {
-                limiterOptions.PermitLimit = 60;
-                limiterOptions.Window = TimeSpan.FromMinutes(1);
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 0;
-            });
+                return;
+            }
 
-            options.AddConcurrencyLimiter("concurrency", limiterOptions =>
+            if (rateLimitingOptions.UseGlobalLimiter)
             {
-                limiterOptions.PermitLimit = 10;
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 0;
-            });
+                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+                    RateLimitPartition.GetFixedWindowLimiter(
+                        partitionKey: GetClientPartitionKey(httpContext),
+                        factory: _ => CreateFixedWindowRateLimiterOptions(rateLimitingOptions.GlobalFixedWindow)));
+            }
+
+            options.AddPolicy(TemplateRateLimitingPolicyNames.Fixed, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientPartitionKey(httpContext),
+                    factory: _ => CreateFixedWindowRateLimiterOptions(rateLimitingOptions.FixedWindowPolicy)));
+
+            options.AddPolicy(TemplateRateLimitingPolicyNames.Concurrency, httpContext =>
+                RateLimitPartition.GetConcurrencyLimiter(
+                    partitionKey: GetEndpointPartitionKey(httpContext),
+                    factory: _ => CreateConcurrencyLimiterOptions(rateLimitingOptions.ConcurrencyPolicy)));
         });
 
         return services;
     }
-}
 
+    private static TemplateRateLimitingOptions CreateDefaultOptions(IHostEnvironment environment)
+    {
+        TemplateRateLimitingOptions options = new();
+
+        if (environment.IsDevelopment())
+        {
+            options.GlobalFixedWindow.PermitLimit = 300;
+            options.GlobalFixedWindow.WindowSeconds = 60;
+
+            options.FixedWindowPolicy.PermitLimit = 120;
+            options.FixedWindowPolicy.WindowSeconds = 60;
+
+            options.ConcurrencyPolicy.PermitLimit = 20;
+        }
+
+        return options;
+    }
+
+    private static FixedWindowRateLimiterOptions CreateFixedWindowRateLimiterOptions(
+        FixedWindowRateLimitingOptions options)
+    {
+        return new FixedWindowRateLimiterOptions
+        {
+            AutoReplenishment = true,
+            PermitLimit = EnsureAtLeast(options.PermitLimit, minimum: 1),
+            Window = TimeSpan.FromSeconds(EnsureAtLeast(options.WindowSeconds, minimum: 1)),
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = EnsureAtLeast(options.QueueLimit, minimum: 0)
+        };
+    }
+
+    private static ConcurrencyLimiterOptions CreateConcurrencyLimiterOptions(
+        ConcurrencyRateLimitingOptions options)
+    {
+        return new ConcurrencyLimiterOptions
+        {
+            PermitLimit = EnsureAtLeast(options.PermitLimit, minimum: 1),
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = EnsureAtLeast(options.QueueLimit, minimum: 0)
+        };
+    }
+
+    private static string GetClientPartitionKey(HttpContext httpContext)
+    {
+        return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-client";
+    }
+
+    private static string GetEndpointPartitionKey(HttpContext httpContext)
+    {
+        return httpContext.GetEndpoint()?.DisplayName
+            ?? httpContext.Request.Path.Value
+            ?? "unknown-endpoint";
+    }
+
+    private static int EnsureAtLeast(int value, int minimum)
+    {
+        return value < minimum ? minimum : value;
+    }
+
+    [LoggerMessage(
+        EventId = 6001,
+        Level = LogLevel.Warning,
+        Message = "Rate limit rejected request. Method: {Method}; Path: {Path}; RemoteIpAddress: {RemoteIpAddress}; Endpoint: {Endpoint}; RetryAfterSeconds: {RetryAfterSeconds}; TraceIdentifier: {TraceIdentifier}")]
+    private static partial void LogRateLimitRejectedRequest(
+        ILogger logger,
+        string method,
+        string path,
+        string? remoteIpAddress,
+        string? endpoint,
+        double? retryAfterSeconds,
+        string traceIdentifier);
+}

--- a/src/Template.Web/Options/ConcurrencyRateLimitingOptions.cs
+++ b/src/Template.Web/Options/ConcurrencyRateLimitingOptions.cs
@@ -1,0 +1,17 @@
+namespace Template.Web.Options;
+
+/// <summary>
+/// Represents concurrency rate limiting configuration.
+/// </summary>
+public sealed class ConcurrencyRateLimitingOptions
+{
+    /// <summary>
+    /// The maximum number of concurrent permits allowed.
+    /// </summary>
+    public int PermitLimit { get; set; } = 10;
+
+    /// <summary>
+    /// The maximum number of requests allowed to wait in the queue.
+    /// </summary>
+    public int QueueLimit { get; set; }
+}

--- a/src/Template.Web/Options/FixedWindowRateLimitingOptions.cs
+++ b/src/Template.Web/Options/FixedWindowRateLimitingOptions.cs
@@ -1,0 +1,22 @@
+namespace Template.Web.Options;
+
+/// <summary>
+/// Represents fixed-window rate limiting configuration.
+/// </summary>
+public sealed class FixedWindowRateLimitingOptions
+{
+    /// <summary>
+    /// Maximum number of permits allowed per window.
+    /// </summary>
+    public int PermitLimit { get; set; } = 60;
+
+    /// <summary>
+    /// Length of the fixed window in seconds.
+    /// </summary>
+    public int WindowSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Maximum number of requests allowed to queue when the permit limit is reached.
+    /// </summary>
+    public int QueueLimit { get; set; }
+}

--- a/src/Template.Web/Options/TemplateRateLimitingOptions.cs
+++ b/src/Template.Web/Options/TemplateRateLimitingOptions.cs
@@ -1,0 +1,52 @@
+namespace Template.Web.Options;
+
+/// <summary>
+/// Represents template-level rate limiting configuration.
+/// </summary>
+public sealed class TemplateRateLimitingOptions
+{
+    /// <summary>
+    /// Configuration section name for rate limiting settings.
+    /// </summary>
+    public const string SectionName = "Template:RateLimiting";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether rate limiting is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the global limiter.
+    /// When true, <see cref="GlobalFixedWindow"/> is used as a global limiter.
+    /// </summary>
+    public bool UseGlobalLimiter { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the global fixed-window rate limiting options.
+    /// </summary>
+    public FixedWindowRateLimitingOptions GlobalFixedWindow { get; set; } = new()
+    {
+        PermitLimit = 60,
+        WindowSeconds = 60,
+        QueueLimit = 0
+    };
+
+    /// <summary>
+    /// Gets or sets the fixed-window rate limiting options applied at the template level.
+    /// </summary>
+    public FixedWindowRateLimitingOptions FixedWindowPolicy { get; set; } = new()
+    {
+        PermitLimit = 60,
+        WindowSeconds = 60,
+        QueueLimit = 0
+    };
+
+    /// <summary>
+    /// Gets or sets the concurrency-based rate limiting options applied at the template level.
+    /// </summary>
+    public ConcurrencyRateLimitingOptions ConcurrencyPolicy { get; set; } = new()
+    {
+        PermitLimit = 10,
+        QueueLimit = 0
+    };
+}

--- a/src/Template.Web/Program.cs
+++ b/src/Template.Web/Program.cs
@@ -19,7 +19,7 @@ try
     builder.Services.AddRazorPages();
     builder.Services.AddTemplateForwardedHeaders(builder.Configuration);
     builder.Services.AddTemplateSecurityHeaders(builder.Configuration);
-    builder.Services.AddTemplateRateLimiting();
+    builder.Services.AddTemplateRateLimiting(builder.Configuration, builder.Environment);
 
     Log.Information("Starting Template.Web application");
     WebApplication app = builder.Build();

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -74,6 +74,24 @@
         "/health",
         "/metrics"
       ]
+    },
+    "RateLimiting": {
+      "Enabled": true,
+      "UseGlobalLimiter": true,
+      "GlobalFixedWindow": {
+        "PermitLimit": 60,
+        "WindowSeconds": 60,
+        "QueueLimit": 0
+      },
+      "FixedWindowPolicy": {
+        "PermitLimit": 60,
+        "WindowSeconds": 60,
+        "QueueLimit": 0
+      },
+      "ConcurrencyPolicy": {
+        "PermitLimit": 10,
+        "QueueLimit": 0
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds configurable ASP.NET Core rate limiting support for the template application.

Closes #6

## Changes

- Added configurable rate limiting through `appsettings.json`.
- Added environment-aware development defaults.
- Added a global fixed-window limiter.
- Added named `"fixed"` rate limiting policy.
- Added named `"concurrency"` rate limiting policy.
- Added JSON rejection response for rejected requests.
- Added `429 Too Many Requests` response handling.
- Added rejected request logging.
- Preserved middleware order with `UseRateLimiter()` after `UseRouting()`.
- Documented rate limiting behavior, configuration, and usage examples in `README.md`.

## Validation

- [x] Confirmed the application builds successfully.
- [x] Confirmed the application starts without rate limiting service errors.
- [x] Confirmed normal requests are allowed.
- [x] Confirmed repeated requests can trigger `429 Too Many Requests`.
- [x] Confirmed rejected requests are logged.
- [x] Confirmed the `"fixed"` named policy can be applied to an endpoint.
- [x] Confirmed the `"concurrency"` named policy can be applied to an endpoint.
- [x] Confirmed README documentation was updated.