### PR TITLE
Complete integration test scaffold - Issue #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,16 +667,35 @@ Planned setup steps:
 - Run the application.
 - Execute tests.
 
-## Build and Test
+## Testing
 
-Build and test instructions will be added once the solution structure is finalized
+The repository includes automated tests under `tests/Template.Web.Tests`.
 
-Planned commands:
+The test project uses `WebApplicationFactory<Program>` to start the real `Template.Web`
+application pipeline in memory. Tests can override configuration through in-memory
+settings and can register test-only MVC controllers from the test assembly.
 
-```
-dotnet restore
-dotnet build
+### Current integration coverage includes:
+
+- Health check endpoints.
+- Security header middleware behavior.
+- Forwarded header behavior.
+- Rate limiting policies.
+- JSON 429 rejection responses.
+- Configuration binding and validation.
+
+### Run tests with:
+
+```bash
 dotnet test
+```
+
+### Run locally:
+
+```bash
+dotnet restore
+dotnet build --configuration Release
+dotnet test --configuration Release
 ```
 
 ## Git Workflow

--- a/tests/Template.Web.Tests/Extensions/WebApplicationFactoryExtensions.cs
+++ b/tests/Template.Web.Tests/Extensions/WebApplicationFactoryExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Template.Web.Tests.Extensions;
+
+/// <summary>
+/// Provides extension methods for the WebApplicationFactory class to facilitate testing of web applications. 
+/// </summary>
+internal static class WebApplicationFactoryExtensions
+{
+    /// <summary>
+    /// Creates an HttpClient with a base address of https://localhost and disables automatic redirection.
+    /// This is useful for testing scenarios where you want to ensure that the application is correctly
+    /// handling HTTPS requests and not automatically redirecting to HTTP.
+    /// </summary>
+    /// <param name="factory">
+    /// The WebApplicationFactory instance used to create the HttpClient. This factory is typically configured
+    /// </param>
+    /// <returns>
+    /// An <see cref="HttpClient"/> instance configured to use HTTPS and not follow redirects, allowing for more accurate
+    /// testing of secure endpoints and redirection behavior.
+    /// </returns>
+    public static HttpClient CreateHttpsClient(this WebApplicationFactory<Program> factory)
+    {
+        return factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            AllowAutoRedirect = false
+        });
+    }
+}

--- a/tests/Template.Web.Tests/HealthCheckTests.cs
+++ b/tests/Template.Web.Tests/HealthCheckTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Template.Web.Tests.Extensions;
 using Template.Web.Tests.Infrastructure;
 
 namespace Template.Web.Tests;
@@ -17,11 +18,10 @@ public sealed class HealthCheckTests
     public async Task HealthEndpoint_ReturnsHealthy()
     {
         using TemplateWebApplicationFactory factory = CreateFactory();
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/health", TestContext.Current.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
 
@@ -38,7 +38,7 @@ public sealed class HealthCheckTests
     public async Task HealthReadyEndpoint_ReturnsHealthy()
     {
         using TemplateWebApplicationFactory factory = CreateFactory();
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/health/ready", TestContext.Current.CancellationToken);
 
@@ -57,7 +57,7 @@ public sealed class HealthCheckTests
     public async Task HealthLiveEndpoint_ReturnsHealthy()
     {
         using TemplateWebApplicationFactory factory = CreateFactory();
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/health/live", TestContext.Current.CancellationToken);
 
@@ -80,7 +80,7 @@ public sealed class HealthCheckTests
     public async Task HealthEndpoints_DoNotApplySecurityHeaders(string path)
     {
         using TemplateWebApplicationFactory factory = CreateFactory();
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync(path, TestContext.Current.CancellationToken);
 
@@ -99,14 +99,5 @@ public sealed class HealthCheckTests
     private static TemplateWebApplicationFactory CreateFactory()
     {
         return new TemplateWebApplicationFactory(new Dictionary<string, string?>());
-    }
-
-    private static HttpClient CreateHttpsClient(WebApplicationFactory<Program> factory)
-    {
-        return factory.CreateClient(new WebApplicationFactoryClientOptions
-        {
-            BaseAddress = new Uri("https://localhost"),
-            AllowAutoRedirect = false
-        });
     }
 }

--- a/tests/Template.Web.Tests/HealthCheckTests.cs
+++ b/tests/Template.Web.Tests/HealthCheckTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Template.Web.Tests.Extensions;
 using Template.Web.Tests.Infrastructure;
 

--- a/tests/Template.Web.Tests/RateLimitingTests.cs
+++ b/tests/Template.Web.Tests/RateLimitingTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Text.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -8,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Template.Web.Extensions;
 using Template.Web.Options;
+using Template.Web.Tests.Extensions;
 using Template.Web.Tests.Infrastructure;
 using Template.Web.Tests.TestControllers;
 
@@ -34,7 +34,7 @@ public sealed class RateLimitingTests
             ["Template:RateLimiting:GlobalFixedWindow:QueueLimit"] = "0"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage firstResponse = await client.GetAsync("/", TestContext.Current.CancellationToken);
         using HttpResponseMessage secondResponse = await client.GetAsync("/", TestContext.Current.CancellationToken);
@@ -59,7 +59,7 @@ public sealed class RateLimitingTests
             ["Template:RateLimiting:FixedWindowPolicy:QueueLimit"] = "0"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage firstResponse = await client.GetAsync("/test/rate-limiting/fixed", TestContext.Current.CancellationToken);
         using HttpResponseMessage secondResponse = await client.GetAsync("/test/rate-limiting/fixed", TestContext.Current.CancellationToken);
@@ -85,7 +85,7 @@ public sealed class RateLimitingTests
             ["Template:RateLimiting:ConcurrencyPolicy:QueueLimit"] = "0"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         Task<HttpResponseMessage> firstRequest = client.GetAsync("/test/rate-limiting/concurrency", TestContext.Current.CancellationToken);
 
@@ -114,7 +114,7 @@ public sealed class RateLimitingTests
             ["Template:RateLimiting:GlobalFixedWindow:QueueLimit"] = "0"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage firstResponse = await client.GetAsync("/", TestContext.Current.CancellationToken);
         using HttpResponseMessage rejectedResponse = await client.GetAsync("/", TestContext.Current.CancellationToken);
@@ -146,7 +146,7 @@ public sealed class RateLimitingTests
             ["Template:RateLimiting:GlobalFixedWindow:QueueLimit"] = "0"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage firstResponse = await client.GetAsync("/", TestContext.Current.CancellationToken);
         using HttpResponseMessage secondResponse = await client.GetAsync("/", TestContext.Current.CancellationToken);
@@ -262,20 +262,6 @@ public sealed class RateLimitingTests
     private static TemplateWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
     {
         return new TemplateWebApplicationFactory(configurationValues);
-    }
-
-    /// <summary>
-    /// Creates an HTTPS test client so requests are not intercepted by HTTPS redirection middleware.
-    /// </summary>
-    /// <param name="factory">The web application factory used to create the client.</param>
-    /// <returns>An <see cref="HttpClient"/> configured with an HTTPS base address.</returns>
-    private static HttpClient CreateHttpsClient(WebApplicationFactory<Program> factory)
-    {
-        return factory.CreateClient(new WebApplicationFactoryClientOptions
-        {
-            BaseAddress = new Uri("https://localhost"),
-            AllowAutoRedirect = false
-        });
     }
 
     private static OptionsValidationException AssertRateLimitingOptionsValidationFails(

--- a/tests/Template.Web.Tests/RootEndpointTests.cs
+++ b/tests/Template.Web.Tests/RootEndpointTests.cs
@@ -1,0 +1,23 @@
+using System.Net;
+using Template.Web.Tests.Extensions;
+using Template.Web.Tests.Infrastructure;
+
+namespace Template.Web.Tests;
+
+public sealed class RootEndpointTests
+{
+    [Fact]
+    public async Task RootEndpoint_ReturnsHelloWorld()
+    {
+        using TemplateWebApplicationFactory factory = new(new Dictionary<string, string?>());
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Hello World!", body);
+    }
+}

--- a/tests/Template.Web.Tests/SecurityHeadersTests.cs
+++ b/tests/Template.Web.Tests/SecurityHeadersTests.cs
@@ -1,10 +1,10 @@
 using System.Net;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Template.Web.Extensions;
 using Template.Web.Options;
+using Template.Web.Tests.Extensions;
 using Template.Web.Tests.Infrastructure;
 
 namespace Template.Web.Tests;
@@ -26,7 +26,7 @@ public sealed class SecurityHeadersTests
             ["Template:SecurityHeaders:Enabled"] = "true"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/test/security-headers", TestContext.Current.CancellationToken);
 
@@ -60,7 +60,7 @@ public sealed class SecurityHeadersTests
             ["Template:SecurityHeaders:EnableContentSecurityPolicy"] = "false"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/test/security-headers", TestContext.Current.CancellationToken);
 
@@ -83,7 +83,7 @@ public sealed class SecurityHeadersTests
             ["Template:SecurityHeaders:EnablePermissionsPolicy"] = "false"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/test/security-headers", TestContext.Current.CancellationToken);
 
@@ -106,7 +106,7 @@ public sealed class SecurityHeadersTests
             ["Template:SecurityHeaders:EnableCrossOriginHeaders"] = "false"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync("/test/security-headers", TestContext.Current.CancellationToken);
 
@@ -177,7 +177,7 @@ public sealed class SecurityHeadersTests
             ["Template:SecurityHeaders:ExcludedPathPrefixes:1"] = "/metrics"
         });
 
-        using HttpClient client = CreateHttpsClient(factory);
+        using HttpClient client = factory.CreateHttpsClient();
 
         using HttpResponseMessage response = await client.GetAsync(path, TestContext.Current.CancellationToken);
 
@@ -194,20 +194,6 @@ public sealed class SecurityHeadersTests
     private static TemplateWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
     {
         return new TemplateWebApplicationFactory(configurationValues);
-    }
-
-    /// <summary>
-    /// Creates an HTTPS test client so requests are not intercepted by HTTPS redirection middleware.
-    /// </summary>
-    /// <param name="factory">The web application factory used to create the client.</param>
-    /// <returns>An <see cref="HttpClient"/> configured with an HTTPS base address.</returns>
-    private static HttpClient CreateHttpsClient(WebApplicationFactory<Program> factory)
-    {
-        return factory.CreateClient(new WebApplicationFactoryClientOptions
-        {
-            BaseAddress = new Uri("https://localhost"),
-            AllowAutoRedirect = false
-        });
     }
 
     private static void AssertSecurityHeadersMissing(HttpResponseMessage response)


### PR DESCRIPTION
## Summary

- Completes the integration test scaffold for the Template.Web application.
- Verifies the existing WebApplicationFactory-based test host configuration.
- Adds shared test infrastructure for HTTPS test clients.
- Adds baseline endpoint coverage for the root application endpoint.
- Cleans up duplicate assertions and minor test helper issues.
- Documents the integration testing strategy in README.md.

## Testing

- Ran `dotnet restore`
- Ran `dotnet build --configuration Release`
- Ran `dotnet test --configuration Release`

Closes #55