### PR TITLE
Add structured request logging configuration - issue #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,55 @@ The application logs any exceptions that occur during the bootstrapping process 
 ```csharp
 Log.Fatal(ex, "Template.Web application terminated unexpectedly");
 ```
+### Structured Request Logging
+
+The template includes structured HTTP request logging through Serilog.
+
+Request logging records a single completion event for each normal request and includes:
+
+- HTTP method
+- Request path
+- Response status code
+- Elapsed request duration
+- Request ID
+- Correlation ID
+- Request scheme and host
+- Remote IP address, when enabled
+- Authenticated user name, when enabled
+
+Request logging is configured through:
+
+```csharp
+builder.Services.AddTemplateRequestLogging(builder.Configuration);
+```
+And applied through the standard template pipeline:
+```csharp
+app.UseTemplateRequestLogging();
+```
+Configuration is controlled through `appsettings.json`:
+```json
+"Template": {
+  "RequestLogging": {
+    "Enabled": true,
+    "CorrelationHeaderName": "X-Correlation-ID",
+    "IncludeQueryString": false,
+    "IncludeUserName": true,
+    "IncludeRemoteIpAddress": true,
+    "ExcludedPathPrefixes": [
+      "/health",
+      "/metrics",
+      "/favicon.ico",
+      "/css",
+      "/js",
+      "/lib",
+      "/_framework"
+    ]
+  }
+}
+```
+Query string logging is disabled by default because query strings may contain sensitive values. Applications should avoid logging request bodies, response bodies, cookies, authorization headers, access tokens, refresh tokens, or authentication payloads unless a specific, reviewed diagnostic need exists.
+
+
 ## Error Handling
 
 The template includes centralized error handling for both unhandled exceptions and HTTP status code responses.

--- a/src/Template.Web/Extensions/PipelineExtensions.cs
+++ b/src/Template.Web/Extensions/PipelineExtensions.cs
@@ -21,12 +21,12 @@ public static class PipelineExtensions
         // 1. Proxy/load balancer correction must happen early.
         app.UseTemplateForwardedHeaders();
 
-        // 2. Centralized exception handling.
+        // 2. Structured request logging should see corrected scheme, host, and client IP.
+        app.UseTemplateRequestLogging();
+
+        // 3. Centralized exception handling.
         app.UseTemplateErrorHandling();
         app.UseTemplateProblemDetails();
-
-        // 3. Structured request logging should see corrected scheme, host, and client IP.
-        app.UseTemplateRequestLogging();
 
         // 4. Optional security response headers.
         app.UseTemplateSecurityHeaders();

--- a/src/Template.Web/Extensions/RequestLoggingExtensions.cs
+++ b/src/Template.Web/Extensions/RequestLoggingExtensions.cs
@@ -1,28 +1,93 @@
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Serilog;
+using Serilog.Context;
 using Serilog.Events;
+using Template.Web.Options;
 
 namespace Template.Web.Extensions;
 
 /// <summary>
-/// Provides extension methods for configuring request logging on a <see cref="WebApplication"/>.
+/// Provides extension methods for configuring structured HTTP request logging.
 /// </summary>
 public static class RequestLoggingExtensions
 {
     /// <summary>
-    /// Configures Serilog request logging with the application's preferred message template,
-    /// log level selection logic, and diagnostic context enrichment.
+    /// Registers structured request logging options.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The original service collection for chaining.</returns>
+    public static IServiceCollection AddTemplateRequestLogging(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services
+            .AddOptions<TemplateRequestLoggingOptions>()
+            .Bind(configuration.GetSection(TemplateRequestLoggingOptions.SectionName))
+            .Validate(
+                options => !string.IsNullOrWhiteSpace(options.CorrelationHeaderName),
+                "Template:RequestLogging:CorrelationHeaderName is required.")
+            .Validate(
+                options => options.ExcludedPathPrefixes.All(path =>
+                    !string.IsNullOrWhiteSpace(path) &&
+                    path.StartsWith('/')),
+                "Template:RequestLogging:ExcludedPathPrefixes values must start with '/'.")
+            .ValidateOnStart();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Configures structured request logging with correlation identifiers,
+    /// request duration metrics, filtering, and safe diagnostic enrichment.
     /// </summary>
     /// <param name="app">The web application to configure.</param>
-    /// <returns>The same <see cref="WebApplication"/> instance for chaining.</returns>
+    /// <returns>The same web application instance for chaining.</returns>
     public static WebApplication UseTemplateRequestLogging(this WebApplication app)
     {
+        TemplateRequestLoggingOptions requestLoggingOptions = app.Services
+            .GetRequiredService<IOptions<TemplateRequestLoggingOptions>>()
+            .Value;
+
+        if (!requestLoggingOptions.Enabled)
+        {
+            return app;
+        }
+
+        app.Use(async (context, next) =>
+        {
+            string correlationId = GetCorrelationId(context, requestLoggingOptions);
+
+            context.Response.OnStarting(() =>
+            {
+                if (!context.Response.Headers.ContainsKey(requestLoggingOptions.CorrelationHeaderName))
+                {
+                    context.Response.Headers[requestLoggingOptions.CorrelationHeaderName] = correlationId;
+                }
+
+                return Task.CompletedTask;
+            });
+
+            using (LogContext.PushProperty("CorrelationId", correlationId))
+            using (LogContext.PushProperty("RequestId", context.TraceIdentifier))
+            {
+                await next(context);
+            }
+        });
+
         app.UseSerilogRequestLogging(options =>
         {
             options.MessageTemplate =
                 "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
 
-            options.GetLevel = (httpContext, elapsed, exception) =>
+            options.GetLevel = (httpContext, _, exception) =>
             {
+                if (IsExcludedPath(httpContext.Request.Path, requestLoggingOptions))
+                {
+                    return LogEventLevel.Verbose;
+                }
+
                 if (exception is not null)
                 {
                     return LogEventLevel.Error;
@@ -32,28 +97,78 @@ public static class RequestLoggingExtensions
 
                 return statusCode >= StatusCodes.Status500InternalServerError
                     ? LogEventLevel.Error
-                    : statusCode >= StatusCodes.Status400BadRequest ? LogEventLevel.Warning : LogEventLevel.Information;
+                    : statusCode >= StatusCodes.Status400BadRequest
+                        ? LogEventLevel.Warning
+                        : LogEventLevel.Information;
             };
 
+            // Do not enrich request logs with request bodies, response bodies, cookies,
+            // authorization headers, access tokens, refresh tokens, SAML/OIDC payloads,
+            // password fields, form fields, or query strings unless explicitly reviewed.
+            // Request logging should default to operational metadata only.
             options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
             {
+                diagnosticContext.Set("CorrelationId", GetCorrelationId(httpContext, requestLoggingOptions));
+                diagnosticContext.Set("RequestId", httpContext.TraceIdentifier);
+                diagnosticContext.Set("TraceIdentifier", httpContext.TraceIdentifier);
                 diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
                 diagnosticContext.Set("RequestScheme", httpContext.Request.Scheme);
                 diagnosticContext.Set("RequestPathBase", httpContext.Request.PathBase.Value);
-                diagnosticContext.Set("QueryString", httpContext.Request.QueryString.Value);
 
-                diagnosticContext.Set("RemoteIpAddress",
-                    httpContext.Connection.RemoteIpAddress?.ToString());
+                if (requestLoggingOptions.IncludeQueryString)
+                {
+                    diagnosticContext.Set("QueryString", httpContext.Request.QueryString.Value);
+                }
 
-                diagnosticContext.Set("UserName",
-                    httpContext.User?.Identity?.IsAuthenticated == true
-                        ? httpContext.User.Identity.Name
-                        : null);
+                if (requestLoggingOptions.IncludeRemoteIpAddress)
+                {
+                    diagnosticContext.Set(
+                        "RemoteIpAddress",
+                        httpContext.Connection.RemoteIpAddress?.ToString());
+                }
 
-                diagnosticContext.Set("TraceIdentifier", httpContext.TraceIdentifier);
+                if (requestLoggingOptions.IncludeUserName)
+                {
+                    diagnosticContext.Set(
+                        "UserName",
+                        httpContext.User?.Identity?.IsAuthenticated == true
+                            ? httpContext.User.Identity.Name
+                            : null);
+                }
             };
         });
 
         return app;
+    }
+
+    private static string GetCorrelationId(
+        HttpContext httpContext,
+        TemplateRequestLoggingOptions options)
+    {
+        if (httpContext.Request.Headers.TryGetValue(options.CorrelationHeaderName, out StringValues headerValues))
+        {
+            string? headerValue = headerValues.FirstOrDefault();
+
+            if (!string.IsNullOrWhiteSpace(headerValue))
+            {
+                string cleanValue = headerValue.Trim();
+
+                return cleanValue.Length <= 128
+                    ? cleanValue
+                    : cleanValue[..128];
+            }
+        }
+
+        return httpContext.TraceIdentifier;
+    }
+
+    private static bool IsExcludedPath(
+        PathString requestPath,
+        TemplateRequestLoggingOptions options)
+    {
+        return requestPath.HasValue && options.ExcludedPathPrefixes.Any(prefix =>
+            requestPath.StartsWithSegments(
+                new PathString(prefix),
+                StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Template.Web/Options/TemplateRequestLoggingOptions.cs
+++ b/src/Template.Web/Options/TemplateRequestLoggingOptions.cs
@@ -1,0 +1,53 @@
+namespace Template.Web.Options;
+
+/// <summary>
+/// Options controlling structured HTTP request logging behavior.
+/// </summary>
+public sealed class TemplateRequestLoggingOptions
+{
+    /// <summary>
+    /// Gets the configuration section name used to bind request logging settings.
+    /// </summary>
+    public static string SectionName { get; internal set; } = "Template:RequestLogging";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether structured request logging is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the request/response header used for request correlation.
+    /// </summary>
+    public string CorrelationHeaderName { get; set; } = "X-Correlation-ID";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the query string should be logged.
+    /// Disabled by default because query strings may contain sensitive values.
+    /// </summary>
+    public bool IncludeQueryString { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether authenticated user names should be logged.
+    /// </summary>
+    public bool IncludeUserName { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the remote IP address should be logged.
+    /// </summary>
+    public bool IncludeRemoteIpAddress { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets path prefixes that should be excluded from normal request logging.
+    /// Matching requests are logged at Verbose level so the default sinks suppress them.
+    /// </summary>
+    public List<string> ExcludedPathPrefixes { get; set; } =
+    [
+        "/health",
+        "/metrics",
+        "/favicon.ico",
+        "/css",
+        "/js",
+        "/lib",
+        "/_framework"
+    ];
+}

--- a/src/Template.Web/Program.cs
+++ b/src/Template.Web/Program.cs
@@ -5,9 +5,9 @@ using Template.Web.Extensions;
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .WriteTo.Debug(
-        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [Bootstrap] {Message:lj}{NewLine}{Exception}")
+        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}")
     .WriteTo.Console(
-        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [Bootstrap] {Message:lj}{NewLine}{Exception}")
+        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}")
     .CreateBootstrapLogger();
 
 try
@@ -22,7 +22,7 @@ try
     builder.Services.AddTemplateForwardedHeaders(builder.Configuration);
     builder.Services.AddTemplateSecurityHeaders(builder.Configuration);
     builder.Services.AddTemplateRateLimiting(builder.Configuration, builder.Environment);
-
+    builder.Services.AddTemplateRequestLogging(builder.Configuration);
     builder.Services.AddTemplateProblemDetails(builder.Environment);
 
     Log.Information("Starting Template.Web application");

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -31,7 +31,7 @@
         "Name": "Console",
         "Args": {
           "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
         }
       },
       {
@@ -92,6 +92,22 @@
         "PermitLimit": 10,
         "QueueLimit": 0
       }
+    },
+    "RequestLogging": {
+      "Enabled": true,
+      "CorrelationHeaderName": "X-Correlation-ID",
+      "IncludeQueryString": false,
+      "IncludeUserName": true,
+      "IncludeRemoteIpAddress": true,
+      "ExcludedPathPrefixes": [
+        "/health",
+        "/metrics",
+        "/favicon.ico",
+        "/css",
+        "/js",
+        "/lib",
+        "/_framework"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #52

This PR completes structured HTTP request logging support for the template application.

### Changes

- Added configurable request logging options under `Template:RequestLogging`.
- Added correlation ID support using the configured correlation header.
- Added request ID and correlation ID enrichment for structured logs.
- Added request duration logging through Serilog request completion events.
- Added configurable noisy path exclusions for endpoints such as health checks, metrics, static assets, and framework resources.
- Disabled full query string logging by default to avoid accidental sensitive data exposure.
- Preserved safe operational metadata logging such as request method, path, status code, elapsed time, request ID, correlation ID, scheme, host, and optional remote IP/user name.
- Updated Serilog output template to include correlation ID context.
- Documented sensitive logging considerations and request logging configuration in README.

### Sensitive Logging Behavior

The default request logging configuration intentionally avoids logging:

- Request bodies
- Response bodies
- Cookies
- Authorization headers
- Access tokens
- Refresh tokens
- SAML/OIDC payloads
- Password fields
- Full query strings unless explicitly enabled

### Validation

- Confirmed the application builds successfully.
- Confirmed structured request logging writes request completion events.
- Confirmed custom `X-Correlation-ID` values are included in response headers and logs.
- Confirmed excluded/noisy paths are suppressed from normal request logging output.