### PR TITLE
Add authentication provider startup validation - issue #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,24 @@ External providers are disabled by default. This issue provides the configuratio
 ```
 _Do not commit real client IDs, client secrets, certificates, tokens, or provider credentials to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
 
+### Authentication Provider Startup Validation
+
+Authentication provider configuration is validated during application startup.
+
+Provider-specific values are only required when that provider is enabled. Disabled providers may keep placeholder or empty values so the base template remains safe to run without external identity-provider setup.
+
+When a provider is enabled, startup validation fails fast if required values are missing. Validation messages identify the missing configuration key, but do not log configured secret values.
+
+Validated providers include:
+
+- OpenID Connect
+- SAML2
+- Microsoft
+- Google
+- GitHub
+
+This prevents partially configured authentication providers from failing later during runtime login flows.
+
 ## Data Access
 
 This section will document EF Core and database patterns.

--- a/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
@@ -27,21 +27,11 @@ public static class AuthenticationServiceExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
+        services.AddSingleton<IValidateOptions<TemplateAuthenticationOptions>, TemplateAuthenticationOptionsValidator>();
+
         services
             .AddOptions<TemplateAuthenticationOptions>()
             .Bind(configuration.GetSection(TemplateAuthenticationOptions.SectionName))
-            .Validate(options => !string.IsNullOrWhiteSpace(options.DefaultScheme),
-                "Template:Authentication:DefaultScheme is required.")
-            .Validate(options => !string.IsNullOrWhiteSpace(options.DefaultChallengeScheme),
-                "Template:Authentication:DefaultChallengeScheme is required.")
-            .Validate(options => !string.IsNullOrWhiteSpace(options.DefaultSignInScheme),
-                "Template:Authentication:DefaultSignInScheme is required.")
-            .Validate(options => !options.Enabled || options.Cookie.Enabled,
-                "Template:Authentication:Cookie:Enabled must be true when template authentication is enabled.")
-            .Validate(options => !options.Enabled || !string.IsNullOrWhiteSpace(options.Cookie.Scheme),
-                "Template:Authentication:Cookie:Scheme is required when template authentication is enabled.")
-            .Validate(options => !options.Enabled || options.Cookie.ExpireMinutes > 0,
-                "Template:Authentication:Cookie:ExpireMinutes must be greater than zero when template authentication is enabled.")
             .ValidateOnStart();
 
         AuthenticationBuilder authenticationBuilder = services.AddAuthentication(options =>

--- a/src/Template.Web/Authentication/Options/TemplateAuthenticationOptionsValidator.cs
+++ b/src/Template.Web/Authentication/Options/TemplateAuthenticationOptionsValidator.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Options;
+using Template.Web.Authentication.Providers.OpenIdConnect;
+using Template.Web.Authentication.Providers.Saml2;
+
+namespace Template.Web.Authentication.Options;
+
+/// <summary>
+/// Validates template authentication configuration during application startup.
+/// </summary>
+public sealed class TemplateAuthenticationOptionsValidator : IValidateOptions<TemplateAuthenticationOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, TemplateAuthenticationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        List<string> failures = [];
+
+        ValidateTemplateAuthentication(options, failures);
+        ValidateOpenIdConnectProvider(options.Providers.OpenIdConnect, failures);
+        ValidateSaml2Provider(options.Providers.Saml2, failures);
+        ValidateExternalProvider("Microsoft", options.Providers.Microsoft, failures);
+        ValidateExternalProvider("Google", options.Providers.Google, failures);
+        ValidateExternalProvider("GitHub", options.Providers.GitHub, failures);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void ValidateTemplateAuthentication(
+        TemplateAuthenticationOptions options,
+        ICollection<string> failures)
+    {
+        Require(
+            !string.IsNullOrWhiteSpace(options.DefaultScheme),
+            "Template:Authentication:DefaultScheme is required.",
+            failures);
+
+        Require(
+            !string.IsNullOrWhiteSpace(options.DefaultChallengeScheme),
+            "Template:Authentication:DefaultChallengeScheme is required.",
+            failures);
+
+        Require(
+            !string.IsNullOrWhiteSpace(options.DefaultSignInScheme),
+            "Template:Authentication:DefaultSignInScheme is required.",
+            failures);
+
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        Require(
+            options.Cookie.Enabled,
+            "Template:Authentication:Cookie:Enabled must be true when template authentication is enabled.",
+            failures);
+
+        Require(
+            !string.IsNullOrWhiteSpace(options.Cookie.Scheme),
+            "Template:Authentication:Cookie:Scheme is required when template authentication is enabled.",
+            failures);
+
+        Require(
+            options.Cookie.ExpireMinutes > 0,
+            "Template:Authentication:Cookie:ExpireMinutes must be greater than zero when template authentication is enabled.",
+            failures);
+    }
+
+    private static void ValidateOpenIdConnectProvider(
+        TemplateOpenIdConnectAuthenticationOptions options,
+        ICollection<string> failures)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        const string prefix = "Template:Authentication:Providers:OpenIdConnect";
+
+        RequireProviderValue(prefix, nameof(options.Scheme), options.Scheme, failures);
+        RequireProviderValue(prefix, nameof(options.DisplayName), options.DisplayName, failures);
+        RequireProviderValue(prefix, nameof(options.Authority), options.Authority, failures);
+        RequireProviderValue(prefix, nameof(options.ClientId), options.ClientId, failures);
+        RequireProviderValue(prefix, nameof(options.CallbackPath), options.CallbackPath, failures);
+        RequireProviderValue(prefix, nameof(options.ResponseType), options.ResponseType, failures);
+
+        Require(
+            options.Scopes.Any(scope => !string.IsNullOrWhiteSpace(scope)),
+            $"{prefix}:Scopes must contain at least one non-empty value when the OpenID Connect provider is enabled.",
+            failures);
+    }
+
+    private static void ValidateSaml2Provider(
+        TemplateSaml2AuthenticationOptions options,
+        ICollection<string> failures)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        const string prefix = "Template:Authentication:Providers:Saml2";
+
+        RequireProviderValue(prefix, nameof(options.Scheme), options.Scheme, failures);
+        RequireProviderValue(prefix, nameof(options.DisplayName), options.DisplayName, failures);
+        RequireProviderValue(prefix, nameof(options.EntityId), options.EntityId, failures);
+        RequireProviderValue(prefix, nameof(options.MetadataUrl), options.MetadataUrl, failures);
+        RequireProviderValue(prefix, nameof(options.ModulePath), options.ModulePath, failures);
+    }
+
+    private static void ValidateExternalProvider(
+        string providerName,
+        TemplateExternalAuthenticationProviderOptions options,
+        ICollection<string> failures)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        string prefix = $"Template:Authentication:Providers:{providerName}";
+
+        RequireProviderValue(prefix, nameof(options.Scheme), options.Scheme, failures);
+        RequireProviderValue(prefix, nameof(options.DisplayName), options.DisplayName, failures);
+        RequireProviderValue(prefix, nameof(options.ClientId), options.ClientId, failures);
+        RequireProviderValue(prefix, nameof(options.ClientSecret), options.ClientSecret, failures);
+        RequireProviderValue(prefix, nameof(options.CallbackPath), options.CallbackPath, failures);
+    }
+
+    private static void RequireProviderValue(
+        string prefix,
+        string key,
+        string? value,
+        ICollection<string> failures)
+    {
+        Require(
+            !string.IsNullOrWhiteSpace(value),
+            $"{prefix}:{key} is required when the provider is enabled.",
+            failures);
+    }
+
+    private static void Require(
+        bool condition,
+        string failureMessage,
+        ICollection<string> failures)
+    {
+        if (!condition)
+        {
+            failures.Add(failureMessage);
+        }
+    }
+}

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -145,7 +145,7 @@
           "Authority": "",
           "ClientId": "",
           "ClientSecret": "",
-          "ModulePath": "/signin-oidc",
+          "CallbackPath": "/signin-oidc",
           "ResponseType": "code",
           "SaveTokens": true,
           "Scopes": [
@@ -160,7 +160,7 @@
           "DisplayName": "SAML2",
           "EntityId": "",
           "MetadataUrl": "",
-          "CallbackPath": "/Saml2/Acs",
+          "ModulePath": "/Saml2/Acs",
           "LoadMetadata": true,
           "RequireSignedAssertions": true,
           "ValidateCertificates": true

--- a/tests/Template.Web.Tests/AuthenticationTests.cs
+++ b/tests/Template.Web.Tests/AuthenticationTests.cs
@@ -210,6 +210,121 @@ public sealed class AuthenticationTests
     }
 
     /// <summary>
+    /// Verifies that the OpenIdConnect authentication provider does not require configuration when it is disabled.
+    /// </summary>
+    /// <remarks>This test ensures that when the OpenIdConnect provider is explicitly disabled in the
+    /// configuration, missing or empty configuration values for authority and client ID do not cause errors. Use this
+    /// test to validate that the application can start without OpenIdConnect settings when the provider is not
+    /// enabled.</remarks>
+    [Fact]
+    public void DisabledOpenIdConnectProvider_DoesNotRequireConfiguration()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Providers:OpenIdConnect:Enabled"] = "false",
+            ["Template:Authentication:Providers:OpenIdConnect:Authority"] = "",
+            ["Template:Authentication:Providers:OpenIdConnect:ClientId"] = ""
+        });
+
+        TemplateAuthenticationOptions options = factory.Services
+            .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
+            .Value;
+
+        Assert.False(options.Providers.OpenIdConnect.Enabled);
+    }
+
+    /// <summary>
+    /// Verifies that enabling the OpenIdConnect authentication provider without specifying an authority causes
+    /// application startup to fail with an options validation exception.
+    /// </summary>
+    /// <remarks>This test ensures that the configuration is validated and that the authority setting is
+    /// required when the OpenIdConnect provider is enabled. It helps prevent misconfiguration at startup by asserting
+    /// that a missing authority results in a clear validation error.</remarks>
+    [Fact]
+    public void EnabledOpenIdConnectProvider_MissingAuthority_FailsStartup()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Providers:OpenIdConnect:Enabled"] = "true",
+            ["Template:Authentication:Providers:OpenIdConnect:Authority"] = "",
+            ["Template:Authentication:Providers:OpenIdConnect:ClientId"] = "test-client-id",
+            ["Template:Authentication:Providers:OpenIdConnect:CallbackPath"] = "/signin-oidc",
+            ["Template:Authentication:Providers:OpenIdConnect:ResponseType"] = "code",
+            ["Template:Authentication:Providers:OpenIdConnect:Scopes:0"] = "openid"
+        });
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+            factory.Services
+                .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
+                .Value);
+
+        Assert.Contains(
+            "Template:Authentication:Providers:OpenIdConnect:Authority is required when the provider is enabled",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that application startup fails with an OptionsValidationException when the SAML2 provider is enabled
+    /// but the MetadataUrl configuration is missing or empty.
+    /// </summary>
+    /// <remarks>This test ensures that the SAML2 authentication provider enforces the requirement for a
+    /// non-empty MetadataUrl when enabled. It validates that misconfiguration is detected early during application
+    /// startup, preventing the application from running with incomplete authentication settings.</remarks>
+    [Fact]
+    public void EnabledSaml2Provider_MissingMetadataUrl_FailsStartup()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Providers:Saml2:Enabled"] = "true",
+            ["Template:Authentication:Providers:Saml2:EntityId"] = "https://template.example/saml2",
+            ["Template:Authentication:Providers:Saml2:MetadataUrl"] = "",
+            ["Template:Authentication:Providers:Saml2:ModulePath"] = "/Saml2/Acs"
+        });
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+            factory.Services
+                .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
+                .Value);
+
+        Assert.Contains(
+            "Template:Authentication:Providers:Saml2:MetadataUrl is required when the provider is enabled",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that application startup fails with an options validation exception when the Microsoft authentication
+    /// provider is enabled but the client secret is missing.
+    /// </summary>
+    /// <remarks>This test ensures that the configuration for the Microsoft authentication provider enforces
+    /// the requirement for a client secret when the provider is enabled. It validates that an appropriate exception is
+    /// thrown and that the error message clearly indicates the missing configuration.</remarks>
+    [Fact]
+    public void EnabledMicrosoftProvider_MissingClientSecret_FailsStartup()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Providers:Microsoft:Enabled"] = "true",
+            ["Template:Authentication:Providers:Microsoft:Scheme"] = "Microsoft",
+            ["Template:Authentication:Providers:Microsoft:DisplayName"] = "Microsoft",
+            ["Template:Authentication:Providers:Microsoft:ClientId"] = "test-client-id",
+            ["Template:Authentication:Providers:Microsoft:ClientSecret"] = "",
+            ["Template:Authentication:Providers:Microsoft:CallbackPath"] = "/signin-microsoft"
+        });
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+            factory.Services
+                .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
+                .Value);
+
+        Assert.Contains(
+            "Template:Authentication:Providers:Microsoft:ClientSecret is required when the provider is enabled",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Creates a test application factory with the supplied in-memory configuration overrides.
     /// </summary>
     /// <param name="configurationValues">The configuration key/value pairs used to override template settings for a test.</param>

--- a/tests/Template.Web.Tests/AuthenticationTests.cs
+++ b/tests/Template.Web.Tests/AuthenticationTests.cs
@@ -32,12 +32,45 @@ public sealed class AuthenticationTests
             ["Template:Authentication:Cookie:AccessDeniedPath"] = "/Account/AccessDenied",
             ["Template:Authentication:Cookie:ExpireMinutes"] = "90",
             ["Template:Authentication:Cookie:SlidingExpiration"] = "false",
+
             ["Template:Authentication:Providers:OpenIdConnect:Enabled"] = "true",
+            ["Template:Authentication:Providers:OpenIdConnect:Scheme"] = "OpenIdConnect",
+            ["Template:Authentication:Providers:OpenIdConnect:DisplayName"] = "OpenID Connect",
+            ["Template:Authentication:Providers:OpenIdConnect:Authority"] = "https://login.example.test",
+            ["Template:Authentication:Providers:OpenIdConnect:ClientId"] = "test-oidc-client-id",
+            ["Template:Authentication:Providers:OpenIdConnect:CallbackPath"] = "/signin-oidc",
+            ["Template:Authentication:Providers:OpenIdConnect:ResponseType"] = "code",
+            ["Template:Authentication:Providers:OpenIdConnect:Scopes:0"] = "openid",
+            ["Template:Authentication:Providers:OpenIdConnect:Scopes:1"] = "profile",
+            ["Template:Authentication:Providers:OpenIdConnect:Scopes:2"] = "email",
+
             ["Template:Authentication:Providers:Saml2:Enabled"] = "true",
+            ["Template:Authentication:Providers:Saml2:Scheme"] = "Saml2",
+            ["Template:Authentication:Providers:Saml2:DisplayName"] = "SAML2",
+            ["Template:Authentication:Providers:Saml2:EntityId"] = "https://template.example.test/saml2",
+            ["Template:Authentication:Providers:Saml2:MetadataUrl"] = "https://idp.example.test/metadata",
             ["Template:Authentication:Providers:Saml2:ModulePath"] = "/custom-saml2-acs",
+
             ["Template:Authentication:Providers:Microsoft:Enabled"] = "true",
+            ["Template:Authentication:Providers:Microsoft:Scheme"] = "Microsoft",
+            ["Template:Authentication:Providers:Microsoft:DisplayName"] = "Microsoft",
+            ["Template:Authentication:Providers:Microsoft:ClientId"] = "test-microsoft-client-id",
+            ["Template:Authentication:Providers:Microsoft:ClientSecret"] = "test-microsoft-client-secret",
+            ["Template:Authentication:Providers:Microsoft:CallbackPath"] = "/signin-microsoft",
+
             ["Template:Authentication:Providers:Google:Enabled"] = "true",
-            ["Template:Authentication:Providers:GitHub:Enabled"] = "true"
+            ["Template:Authentication:Providers:Google:Scheme"] = "Google",
+            ["Template:Authentication:Providers:Google:DisplayName"] = "Google",
+            ["Template:Authentication:Providers:Google:ClientId"] = "test-google-client-id",
+            ["Template:Authentication:Providers:Google:ClientSecret"] = "test-google-client-secret",
+            ["Template:Authentication:Providers:Google:CallbackPath"] = "/signin-google",
+
+            ["Template:Authentication:Providers:GitHub:Enabled"] = "true",
+            ["Template:Authentication:Providers:GitHub:Scheme"] = "GitHub",
+            ["Template:Authentication:Providers:GitHub:DisplayName"] = "GitHub",
+            ["Template:Authentication:Providers:GitHub:ClientId"] = "test-github-client-id",
+            ["Template:Authentication:Providers:GitHub:ClientSecret"] = "test-github-client-secret",
+            ["Template:Authentication:Providers:GitHub:CallbackPath"] = "/signin-github"
         });
 
         TemplateAuthenticationOptions options = factory.Services


### PR DESCRIPTION
### Summary

This PR adds startup validation for authentication provider configuration so enabled providers fail fast when required settings are missing or incomplete.

### Changes
- Added centralized validation for `TemplateAuthenticationOptions`.
- Validates provider-specific settings only when a provider is enabled.
- Preserves disabled provider behavior so placeholder configuration remains allowed.
- Adds validation coverage for:
  - OpenID Connect
  - SAML2
  - Microsoft
  - Google
  - GitHub
- Ensures validation messages identify the missing configuration key.
- Avoids logging or exposing secret values.
- Corrected provider configuration key alignment:
  - OpenID Connect uses `CallbackPath`
  - SAML2 uses `ModulePath`
- Added tests for enabled-provider validation failures.
- Updated README documentation for authentication provider startup validation.

### Validation Behavior
Enabled providers now fail startup validation when required values such as scheme, display name, authority, entity ID, metadata URL, client ID, client secret, callback path, module path, response type, or scopes are missing.

Disabled providers do not require full configuration, allowing the base template to remain safe to run without external identity-provider setup.

### Testing
- Added automated tests for missing required provider settings.
- Verified disabled providers do not require complete configuration.
- Verified existing authentication tests continue to pass.

```text
Restore complete (1.8s)
  Template.Web net10.0 succeeded (10.9s) → src\Template.Web\bin\Debug\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (3.2s) → tests\Template.Web.Tests\bin\Debug\net10.0\Template.Web.Tests.dll

Build succeeded in 16.5s
```
```text
Restore complete (1.8s)
  Template.Web net10.0 succeeded (10.4s) → src\Template.Web\bin\Debug\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (3.1s) → tests\Template.Web.Tests\bin\Debug\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.66]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.19]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.62]   Starting:    Template.Web.Tests
[xUnit.net 00:00:07.18]   Finished:    Template.Web.Tests (ID = '9c515c52143e1bfe68489f9cb18def7ba96f3674832c67cdc151370ab2cad559')
  Template.Web.Tests test net10.0 succeeded (9.0s)

Test summary: total: 50, failed: 0, succeeded: 50, skipped: 0, duration: 8.9s
Build succeeded in 24.8s
```
Closes #74.