### PR TITLE
Add external provider authentication foundation - issue #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,41 @@ SAML2 is disabled by default. To enable it, configure the `Template:Authenticati
 }
 ```
 _Do not commit real certificates, private keys, or real IdP metadata to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
+### External Providers
 
+The template includes foundational external provider configuration for Microsoft, Google, GitHub, and future OAuth/OIDC-compatible providers.
+External providers are disabled by default. This issue provides the configuration and extension-point structure only. Production provider registration, account linking, MFA enforcement, and provider-specific setup are handled by future dedicated issues.
+```json
+"Template": {
+  "Authentication": {
+    "Microsoft": {
+      "Enabled": false,
+      "Scheme": "Microsoft",
+      "DisplayName": "Microsoft",
+      "ClientId": "",
+      "ClientSecret": "",
+      "CallbackPath": "/signin-microsoft"
+    },
+    "Google": {
+      "Enabled": false,
+      "Scheme": "Google",
+      "DisplayName": "Google",
+      "ClientId": "",
+      "ClientSecret": "",
+      "CallbackPath": "/signin-google"
+    },
+    "GitHub": {
+      "Enabled": false,
+      "Scheme": "GitHub",
+      "DisplayName": "GitHub",
+      "ClientId": "",
+      "ClientSecret": "",
+      "CallbackPath": "/signin-github"
+    }
+  }
+}
+```
+_Do not commit real client IDs, client secrets, certificates, tokens, or provider credentials to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
 
 ## Data Access
 

--- a/src/Template.Web/Authentication/Options/TemplateAuthenticationProviderOptions.cs
+++ b/src/Template.Web/Authentication/Options/TemplateAuthenticationProviderOptions.cs
@@ -27,4 +27,9 @@ public sealed class TemplateAuthenticationProviderOptions
     /// Gets or sets Google provider options.
     /// </summary>
     public TemplateExternalAuthenticationProviderOptions Google { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the options used to configure GitHub as an external authentication provider.
+    /// </summary>
+    public TemplateExternalAuthenticationProviderOptions GitHub { get; set; } = new();
 }

--- a/src/Template.Web/Authentication/Options/TemplateExternalAuthenticationProviderOptions.cs
+++ b/src/Template.Web/Authentication/Options/TemplateExternalAuthenticationProviderOptions.cs
@@ -9,4 +9,30 @@ public sealed class TemplateExternalAuthenticationProviderOptions
     /// Gets or sets a value indicating whether the external authentication provider is enabled.
     /// </summary>
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI scheme component (such as "http", "https", or "ftp").
+    /// </summary>
+    public string Scheme { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the display name associated with the object.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the client application.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the client secret used for authentication with the external service.
+    /// </summary>
+    public string ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the request path within the application's base path where the authentication middleware will
+    /// receive the authentication response.
+    /// </summary>
+    public string CallbackPath { get; set; } = string.Empty;
 }

--- a/src/Template.Web/Authentication/Providers/GitHub/GitHubAuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Providers/GitHub/GitHubAuthenticationServiceExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authentication;
+using Template.Web.Authentication.Options;
+
+namespace Template.Web.Authentication.Providers.GitHub;
+
+/// <summary>
+/// Provides extension methods for registering GitHub authentication provider services.
+/// </summary>
+public static class GitHubAuthenticationServiceExtensions
+{
+    /// <summary>
+    /// Adds the template GitHub authentication provider registration.
+    /// </summary>
+    /// <param name="builder">The authentication builder used to register authentication handlers.</param>
+    /// <param name="options">The GitHub provider options.</param>
+    /// <returns>The same <see cref="AuthenticationBuilder"/> instance for chaining.</returns>
+    public static AuthenticationBuilder AddTemplateGitHubAuthentication(
+        this AuthenticationBuilder builder,
+        TemplateExternalAuthenticationProviderOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.Enabled)
+        {
+            return builder;
+        }
+
+        // GitHub provider support will be implemented in a future provider-specific issue.
+        // This placeholder intentionally does not register a concrete authentication handler yet.
+        return builder;
+    }
+}

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -8,12 +8,12 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <VersionPrefix>0.2.2</VersionPrefix>
+    <VersionPrefix>0.2.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.2.2.0</AssemblyVersion>
-    <FileVersion>0.2.2.0</FileVersion>
+    <AssemblyVersion>0.2.3.0</AssemblyVersion>
+    <FileVersion>0.2.3.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
 
   </PropertyGroup>

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -166,10 +166,28 @@
           "ValidateCertificates": true
         },
         "Microsoft": {
-          "Enabled": false
+          "Enabled": false,
+          "Scheme": "Microsoft",
+          "DisplayName": "Microsoft",
+          "ClientId": "",
+          "ClientSecret": "",
+          "CallbackPath": "/signin-microsoft"
         },
         "Google": {
-          "Enabled": false
+          "Enabled": false,
+          "Scheme": "Google",
+          "DisplayName": "Google",
+          "ClientId": "",
+          "ClientSecret": "",
+          "CallbackPath": "/signin-google"
+        },
+        "GitHub": {
+          "Enabled": false,
+          "Scheme": "GitHub",
+          "DisplayName": "GitHub",
+          "ClientId": "",
+          "ClientSecret": "",
+          "CallbackPath": "/signin-github"
         }
       }
     }

--- a/tests/Template.Web.Tests/AuthenticationTests.cs
+++ b/tests/Template.Web.Tests/AuthenticationTests.cs
@@ -35,7 +35,8 @@ public sealed class AuthenticationTests
             ["Template:Authentication:Providers:OpenIdConnect:Enabled"] = "true",
             ["Template:Authentication:Providers:Saml2:Enabled"] = "true",
             ["Template:Authentication:Providers:Microsoft:Enabled"] = "true",
-            ["Template:Authentication:Providers:Google:Enabled"] = "true"
+            ["Template:Authentication:Providers:Google:Enabled"] = "true",
+            ["Template:Authentication:Providers:GitHub:Enabled"] = "true"
         });
 
         TemplateAuthenticationOptions options = factory.Services
@@ -59,6 +60,7 @@ public sealed class AuthenticationTests
         Assert.True(options.Providers.Saml2.Enabled);
         Assert.True(options.Providers.Microsoft.Enabled);
         Assert.True(options.Providers.Google.Enabled);
+        Assert.True(options.Providers.GitHub.Enabled);
     }
 
     /// <summary>

--- a/tests/Template.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/Template.Web.Tests/OpenTelemetryTests.cs
@@ -16,7 +16,7 @@ namespace Template.Web.Tests;
 /// </summary>
 public sealed class OpenTelemetryTests
 {
-    private const string _releaseVersion = "0.2.2";
+    private const string _releaseVersion = "0.2.3";
 
     /// <summary>
     /// Verifies that template OpenTelemetry options are bound from configuration.


### PR DESCRIPTION
## Summary

This PR adds the foundational structure for external authentication provider support.

Changes include:

- Expanded external authentication provider configuration options.
- Added configuration support for Microsoft, Google, GitHub, and future external providers.
- Added centralized provider registration extension structure.
- Kept all external providers disabled by default.
- Preserved existing authentication behavior and secure-by-default posture.
- Updated authentication tests to verify external provider configuration binding.
- Updated README documentation for optional external provider support and safe secret handling.

## Notes

This PR provides the reusable foundation for external providers only. It does not implement full provider login flows, production provider registration, user account linking, MFA enforcement, OIDC deep behavior, or SAML2-specific behavior.

Provider-specific implementations can be added in future dedicated issues without major refactoring.

## Testing

- Verified the application builds successfully.
- Verified existing authentication behavior remains unchanged.
- Verified external provider configuration binds from application configuration.

Closes #73