### PR TITLE
Reconcile authentication default behavior and documentation - Issue #81

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,10 +648,25 @@ The OTLP exporter can also be configured through standard OpenTelemetry environm
 
 ## Authentication and Authorization
 
+### Default Authentication Posture
+
+The base template enables the template authentication module and local cookie authentication by default.
+
+By default:
+
+- `Template:Authentication:Enabled` is `true`.
+- The default authenticate, challenge, and sign-in schemes use `Cookies`.
+- Local cookie authentication is enabled.
+- External providers such as OpenID Connect, SAML2, Microsoft, Google, and GitHub are disabled.
+
+This gives applications a working local authentication baseline while keeping external identity provider integration opt-in.
+
+To enable an external provider, keep template authentication enabled and set only the required provider configuration to enabled. For example, OIDC requires `Template:Authentication:Providers:OpenIdConnect:Enabled` to be set to `true` along with valid authority, client ID, and client secret values.
+
 ### OpenID Connect
 
 The template includes standards-based OpenID Connect authentication support.
-OIDC is disabled by default. To enable it, configure the `Template:Authentication` section and set both authentication and the OpenID Connect provider to enabled.
+External OIDC provider integration is disabled by default. To enable it, configure the `Template:Authentication` section and set both authentication and the OpenID Connect provider to enabled.
 
 ```json
 "Template": {
@@ -684,7 +699,7 @@ _Do not commit real client secrets to source control. Use user secrets, environm
 ### SAML2
 
 The template includes standards-based SAML2 authentication support.
-SAML2 is disabled by default. To enable it, configure the `Template:Authentication` section and set both authentication and the Saml2 provider to enabled.
+External SAML2 provider integration is disabled by default. To enable it, configure the `Template:Authentication` section and set both authentication and the Saml2 provider to enabled.
 ```json
 "Template": {
   "Authentication": {
@@ -949,7 +964,7 @@ Initial planned milestones:
 - [x]  Add authentication module structure.
 - [x]  Add OIDC support.
 - [x]  Add SAML2 support.
-- [ ]  Add external provider support.
+- [x]  Add external provider support.
 - [ ]  Add template packaging.
 - [x]  Add GitHub workflows.
 - [x]  Add documentation.

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -126,7 +126,7 @@
     "Authentication": {
       "Enabled": true,
       "DefaultScheme": "Cookies",
-      "DefaultChallengeScheme": "OpenIdConnect",
+      "DefaultChallengeScheme": "Cookies",
       "DefaultSignInScheme": "Cookies",
       "Cookie": {
         "Enabled": true,

--- a/tests/Template.Web.Tests/AuthenticationTests.cs
+++ b/tests/Template.Web.Tests/AuthenticationTests.cs
@@ -49,6 +49,7 @@ public sealed class AuthenticationTests
         Assert.Equal("Cookies", options.DefaultSignInScheme);
 
         Assert.True(options.Cookie.Enabled);
+        Assert.Equal("Cookies", options.DefaultChallengeScheme);
         Assert.Equal("Cookies", options.Cookie.Scheme);
         Assert.Equal("/Account/Login", options.Cookie.LoginPath);
         Assert.Equal("/Account/Logout", options.Cookie.LogoutPath);
@@ -64,7 +65,7 @@ public sealed class AuthenticationTests
     }
 
     /// <summary>
-    /// Verifies that authentication is disabled by default for the base template.
+    /// Verifies that template authentication and cookie authentication are enabled by default for the base template.
     /// </summary>
     [Fact]
     public void AuthenticationOptions_AreEnabledByDefault()


### PR DESCRIPTION
## Summary

- Clarifies the default authentication posture for the base template.
- Keeps template authentication and cookie authentication enabled by default.
- Keeps external authentication providers disabled by default.
- Updates the default challenge scheme to use Cookies instead of OpenIdConnect.
- Corrects conflicting test comments and asserts the default challenge scheme.
- Updates README documentation to distinguish template authentication from provider enablement.

## Default Behavior

The base template now clearly documents Option A:

- Template authentication is enabled by default.
- Cookie authentication is enabled by default.
- External providers remain disabled by default.
- Applications opt into OIDC, SAML2, Microsoft, Google, or GitHub provider support explicitly.

## Validation

- [x] `dotnet build --configuration Release`
```text
Restore complete (2.7s)
  Template.Web net10.0 succeeded (11.5s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (4.0s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll

Build succeeded in 18.6s
```

- [x] `dotnet test --configuration Release`
```text
Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.9s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:02.74]   Discovering: Template.Web.Tests
[xUnit.net 00:00:03.27]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:03.69]   Starting:    Template.Web.Tests
[xUnit.net 00:00:12.62]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (16.6s)

Test summary: total: 46, failed: 0, succeeded: 46, skipped: 0, duration: 16.6s
Build succeeded in 20.3s
```

Closes #81