### PR TITLE
Add external authentication challenge and sign-out endpoints - Issue #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,21 @@ Validated providers include:
 
 This prevents partially configured authentication providers from failing later during runtime login flows.
 
+### Baseline Authentication Endpoints
+
+The template provides minimal account and external authentication endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /Account/Login` | Displays the baseline login page and available registered external providers. |
+| `POST /Account/Logout` | Signs out of the local cookie session. Requires anti-forgery validation. |
+| `GET /Account/AccessDenied` | Displays a safe access denied response. |
+| `GET /External/Challenge` | Starts an external authentication challenge for a registered provider scheme. |
+
+`/External/Challenge` accepts a `provider` value and an optional `returnUrl`.
+
+Return URLs are validated as local URLs before redirecting to avoid open redirect vulnerabilities. Unknown provider schemes are rejected safely. Provider secrets, tokens, cookies, and sensitive query-string values should not be logged.
+
 ## Data Access
 
 This section will document EF Core and database patterns.

--- a/src/Template.Web/Controllers/AccountController.cs
+++ b/src/Template.Web/Controllers/AccountController.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Template.Web.Models;
+
+namespace Template.Web.Controllers;
+
+/// <summary>
+/// Provides actions for user authentication, including login, logout, and access denied handling.
+/// </summary>
+/// <remarks>This controller exposes endpoints for user authentication workflows. It supports external
+/// authentication providers and enforces security best practices such as requiring local return URLs to prevent open
+/// redirect vulnerabilities. Actions are decorated with appropriate authorization and anti-forgery attributes as
+/// needed.</remarks>
+/// <param name="schemeProvider">The authentication scheme provider used to retrieve available external authentication schemes for login operations.
+/// Cannot be null.</param>
+public class AccountController(IAuthenticationSchemeProvider schemeProvider) : Controller
+{
+    private readonly IAuthenticationSchemeProvider _schemeProvider = schemeProvider;
+
+    /// <summary>
+    /// Displays the login page and provides available external authentication providers.
+    /// </summary>
+    /// <remarks>This action is accessible without authentication. Only local return URLs are permitted to
+    /// prevent open redirect vulnerabilities.</remarks>
+    /// <param name="returnUrl">The URL to redirect to after a successful login. If null or empty, the user is redirected to the application's
+    /// root. Must be a local URL.</param>
+    /// <returns>A view result that renders the login page with available external authentication providers, or a bad request
+    /// result if the return URL is not local.</returns>
+    [HttpGet("/Account/Login")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Login(string? returnUrl = null)
+    {
+        string safeReturnUrl = string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl;
+
+        if (!Url.IsLocalUrl(safeReturnUrl))
+        {
+            return BadRequest();
+        }
+
+        IEnumerable<AuthenticationScheme> schemes = await _schemeProvider.GetAllSchemesAsync();
+
+        AccountLoginViewModel model = new()
+        {
+            ReturnUrl = safeReturnUrl,
+            ExternalProviders = schemes
+                .Where(scheme => !string.Equals(
+                    scheme.Name,
+                    CookieAuthenticationDefaults.AuthenticationScheme,
+                    StringComparison.Ordinal))
+                .Where(scheme => !string.IsNullOrWhiteSpace(scheme.DisplayName))
+                .Select(scheme => new ExternalAuthenticationProviderViewModel
+                {
+                    Scheme = scheme.Name,
+                    DisplayName = scheme.DisplayName ?? scheme.Name
+                })
+                .OrderBy(provider => provider.DisplayName)
+                .ToList()
+        };
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Signs out the current user and redirects to the specified return URL.
+    /// </summary>
+    /// <remarks>This action requires a valid anti-forgery token and only accepts local URLs for redirection
+    /// to help prevent open redirect vulnerabilities.</remarks>
+    /// <param name="returnUrl">The URL to redirect to after sign-out. If null or empty, defaults to the application's root ('/'). Must be a
+    /// local URL.</param>
+    /// <returns>A redirect result to the specified local return URL if sign-out is successful; otherwise, a bad request result
+    /// if the return URL is not local.</returns>
+    [HttpPost("/Account/Logout")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Logout(string? returnUrl = null)
+    {
+        string safeReturnUrl = string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl;
+
+        if (!Url.IsLocalUrl(safeReturnUrl))
+        {
+            return BadRequest();
+        }
+
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        return LocalRedirect(safeReturnUrl);
+    }
+
+    /// <summary>
+    /// Handles requests to the access denied page and returns a view indicating that the user does not have permission
+    /// to access the requested resource.
+    /// </summary>
+    /// <remarks>This action is accessible to all users, including unauthenticated users. The response status
+    /// code is set to 403 to indicate forbidden access.</remarks>
+    /// <returns>A view result that displays the access denied page with a 403 Forbidden status code.</returns>
+    [HttpGet("/Account/AccessDenied")]
+    [AllowAnonymous]
+    public IActionResult AccessDenied()
+    {
+        Response.StatusCode = StatusCodes.Status403Forbidden;
+        return View();
+    }
+}

--- a/src/Template.Web/Controllers/ExternalController.cs
+++ b/src/Template.Web/Controllers/ExternalController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Template.Web.Controllers;
+
+/// <summary>
+/// Provides controller actions for initiating external authentication challenges using configured authentication
+/// schemes.
+/// </summary>
+/// <remarks>This controller is intended for use with external authentication providers such as OAuth or OpenID
+/// Connect. It ensures that only local return URLs are accepted to mitigate open redirect vulnerabilities. The
+/// controller should be used in scenarios where users need to authenticate via third-party identity
+/// providers.</remarks>
+/// <param name="schemeProvider">The authentication scheme provider used to retrieve available external authentication schemes. Cannot be null.</param>
+public sealed class ExternalController(IAuthenticationSchemeProvider schemeProvider) : Controller
+{
+    private readonly IAuthenticationSchemeProvider _schemeProvider = schemeProvider;
+
+    /// <summary>
+    /// Initiates an external authentication challenge using the specified provider.
+    /// </summary>
+    /// <remarks>This method is typically used to start an OAuth or other external login flow. Only local
+    /// return URLs are permitted to prevent open redirect vulnerabilities.</remarks>
+    /// <param name="provider">The name of the external authentication provider to use. Cannot be null, empty, or whitespace.</param>
+    /// <param name="returnUrl">The URL to redirect the user to after successful authentication. If null or empty, defaults to the application's
+    /// root ('/'). Must be a local URL.</param>
+    /// <returns>An IActionResult that initiates the external authentication challenge or returns a BadRequest result if the
+    /// input is invalid.</returns>
+    [HttpGet("/External/Challenge")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Challenge(string provider, string? returnUrl = null)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return BadRequest();
+        }
+
+        string safeReturnUrl = string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl;
+
+        if (!Url.IsLocalUrl(safeReturnUrl))
+        {
+            return BadRequest();
+        }
+
+        AuthenticationScheme? scheme = await _schemeProvider.GetSchemeAsync(provider);
+
+        if (scheme is null ||
+            string.Equals(scheme.Name, CookieAuthenticationDefaults.AuthenticationScheme, StringComparison.Ordinal))
+        {
+            return BadRequest();
+        }
+
+        AuthenticationProperties properties = new()
+        {
+            RedirectUri = safeReturnUrl
+        };
+
+        return Challenge(properties, scheme.Name);
+    }
+}

--- a/src/Template.Web/Models/AccountLoginViewModel.cs
+++ b/src/Template.Web/Models/AccountLoginViewModel.cs
@@ -1,0 +1,17 @@
+namespace Template.Web.Models;
+
+/// <summary>
+/// Represents the baseline login page model.
+/// </summary>
+public sealed class AccountLoginViewModel
+{
+    /// <summary>
+    /// Gets or sets the local return URL used after a successful authentication flow.
+    /// </summary>
+    public string ReturnUrl { get; set; } = "/";
+
+    /// <summary>
+    /// Gets or sets the external authentication providers available for challenge.
+    /// </summary>
+    public IReadOnlyList<ExternalAuthenticationProviderViewModel> ExternalProviders { get; set; } = [];
+}

--- a/src/Template.Web/Models/ExternalAuthenticationProviderViewModel.cs
+++ b/src/Template.Web/Models/ExternalAuthenticationProviderViewModel.cs
@@ -1,0 +1,17 @@
+namespace Template.Web.Models;
+
+/// <summary>
+/// Represents an available external authentication provider.
+/// </summary>
+public sealed class ExternalAuthenticationProviderViewModel
+{
+    /// <summary>
+    /// Gets or sets the authentication scheme name.
+    /// </summary>
+    public string Scheme { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the provider display name.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+}

--- a/src/Template.Web/Views/Account/AccessDenied.cshtml
+++ b/src/Template.Web/Views/Account/AccessDenied.cshtml
@@ -1,0 +1,17 @@
+@{
+    ViewData["Title"] = "Access Denied";
+}
+
+<h1>Access Denied</h1>
+
+<p>
+    You do not have permission to access this resource.
+</p>
+
+<p>
+    If you believe you reached this page in error, return to the application home page and try again.
+</p>
+
+<p>
+    <a href="/">Return home</a>
+</p>

--- a/src/Template.Web/Views/Account/Login.cshtml
+++ b/src/Template.Web/Views/Account/Login.cshtml
@@ -1,0 +1,38 @@
+@model Template.Web.Models.AccountLoginViewModel
+
+@{
+    ViewData["Title"] = "Sign In";
+}
+
+<h1>Sign In</h1>
+
+<p>
+    Select an external authentication provider to continue.
+</p>
+
+@if (Model.ExternalProviders.Count == 0)
+{
+    <p>
+        No external authentication providers are currently configured.
+    </p>
+}
+else
+{
+    <ul>
+        @foreach (Template.Web.Models.ExternalAuthenticationProviderViewModel provider in Model.ExternalProviders)
+        {
+            <li>
+                <a href="@Url.Action(
+                    "Challenge",
+                    "External",
+                    new
+                    {
+                        provider = provider.Scheme,
+                        returnUrl = Model.ReturnUrl
+                    })">
+                    Sign in with @provider.DisplayName
+                </a>
+            </li>
+        }
+    </ul>
+}

--- a/tests/Template.Web.Tests/ExternalAuthenticationEndpointTests.cs
+++ b/tests/Template.Web.Tests/ExternalAuthenticationEndpointTests.cs
@@ -255,7 +255,7 @@ public sealed class ExternalAuthenticationEndpointTests
             CookieAuthenticationDefaults.AuthenticationScheme);
 
         string protectedTicket = options.TicketDataFormat.Protect(ticket);
-        string cookieName = options.Cookie.Name ?? CookieAuthenticationDefaults.CookiePrefix + CookieAuthenticationDefaults.AuthenticationScheme;
+        string cookieName = options.Cookie.Name ?? (CookieAuthenticationDefaults.CookiePrefix + CookieAuthenticationDefaults.AuthenticationScheme);
 
         return new AuthenticationCookieContext(
             cookieName,

--- a/tests/Template.Web.Tests/ExternalAuthenticationEndpointTests.cs
+++ b/tests/Template.Web.Tests/ExternalAuthenticationEndpointTests.cs
@@ -1,0 +1,318 @@
+using System.Net;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Template.Web.Tests.Extensions;
+using Template.Web.Tests.Infrastructure;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides integration tests for the baseline external authentication endpoints.
+/// </summary>
+public sealed class ExternalAuthenticationEndpointTests
+{
+    private const string _testExternalScheme = "TestExternal";
+    private const string _testExternalDisplayName = "Test External";
+
+    /// <summary>
+    /// Verifies that a registered external provider can be challenged with a local return URL.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExternalChallenge_ValidProviderAndLocalReturnUrl_RedirectsToReturnUrl()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            $"/External/Challenge?provider={_testExternalScheme}&returnUrl=%2Fafter-login",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        Assert.Equal("/after-login", response.Headers.Location.OriginalString);
+    }
+
+    /// <summary>
+    /// Verifies that an unknown provider scheme is rejected safely.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExternalChallenge_UnknownProvider_ReturnsBadRequest()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/External/Challenge?provider=UnknownProvider&returnUrl=%2F",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that an external return URL is rejected to avoid open redirect behavior.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExternalChallenge_ExternalReturnUrl_ReturnsBadRequest()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        string returnUrl = Uri.EscapeDataString("https://evil.example/callback");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            $"/External/Challenge?provider={_testExternalScheme}&returnUrl={returnUrl}",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the local cookie scheme is not treated as an external provider challenge target.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExternalChallenge_CookieScheme_ReturnsBadRequest()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            $"/External/Challenge?provider={CookieAuthenticationDefaults.AuthenticationScheme}&returnUrl=%2F",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the baseline login page renders registered external providers.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AccountLogin_RendersRegisteredExternalProviders()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/Account/Login?returnUrl=%2Fprotected",
+            TestContext.Current.CancellationToken);
+
+        string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains(_testExternalDisplayName, content, StringComparison.Ordinal);
+        Assert.Contains(_testExternalScheme, content, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that the login page rejects external return URLs.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AccountLogin_ExternalReturnUrl_ReturnsBadRequest()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        string returnUrl = Uri.EscapeDataString("https://evil.example/login");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            $"/Account/Login?returnUrl={returnUrl}",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the access denied endpoint returns a safe forbidden response.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AccountAccessDenied_ReturnsForbidden()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/Account/AccessDenied",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that logout accepts a valid anti-forgery token, clears the local authentication cookie,
+    /// and redirects only to the supplied local return URL.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AccountLogout_PostWithValidAntiforgeryToken_ClearsCookieAndRedirects()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestExternalProvider();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        ClaimsPrincipal principal = CreateTestPrincipal();
+
+        AuthenticationCookieContext authenticationCookieContext =
+            CreateAuthenticationCookie(factory.Services, principal);
+
+        AntiforgeryTokenContext antiforgeryTokenContext =
+            CreateAntiforgeryToken(factory.Services, principal);
+
+        client.DefaultRequestHeaders.Add(
+            HeaderNames.Cookie,
+            $"{authenticationCookieContext.CookieHeader}; {antiforgeryTokenContext.CookieHeader}");
+
+        using FormUrlEncodedContent content = new(new Dictionary<string, string>
+        {
+            [antiforgeryTokenContext.FormFieldName] = antiforgeryTokenContext.RequestToken,
+            ["returnUrl"] = "/after-logout"
+        });
+
+        using HttpResponseMessage response = await client.PostAsync(
+            "/Account/Logout",
+            content,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        Assert.Equal("/after-logout", response.Headers.Location.OriginalString);
+
+        Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out IEnumerable<string>? setCookieHeaders));
+
+        Assert.Contains(
+            setCookieHeaders,
+            header => header.StartsWith(
+                $"{authenticationCookieContext.CookieName}=;",
+                StringComparison.Ordinal));
+    }
+    /// <summary>
+    /// Creates a test application factory with a test-only external authentication provider.
+    /// </summary>
+    /// <returns>A configured <see cref="WebApplicationFactory{TEntryPoint}"/> instance.</returns>
+    private static WebApplicationFactory<Program> CreateFactoryWithTestExternalProvider()
+    {
+        return new TemplateWebApplicationFactory(new Dictionary<string, string?>())
+            .WithWebHostBuilder(builder => builder.ConfigureServices(services => services
+                        .AddAuthentication()
+                        .AddScheme<AuthenticationSchemeOptions, TestExternalChallengeAuthenticationHandler>(
+                            _testExternalScheme,
+                            _testExternalDisplayName,
+                            _ => { })));
+    }
+
+    /// <summary>
+    /// Creates a test ClaimsPrincipal instance with a predefined identity for use in authentication scenarios.
+    /// </summary>
+    /// <remarks>This method is intended for use in unit tests or development environments where a mock
+    /// authenticated user is required.</remarks>
+    /// <returns>A ClaimsPrincipal representing a test user with a fixed name and identifier.</returns>
+    private static ClaimsPrincipal CreateTestPrincipal()
+    {
+        ClaimsIdentity identity = new(
+            [
+                new Claim(ClaimTypes.NameIdentifier, "test-user-id"),
+            new Claim(ClaimTypes.Name, "Test User")
+            ],
+            CookieAuthenticationDefaults.AuthenticationScheme);
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    /// <summary>
+    /// Creates an authentication cookie context for the specified principal using the configured cookie authentication
+    /// options.
+    /// </summary>
+    /// <remarks>The returned context includes the cookie name and a value suitable for setting as a cookie in
+    /// an HTTP response. The method uses the default cookie authentication scheme and the current options
+    /// configuration.</remarks>
+    /// <param name="services">The service provider used to resolve authentication and options services. Must not be null.</param>
+    /// <param name="principal">The claims principal representing the authenticated user. Must not be null.</param>
+    /// <returns>An AuthenticationCookieContext containing the cookie name and the protected authentication ticket value.</returns>
+    private static AuthenticationCookieContext CreateAuthenticationCookie(
+        IServiceProvider services,
+        ClaimsPrincipal principal)
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> optionsMonitor =
+            services.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>();
+
+        CookieAuthenticationOptions options =
+            optionsMonitor.Get(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        AuthenticationTicket ticket = new(
+            principal,
+            new AuthenticationProperties(),
+            CookieAuthenticationDefaults.AuthenticationScheme);
+
+        string protectedTicket = options.TicketDataFormat.Protect(ticket);
+        string cookieName = options.Cookie.Name ?? CookieAuthenticationDefaults.CookiePrefix + CookieAuthenticationDefaults.AuthenticationScheme;
+
+        return new AuthenticationCookieContext(
+            cookieName,
+            $"{cookieName}={protectedTicket}");
+    }
+
+    /// <summary>
+    /// Creates a new antiforgery token context for the specified user and service provider.
+    /// </summary>
+    /// <remarks>This method generates and stores antiforgery tokens using the provided services and user
+    /// context. The returned context includes all values necessary to submit a valid antiforgery token with a
+    /// request.</remarks>
+    /// <param name="services">The service provider used to resolve antiforgery services and dependencies. Cannot be null.</param>
+    /// <param name="principal">The user principal for whom the antiforgery token is generated. Cannot be null.</param>
+    /// <returns>An AntiforgeryTokenContext containing the form field name, request token, and cookie header for the antiforgery
+    /// token.</returns>
+    private static AntiforgeryTokenContext CreateAntiforgeryToken(
+        IServiceProvider services,
+        ClaimsPrincipal principal)
+    {
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = services,
+            User = principal
+        };
+
+        IAntiforgery antiforgery = services.GetRequiredService<IAntiforgery>();
+        AntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(httpContext);
+
+        string cookieHeader = (httpContext.Response.Headers[HeaderNames.SetCookie]
+            .FirstOrDefault(header => !string.IsNullOrWhiteSpace(header))
+            ?? throw new InvalidOperationException("Anti-forgery token generation did not create a Set-Cookie header."))
+            .Split(';', 2)[0];
+
+        return new AntiforgeryTokenContext(
+            tokens.FormFieldName,
+            tokens.RequestToken ?? string.Empty,
+            cookieHeader);
+    }
+
+    /// <summary>
+    /// Represents the context information for an authentication cookie, including its name and header value.
+    /// </summary>
+    /// <param name="CookieName">The name of the authentication cookie. This value is used to identify the cookie in HTTP requests and responses.</param>
+    /// <param name="CookieHeader">The full header value of the authentication cookie as it appears in HTTP communication.</param>
+    private sealed record AuthenticationCookieContext(
+        string CookieName,
+        string CookieHeader);
+
+    /// <summary>
+    /// Represents the context information required for antiforgery token validation in an HTTP request.
+    /// </summary>
+    /// <param name="FormFieldName">The name of the form field that contains the antiforgery token value. Cannot be null.</param>
+    /// <param name="RequestToken">The antiforgery token value submitted with the request. May be null if not present.</param>
+    /// <param name="CookieHeader">The value of the antiforgery cookie header from the HTTP request. May be null if the cookie is not set.</param>
+    private sealed record AntiforgeryTokenContext(
+        string FormFieldName,
+        string RequestToken,
+        string CookieHeader);
+}

--- a/tests/Template.Web.Tests/Infrastructure/TestExternalChallengeAuthenticationHandler.cs
+++ b/tests/Template.Web.Tests/Infrastructure/TestExternalChallengeAuthenticationHandler.cs
@@ -1,0 +1,44 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Template.Web.Tests.Infrastructure;
+
+/// <summary>
+/// Provides a test-only external authentication handler used to verify challenge endpoint behavior.
+/// </summary>
+/// <param name="options">The authentication scheme options monitor.</param>
+/// <param name="logger">The logger factory.</param>
+/// <param name="encoder">The URL encoder.</param>
+internal sealed class TestExternalChallengeAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    /// <summary>
+    /// Returns no authentication result because this handler is only used to test challenge behavior.
+    /// </summary>
+    /// <returns>A task containing an empty authentication result.</returns>
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        return Task.FromResult(AuthenticateResult.NoResult());
+    }
+
+    /// <summary>
+    /// Handles a challenge by redirecting to the authentication properties redirect URI.
+    /// </summary>
+    /// <param name="properties">The authentication properties supplied by the challenge endpoint.</param>
+    /// <returns>A completed task.</returns>
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        string redirectUri = string.IsNullOrWhiteSpace(properties.RedirectUri)
+            ? "/"
+            : properties.RedirectUri;
+
+        Response.Redirect(redirectUri);
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds baseline Account endpoints for login, logout, and access denied responses.
- Adds provider-neutral `/External/Challenge` endpoint for starting registered external authentication schemes.
- Validates return URLs with local URL checks to avoid open redirect behavior.
- Rejects missing, unknown, or local cookie provider schemes safely.
- Adds anti-forgery protection to logout.
- Documents the baseline authentication endpoint flow in README.

## Tests
- Covers valid external challenge behavior with a test authentication scheme.
- Covers invalid provider rejection.
- Covers invalid external return URL rejection.
- Covers logout behavior.
- Covers access denied response behavior.

Closes #75

```text
Restore complete (2.4s)
  Template.Web net10.0 succeeded (1.2s) → src\Template.Web\bin\Debug\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (8.5s) → tests\Template.Web.Tests\bin\Debug\net10.0\Template.Web.Tests.dll

Build succeeded in 12.7s
```
```text
Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Debug\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Debug\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.62]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.16]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.59]   Starting:    Template.Web.Tests
[xUnit.net 00:00:07.77]   Finished:    Template.Web.Tests (ID = '9c515c52143e1bfe68489f9cb18def7ba96f3674832c67cdc151370ab2cad559')
  Template.Web.Tests test net10.0 succeeded (9.7s)

Test summary: total: 58, failed: 0, succeeded: 58, skipped: 0, duration: 9.6s
Build succeeded in 13.3s
```