### PR TITLE
Add OpenTelemetry foundation - Issue #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,42 @@ This keeps production endpoints unchanged while allowing the tests to verify:
 - Disabled rate limiting behavior.
 - Configuration binding for template rate limiting options.
 
+## OpenTelemetry
 
+The template includes baseline OpenTelemetry support for tracing and metrics.
+
+OpenTelemetry is registered through:
+
+```csharp
+builder.Services.AddTemplateOpenTelemetry(builder.Configuration, builder.Environment);
+```
+Configuration is controlled through `appsettings.json`:
+```json
+"Template": {
+  "OpenTelemetry": {
+    "Enabled": true,
+    "ServiceName": "Template.Web",
+    "ServiceVersion": "0.1.3",
+    "EnableTracing": true,
+    "EnableMetrics": true,
+    "EnableAspNetCoreInstrumentation": true,
+    "EnableHttpClientInstrumentation": true,
+    "Otlp": {
+      "Enabled": false,
+      "Endpoint": "",
+      "Protocol": "Grpc"
+    }
+  }
+}
+```
+By default, the template collects local tracing and metrics instrumentation but does not export telemetry to an external collector. To enable OTLP export, configure an OTLP endpoint and set `Template:OpenTelemetry:Otlp:Enabled` to `true`.
+
+Common local OTLP collector endpoints:
+```text
+http://localhost:4317
+http://localhost:4318
+```
+The OTLP exporter can also be configured through standard OpenTelemetry environment variables such as `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL`.
 ## Authentication and Authorization
 
 This section will document authentication and authorization architecture.

--- a/src/Template.Web/Extensions/OpenTelemetryServiceExtensions.cs
+++ b/src/Template.Web/Extensions/OpenTelemetryServiceExtensions.cs
@@ -1,0 +1,113 @@
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Template.Web.Options;
+
+namespace Template.Web.Extensions;
+
+/// <summary>
+/// Provides extension methods to register OpenTelemetry services for the application.
+/// </summary>
+public static class OpenTelemetryServiceExtensions
+{
+    /// <summary>
+    /// Adds baseline OpenTelemetry tracing and metrics support.
+    /// </summary>
+    /// <param name="services">The service collection to add OpenTelemetry services to.</param>
+    /// <param name="configuration">The application configuration source.</param>
+    /// <param name="environment">The current hosting environment.</param>
+    /// <returns>The same service collection instance so calls can be chained.</returns>
+    public static IServiceCollection AddTemplateOpenTelemetry(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        services
+            .AddOptions<TemplateOpenTelemetryOptions>()
+            .Bind(configuration.GetSection(TemplateOpenTelemetryOptions.SectionName))
+            .Validate(options => !string.IsNullOrWhiteSpace(options.ServiceName),
+                "Template:OpenTelemetry:ServiceName must not be empty.")
+            .Validate(options => !options.Otlp.Enabled || Uri.TryCreate(options.Otlp.Endpoint, UriKind.Absolute, out _),
+                "Template:OpenTelemetry:Otlp:Endpoint must be a valid absolute URI when OTLP export is enabled.")
+            .ValidateOnStart();
+
+        TemplateOpenTelemetryOptions options = configuration
+            .GetSection(TemplateOpenTelemetryOptions.SectionName)
+            .Get<TemplateOpenTelemetryOptions>() ?? new TemplateOpenTelemetryOptions();
+
+        if (!options.Enabled)
+        {
+            return services;
+        }
+
+        OpenTelemetryBuilder openTelemetryBuilder = services
+            .AddOpenTelemetry()
+            .ConfigureResource(resource => resource
+                .AddService(
+                    serviceName: options.ServiceName,
+                    serviceVersion: options.ServiceVersion)
+                .AddAttributes(new Dictionary<string, object>
+                {
+                    ["deployment.environment.name"] = environment.EnvironmentName
+                }));
+
+        if (options.EnableTracing)
+        {
+            openTelemetryBuilder.WithTracing(tracing =>
+            {
+                if (options.EnableAspNetCoreInstrumentation)
+                {
+                    tracing.AddAspNetCoreInstrumentation();
+                }
+
+                if (options.EnableHttpClientInstrumentation)
+                {
+                    tracing.AddHttpClientInstrumentation();
+                }
+
+                if (options.Otlp.Enabled)
+                {
+                    tracing.AddOtlpExporter(exporterOptions => ConfigureOtlpExporter(exporterOptions, options.Otlp));
+                }
+            });
+        }
+
+        if (options.EnableMetrics)
+        {
+            openTelemetryBuilder.WithMetrics(metrics =>
+            {
+                if (options.EnableAspNetCoreInstrumentation)
+                {
+                    metrics.AddAspNetCoreInstrumentation();
+                }
+
+                if (options.EnableHttpClientInstrumentation)
+                {
+                    metrics.AddHttpClientInstrumentation();
+                }
+
+                if (options.Otlp.Enabled)
+                {
+                    metrics.AddOtlpExporter(exporterOptions => ConfigureOtlpExporter(exporterOptions, options.Otlp));
+                }
+            });
+        }
+
+        return services;
+    }
+
+    private static void ConfigureOtlpExporter(
+        OtlpExporterOptions exporterOptions,
+        TemplateOtlpExporterOptions options)
+    {
+        exporterOptions.Endpoint = new Uri(options.Endpoint);
+        exporterOptions.Protocol = string.Equals(
+            options.Protocol,
+            "HttpProtobuf",
+            StringComparison.OrdinalIgnoreCase)
+            ? OtlpExportProtocol.HttpProtobuf
+            : OtlpExportProtocol.Grpc;
+    }
+}

--- a/src/Template.Web/Options/TemplateOpenTelemetryOptions.cs
+++ b/src/Template.Web/Options/TemplateOpenTelemetryOptions.cs
@@ -1,0 +1,52 @@
+namespace Template.Web.Options;
+
+/// <summary>
+/// Represents template-level OpenTelemetry configuration.
+/// </summary>
+public sealed class TemplateOpenTelemetryOptions
+{
+    /// <summary>
+    /// Configuration section name for OpenTelemetry settings.
+    /// </summary>
+    public const string SectionName = "Template:OpenTelemetry";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether OpenTelemetry is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the logical OpenTelemetry service name.
+    /// </summary>
+    public string ServiceName { get; set; } = "Template.Web";
+
+    /// <summary>
+    /// Gets or sets the logical OpenTelemetry service version.
+    /// </summary>
+    public string ServiceVersion { get; set; } = "0.1.3";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether tracing is enabled.
+    /// </summary>
+    public bool EnableTracing { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether metrics are enabled.
+    /// </summary>
+    public bool EnableMetrics { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether ASP.NET Core instrumentation is enabled.
+    /// </summary>
+    public bool EnableAspNetCoreInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether HttpClient instrumentation is enabled.
+    /// </summary>
+    public bool EnableHttpClientInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets OTLP exporter options.
+    /// </summary>
+    public TemplateOtlpExporterOptions Otlp { get; set; } = new();
+}

--- a/src/Template.Web/Options/TemplateOtlpExporterOptions.cs
+++ b/src/Template.Web/Options/TemplateOtlpExporterOptions.cs
@@ -1,0 +1,22 @@
+namespace Template.Web.Options;
+
+/// <summary>
+/// Represents OTLP exporter configuration.
+/// </summary>
+public sealed class TemplateOtlpExporterOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether OTLP export is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OTLP endpoint.
+    /// </summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the OTLP protocol. Supported values are Grpc and HttpProtobuf.
+    /// </summary>
+    public string Protocol { get; set; } = "Grpc";
+}

--- a/src/Template.Web/Program.cs
+++ b/src/Template.Web/Program.cs
@@ -23,6 +23,7 @@ try
     builder.Services.AddTemplateSecurityHeaders(builder.Configuration);
     builder.Services.AddTemplateRateLimiting(builder.Configuration, builder.Environment);
     builder.Services.AddTemplateRequestLogging(builder.Configuration);
+    builder.Services.AddTemplateOpenTelemetry(builder.Configuration, builder.Environment);
     builder.Services.AddTemplateProblemDetails(builder.Environment);
 
     Log.Information("Starting Template.Web application");

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -8,12 +8,12 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.1.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.1.1.0</AssemblyVersion>
-    <FileVersion>0.1.1.0</FileVersion>
+    <AssemblyVersion>0.1.4.0</AssemblyVersion>
+    <FileVersion>0.1.4.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
 
   </PropertyGroup>
@@ -29,6 +29,10 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -108,6 +108,20 @@
         "/lib",
         "/_framework"
       ]
+    },
+    "OpenTelemetry": {
+      "Enabled": true,
+      "ServiceName": "Template.Web",
+      "ServiceVersion": "0.1.4",
+      "EnableTracing": true,
+      "EnableMetrics": true,
+      "EnableAspNetCoreInstrumentation": true,
+      "EnableHttpClientInstrumentation": true,
+      "Otlp": {
+        "Enabled": false,
+        "Endpoint": "",
+        "Protocol": "Grpc"
+      }
     }
   }
 }

--- a/tests/Template.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/Template.Web.Tests/OpenTelemetryTests.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Template.Web.Extensions;
+using Template.Web.Options;
+using Template.Web.Tests.Extensions;
+using Template.Web.Tests.Infrastructure;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides integration and configuration tests for the template OpenTelemetry foundation.
+/// </summary>
+public sealed class OpenTelemetryTests
+{
+    /// <summary>
+    /// Verifies that template OpenTelemetry options are bound from configuration.
+    /// </summary>
+    [Fact]
+    public void OpenTelemetryOptions_Bind_DefaultConfiguration()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:OpenTelemetry:Enabled"] = "true",
+            ["Template:OpenTelemetry:ServiceName"] = "Template.Web",
+            ["Template:OpenTelemetry:ServiceVersion"] = "0.1.4",
+            ["Template:OpenTelemetry:EnableTracing"] = "true",
+            ["Template:OpenTelemetry:EnableMetrics"] = "true",
+            ["Template:OpenTelemetry:EnableAspNetCoreInstrumentation"] = "true",
+            ["Template:OpenTelemetry:EnableHttpClientInstrumentation"] = "true",
+            ["Template:OpenTelemetry:Otlp:Enabled"] = "false",
+            ["Template:OpenTelemetry:Otlp:Endpoint"] = "",
+            ["Template:OpenTelemetry:Otlp:Protocol"] = "Grpc"
+        });
+
+        TemplateOpenTelemetryOptions options = factory.Services
+            .GetRequiredService<IOptions<TemplateOpenTelemetryOptions>>()
+            .Value;
+
+        Assert.True(options.Enabled);
+        Assert.Equal("Template.Web", options.ServiceName);
+        Assert.Equal("0.1.4", options.ServiceVersion);
+        Assert.True(options.EnableTracing);
+        Assert.True(options.EnableMetrics);
+        Assert.True(options.EnableAspNetCoreInstrumentation);
+        Assert.True(options.EnableHttpClientInstrumentation);
+
+        Assert.False(options.Otlp.Enabled);
+        Assert.Equal(string.Empty, options.Otlp.Endpoint);
+        Assert.Equal("Grpc", options.Otlp.Protocol);
+    }
+
+    /// <summary>
+    /// Verifies that OpenTelemetry options validation fails when OTLP export is enabled with an invalid endpoint.
+    /// </summary>
+    [Fact]
+    public void OpenTelemetryOptions_InvalidOtlpEndpoint_FailsValidationWhenExporterEnabled()
+    {
+        OptionsValidationException exception =
+            AssertOpenTelemetryOptionsValidationFails(
+                new Dictionary<string, string?>
+                {
+                    ["Template:OpenTelemetry:Enabled"] = "true",
+                    ["Template:OpenTelemetry:ServiceName"] = "Template.Web",
+                    ["Template:OpenTelemetry:ServiceVersion"] = "0.1.4",
+                    ["Template:OpenTelemetry:EnableTracing"] = "true",
+                    ["Template:OpenTelemetry:EnableMetrics"] = "true",
+                    ["Template:OpenTelemetry:EnableAspNetCoreInstrumentation"] = "true",
+                    ["Template:OpenTelemetry:EnableHttpClientInstrumentation"] = "true",
+                    ["Template:OpenTelemetry:Otlp:Enabled"] = "true",
+                    ["Template:OpenTelemetry:Otlp:Endpoint"] = "not-a-valid-uri",
+                    ["Template:OpenTelemetry:Otlp:Protocol"] = "Grpc"
+                });
+
+        Assert.Contains(
+            "Template:OpenTelemetry:Otlp:Endpoint must be a valid absolute URI when OTLP export is enabled",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that the application starts when OpenTelemetry is enabled and OTLP export is disabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Application_Starts_WhenOpenTelemetryEnabledWithoutOtlpExporter()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:OpenTelemetry:Enabled"] = "true",
+            ["Template:OpenTelemetry:ServiceName"] = "Template.Web",
+            ["Template:OpenTelemetry:ServiceVersion"] = "0.1.4",
+            ["Template:OpenTelemetry:EnableTracing"] = "true",
+            ["Template:OpenTelemetry:EnableMetrics"] = "true",
+            ["Template:OpenTelemetry:EnableAspNetCoreInstrumentation"] = "true",
+            ["Template:OpenTelemetry:EnableHttpClientInstrumentation"] = "true",
+            ["Template:OpenTelemetry:Otlp:Enabled"] = "false",
+            ["Template:OpenTelemetry:Otlp:Endpoint"] = "",
+            ["Template:OpenTelemetry:Otlp:Protocol"] = "Grpc"
+        });
+
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the application starts when OpenTelemetry is disabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Application_Starts_WhenOpenTelemetryDisabled()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:OpenTelemetry:Enabled"] = "false",
+            ["Template:OpenTelemetry:ServiceName"] = "Template.Web",
+            ["Template:OpenTelemetry:ServiceVersion"] = "0.1.4",
+            ["Template:OpenTelemetry:EnableTracing"] = "true",
+            ["Template:OpenTelemetry:EnableMetrics"] = "true",
+            ["Template:OpenTelemetry:EnableAspNetCoreInstrumentation"] = "true",
+            ["Template:OpenTelemetry:EnableHttpClientInstrumentation"] = "true",
+            ["Template:OpenTelemetry:Otlp:Enabled"] = "false",
+            ["Template:OpenTelemetry:Otlp:Endpoint"] = "",
+            ["Template:OpenTelemetry:Otlp:Protocol"] = "Grpc"
+        });
+
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Creates a test application factory with the supplied in-memory configuration overrides.
+    /// </summary>
+    /// <param name="configurationValues">The configuration key/value pairs used to override template settings for a test.</param>
+    /// <returns>A configured <see cref="TemplateWebApplicationFactory"/> instance.</returns>
+    private static TemplateWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        return new TemplateWebApplicationFactory(configurationValues);
+    }
+
+    private static OptionsValidationException AssertOpenTelemetryOptionsValidationFails(
+        IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+
+        _ = services.AddTemplateOpenTelemetry(
+            configuration,
+            new TestHostEnvironment());
+
+        using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+
+        return Assert.Throws<OptionsValidationException>(() =>
+            provider
+                .GetRequiredService<IOptions<TemplateOpenTelemetryOptions>>()
+                .Value);
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Testing";
+
+        public string ApplicationName { get; set; } = "Template.Web.Tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds baseline OpenTelemetry tracing and metrics support.
- Adds ASP.NET Core and HttpClient instrumentation.
- Adds template-owned OpenTelemetry configuration under `Template:OpenTelemetry`.
- Adds optional OTLP exporter configuration, disabled by default for local development.
- Documents OpenTelemetry setup and local configuration in README.

## Testing

- Ran `dotnet build --configuration Release`.
- Ran `dotnet test --configuration Release`.

Closes #53