### PR TITLE
Add SAML2 authentication provider support - Issue #28

### DIFF
--- a/ASSETS-LICENSES.md
+++ b/ASSETS-LICENSES.md
@@ -67,4 +67,5 @@ _`Microsoft.AspNetCore.Mvc.Testing` provides support for writing integration tes
 _The MSbuild targets and properties for building .NET test projects._
 ## [Microsoft.AspNetCore.Authentication.OpenIdConnect](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect)
 _This package contains the OpenID Connect middleware for ASP.NET Core. It enables an application to support authentication using the OpenID Connect protocol, which is an identity layer on top of the OAuth 2.0 protocol. This middleware allows applications to authenticate users by redirecting them to an OpenID Connect provider (such as Azure AD, IdentityServer, etc.) and handling the authentication response._
-
+## [Sustainsys.Saml2.AspNetCore2](https://www.nuget.org/packages/Sustainsys.Saml2.AspNetCore2)
+_Sustainsys.Saml2.AspNetCore2 is a library that provides support for integrating SAML2 authentication into ASP.NET Core 2 applications. It allows developers to authenticate users using SAML2 identity providers, enabling single sign-on (SSO) capabilities for their applications._

--- a/README.md
+++ b/README.md
@@ -651,7 +651,6 @@ The OTLP exporter can also be configured through standard OpenTelemetry environm
 ### OpenID Connect
 
 The template includes standards-based OpenID Connect authentication support.
-
 OIDC is disabled by default. To enable it, configure the `Template:Authentication` section and set both authentication and the OpenID Connect provider to enabled.
 
 ```json
@@ -680,7 +679,37 @@ OIDC is disabled by default. To enable it, configure the `Template:Authenticatio
   }
 }
 ```
-Do not commit real client secrets to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store.
+_Do not commit real client secrets to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
+
+### SAML2
+
+The template includes standards-based SAML2 authentication support.
+SAML2 is disabled by default. To enable it, configure the `Template:Authentication` section and set both authentication and the Saml2 provider to enabled.
+```json
+"Template": {
+  "Authentication": {
+    "Enabled": true,
+    "DefaultScheme": "Cookies",
+    "DefaultChallengeScheme": "Saml2",
+    "DefaultSignInScheme": "Cookies",
+    "Providers": {
+      "Saml2": {
+        "Enabled": true,
+        "Scheme": "Saml2",
+        "DisplayName": "SAML2",
+        "EntityId": "https://localhost:5001/saml2",
+        "MetadataUrl": "https://idp.example.com/metadata",
+        "CallbackPath": "/Saml2/Acs",
+        "LoadMetadata": true,
+        "RequireSignedAssertions": true,
+        "ValidateCertificates": true
+      }
+    }
+  }
+}
+```
+_Do not commit real certificates, private keys, or real IdP metadata to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
+
 
 ## Data Access
 
@@ -885,7 +914,7 @@ Initial planned milestones:
 - [ ]  Add SQL Server provider option.
 - [x]  Add authentication module structure.
 - [x]  Add OIDC support.
-- [ ]  Add SAML2 support.
+- [x]  Add SAML2 support.
 - [ ]  Add external provider support.
 - [ ]  Add template packaging.
 - [x]  Add GitHub workflows.

--- a/src/Template.Web/Authentication/Options/TemplateAuthenticationProviderOptions.cs
+++ b/src/Template.Web/Authentication/Options/TemplateAuthenticationProviderOptions.cs
@@ -1,4 +1,5 @@
 using Template.Web.Authentication.Providers.OpenIdConnect;
+using Template.Web.Authentication.Providers.Saml2;
 
 namespace Template.Web.Authentication.Options;
 
@@ -15,7 +16,7 @@ public sealed class TemplateAuthenticationProviderOptions
     /// <summary>
     /// Gets or sets SAML2 provider options.
     /// </summary>
-    public TemplateExternalAuthenticationProviderOptions Saml2 { get; set; } = new();
+    public TemplateSaml2AuthenticationOptions Saml2 { get; set; } = new();
 
     /// <summary>
     /// Gets or sets Microsoft provider options.

--- a/src/Template.Web/Authentication/Providers/Saml2/Saml2AuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Providers/Saml2/Saml2AuthenticationServiceExtensions.cs
@@ -35,6 +35,8 @@ public static class Saml2AuthenticationServiceExtensions
             saml2Options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             saml2Options.SPOptions.EntityId = new EntityId(options.EntityId);
             saml2Options.SPOptions.ModulePath = options.ModulePath;
+            saml2Options.SPOptions.WantAssertionsSigned = options.RequireSignedAssertions;
+            saml2Options.SPOptions.ValidateCertificates = options.ValidateCertificates;
 
             IdentityProvider identityProvider = new(
                 new EntityId(options.MetadataUrl),
@@ -42,8 +44,7 @@ public static class Saml2AuthenticationServiceExtensions
             {
                 MetadataLocation = options.MetadataUrl,
                 LoadMetadata = options.LoadMetadata,
-                AllowUnsolicitedAuthnResponse = false,
-                WantAuthnRequestsSigned = options.RequireSignedAssertions
+                AllowUnsolicitedAuthnResponse = false
             };
 
             saml2Options.IdentityProviders.Add(identityProvider);

--- a/src/Template.Web/Authentication/Providers/Saml2/Saml2AuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Providers/Saml2/Saml2AuthenticationServiceExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authentication;
-using Template.Web.Authentication.Options;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Sustainsys.Saml2;
+using Sustainsys.Saml2.Metadata;
 
 namespace Template.Web.Authentication.Providers.Saml2;
 
@@ -9,14 +11,16 @@ namespace Template.Web.Authentication.Providers.Saml2;
 public static class Saml2AuthenticationServiceExtensions
 {
     /// <summary>
-    /// Adds the template SAML2 authentication provider registration.
+    /// Adds SAML2 authentication using the specified template options to the authentication builder.
     /// </summary>
-    /// <param name="builder">The authentication builder used to register authentication handlers.</param>
-    /// <param name="options">The SAML2 provider options.</param>
-    /// <returns>The same <see cref="AuthenticationBuilder"/> instance for chaining.</returns>
+    /// <remarks>If the SAML2 authentication is not enabled in the provided options, the method returns the
+    /// original builder without modification.</remarks>
+    /// <param name="builder">The authentication builder to which the SAML2 authentication scheme is added.</param>
+    /// <param name="options">The options used to configure the SAML2 authentication scheme. Cannot be null.</param>
+    /// <returns>The authentication builder with the SAML2 authentication scheme configured.</returns>
     public static AuthenticationBuilder AddTemplateSaml2Authentication(
         this AuthenticationBuilder builder,
-        TemplateExternalAuthenticationProviderOptions options)
+        TemplateSaml2AuthenticationOptions options)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(options);
@@ -26,8 +30,25 @@ public static class Saml2AuthenticationServiceExtensions
             return builder;
         }
 
-        // SAML2 provider support will be implemented in a future provider-specific issue.
-        // This placeholder intentionally does not register a concrete authentication handler yet.
+        builder.AddSaml2(options.Scheme, options.DisplayName, saml2Options =>
+        {
+            saml2Options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            saml2Options.SPOptions.EntityId = new EntityId(options.EntityId);
+            saml2Options.SPOptions.ModulePath = options.ModulePath;
+
+            IdentityProvider identityProvider = new(
+                new EntityId(options.MetadataUrl),
+                saml2Options.SPOptions)
+            {
+                MetadataLocation = options.MetadataUrl,
+                LoadMetadata = options.LoadMetadata,
+                AllowUnsolicitedAuthnResponse = false,
+                WantAuthnRequestsSigned = options.RequireSignedAssertions
+            };
+
+            saml2Options.IdentityProviders.Add(identityProvider);
+        });
+
         return builder;
     }
 }

--- a/src/Template.Web/Authentication/Providers/Saml2/TemplateSaml2AuthenticationOptions.cs
+++ b/src/Template.Web/Authentication/Providers/Saml2/TemplateSaml2AuthenticationOptions.cs
@@ -1,0 +1,62 @@
+namespace Template.Web.Authentication.Providers.Saml2;
+
+/// <summary>
+/// Represents SAML2 authentication provider configuration.
+/// </summary>
+public sealed class TemplateSaml2AuthenticationOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the feature is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authentication scheme used for the current operation.
+    /// </summary>
+    public string Scheme { get; set; } = "Saml2";
+
+    /// <summary>
+    /// Gets or sets the display name associated with the SAML2 entity.
+    /// </summary>
+    public string DisplayName { get; set; } = "SAML2";
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the entity.
+    /// </summary>
+    public string EntityId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the URL of the metadata endpoint associated with this instance.
+    /// </summary>
+    public string MetadataUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the relative request path that the application listens on for SAML2 authentication callbacks.
+    /// </summary>
+    /// <remarks>This path is used by the authentication middleware to receive SAML2 assertions from the
+    /// identity provider. It should match the Assertion Consumer Service (ACS) endpoint configured with the identity
+    /// provider.</remarks>
+    public string ModulePath { get; set; } = "/Saml2/Acs";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether metadata should be loaded.
+    /// </summary>
+    public bool LoadMetadata { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether assertions must be signed.
+    /// </summary>
+    /// <remarks>Set this property to <see langword="true"/> to require that all assertions are
+    /// cryptographically signed for validation. This enhances security by ensuring the authenticity and integrity of
+    /// assertions. If set to <see langword="false"/>, unsigned assertions will be accepted, which may reduce
+    /// security.</remarks>
+    public bool RequireSignedAssertions { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to validate SSL certificates during secure connections.
+    /// </summary>
+    /// <remarks>Set this property to <see langword="false"/> to disable certificate validation, which may
+    /// expose the connection to security risks. It is recommended to leave this property set to <see langword="true"/>
+    /// in production environments.</remarks>
+    public bool ValidateCertificates { get; set; } = true;
+}

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 
@@ -8,12 +8,12 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.2.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
-    <FileVersion>0.2.1.0</FileVersion>
+    <AssemblyVersion>0.2.2.0</AssemblyVersion>
+    <FileVersion>0.2.2.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
 
   </PropertyGroup>
@@ -34,6 +34,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="Sustainsys.Saml2.AspNetCore2" Version="2.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -155,7 +155,15 @@
           ]
         },
         "Saml2": {
-          "Enabled": false
+          "Enabled": false,
+          "Scheme": "Saml2",
+          "DisplayName": "SAML2",
+          "EntityId": "",
+          "MetadataUrl": "",
+          "CallbackPath": "/Saml2/Acs",
+          "LoadMetadata": true,
+          "RequireSignedAssertions": true,
+          "ValidateCertificates": true
         },
         "Microsoft": {
           "Enabled": false

--- a/tests/Template.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/Template.Web.Tests/OpenTelemetryTests.cs
@@ -16,7 +16,7 @@ namespace Template.Web.Tests;
 /// </summary>
 public sealed class OpenTelemetryTests
 {
-    private const string _releaseVersion = "0.2.1";
+    private const string _releaseVersion = "0.2.2";
 
     /// <summary>
     /// Verifies that template OpenTelemetry options are bound from configuration.

--- a/tests/Template.Web.Tests/Template.Web.Tests.csproj
+++ b/tests/Template.Web.Tests/Template.Web.Tests.csproj
@@ -12,8 +12,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Adds modular SAML2 authentication provider support to the template authentication structure.

This change introduces configurable SAML2 provider options, registers the SAML2 authentication handler through the existing authentication extension pattern, and keeps provider-specific setup isolated from `Program.cs`.

Closes #28

## Changes

- Added SAML2 provider configuration options.
- Added SAML2 authentication service extension.
- Registered SAML2 through the existing template authentication builder flow.
- Added Sustainsys SAML2 package reference.
- Updated authentication provider options to use strongly typed SAML2 settings.
- Added SAML2 configuration defaults to `appsettings.json`.
- Used cookie authentication as the local sign-in scheme.
- Added configurable SAML2 values for:
  - Scheme
  - Display name
  - Entity ID
  - Metadata URL
  - Module path
  - Metadata loading
  - Signed assertion requirements
  - Certificate validation behavior
- Kept SAML2 disabled by default.
- Updated README documentation with SAML2 configuration guidance.

## Validation

- Confirmed `Program.cs` remains clean and does not contain SAML2-specific setup logic.
- Confirmed the application builds successfully.
- Confirmed the application runs normally when SAML2 is disabled.
- Confirmed SAML2 can be enabled through configuration without changing startup code.

## Notes

SAML2 provider values in source are placeholders only. Real identity provider metadata, certificates, secrets, and environment-specific settings should be supplied through user secrets, environment variables, deployment configuration, or a secure configuration provider.