### PR TITLE
Implement Microsoft external provider authentication - Issue #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,8 @@ External OIDC provider integration is disabled by default. To enable it, configu
     "Providers": {
       "OpenIdConnect": {
         "Enabled": true,
+        "Scheme": "OpenIdConnect",
+        "DisplayName": "OpenID Connect",
         "Authority": "https://login.example.com",
         "ClientId": "",
         "ClientSecret": "",
@@ -724,21 +726,45 @@ External SAML2 provider integration is disabled by default. To enable it, config
 }
 ```
 _Do not commit real certificates, private keys, or real IdP metadata to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
+
+### Microsoft External Provider
+
+The template includes Microsoft external authentication support through `Microsoft.AspNetCore.Authentication.MicrosoftAccount`.
+
+The Microsoft provider is disabled by default and only registers when:
+
+`Template:Authentication:Providers:Microsoft:Enabled`
+
+is set to `true`.
+
+```json
+"Template": {
+  "Authentication": {
+    "Enabled": true,
+    "DefaultScheme": "Cookies",
+    "DefaultChallengeScheme": "Microsoft",
+    "DefaultSignInScheme": "Cookies",
+    "Providers": {
+      "Microsoft": {
+        "Enabled": true,
+        "Scheme": "Microsoft",
+        "DisplayName": "Microsoft",
+        "ClientId": "",
+        "ClientSecret": "",
+        "CallbackPath": "/signin-microsoft",
+        "Scopes": []
+      }
+    }
+  }
+}
+```
 ### External Providers
 
-The template includes foundational external provider configuration for Microsoft, Google, GitHub, and future OAuth/OIDC-compatible providers.
+The template includes foundational external provider configuration for Google, GitHub, and future OAuth/OIDC-compatible providers.
 External providers are disabled by default. This issue provides the configuration and extension-point structure only. Production provider registration, account linking, MFA enforcement, and provider-specific setup are handled by future dedicated issues.
 ```json
 "Template": {
   "Authentication": {
-    "Microsoft": {
-      "Enabled": false,
-      "Scheme": "Microsoft",
-      "DisplayName": "Microsoft",
-      "ClientId": "",
-      "ClientSecret": "",
-      "CallbackPath": "/signin-microsoft"
-    },
     "Google": {
       "Enabled": false,
       "Scheme": "Google",

--- a/src/Template.Web/Authentication/Options/TemplateExternalAuthenticationProviderOptions.cs
+++ b/src/Template.Web/Authentication/Options/TemplateExternalAuthenticationProviderOptions.cs
@@ -35,4 +35,9 @@ public sealed class TemplateExternalAuthenticationProviderOptions
     /// receive the authentication response.
     /// </summary>
     public string CallbackPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets optional provider scopes requested during the external authentication challenge.
+    /// </summary>
+    public string[] Scopes { get; set; } = [];
 }

--- a/src/Template.Web/Authentication/Providers/Microsoft/MicrosoftAuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Providers/Microsoft/MicrosoftAuthenticationServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Template.Web.Authentication.Options;
 
 namespace Template.Web.Authentication.Providers.Microsoft;
@@ -26,8 +27,19 @@ public static class MicrosoftAuthenticationServiceExtensions
             return builder;
         }
 
-        // Microsoft provider support will be implemented in a future provider-specific issue.
-        // This placeholder intentionally does not register a concrete authentication handler yet.
+        builder.AddMicrosoftAccount(options.Scheme, options.DisplayName, microsoftOptions =>
+        {
+            microsoftOptions.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            microsoftOptions.ClientId = options.ClientId;
+            microsoftOptions.ClientSecret = options.ClientSecret;
+            microsoftOptions.CallbackPath = options.CallbackPath;
+
+            foreach (string scope in options.Scopes.Where(scope => !string.IsNullOrWhiteSpace(scope)))
+            {
+                microsoftOptions.Scope.Add(scope);
+            }
+        });
+
         return builder;
     }
 }

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -171,7 +171,8 @@
           "DisplayName": "Microsoft",
           "ClientId": "",
           "ClientSecret": "",
-          "CallbackPath": "/signin-microsoft"
+          "CallbackPath": "/signin-microsoft",
+          "Scopes": []
         },
         "Google": {
           "Enabled": false,

--- a/tests/Template.Web.Tests/MicrosoftAuthenticationTests.cs
+++ b/tests/Template.Web.Tests/MicrosoftAuthenticationTests.cs
@@ -1,15 +1,16 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Template.Web.Authentication.Extensions;
 using Template.Web.Authentication.Options;
-using Template.Web.Tests.Infrastructure;
 
 namespace Template.Web.Tests;
 
 /// <summary>
-/// Provides integration tests for Microsoft external authentication provider registration.
+/// Provides tests for Microsoft external authentication provider registration.
 /// </summary>
 public sealed class MicrosoftAuthenticationTests
 {
@@ -20,14 +21,14 @@ public sealed class MicrosoftAuthenticationTests
     [Fact]
     public async Task DisabledMicrosoftProvider_DoesNotRegisterMicrosoftScheme()
     {
-        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        using ServiceProvider services = CreateServiceProvider(new Dictionary<string, string?>
         {
             ["Template:Authentication:Providers:Microsoft:Enabled"] = "false",
             ["Template:Authentication:Providers:Microsoft:ClientId"] = "",
             ["Template:Authentication:Providers:Microsoft:ClientSecret"] = ""
         });
 
-        IAuthenticationSchemeProvider schemeProvider = factory.Services
+        IAuthenticationSchemeProvider schemeProvider = services
             .GetRequiredService<IAuthenticationSchemeProvider>();
 
         AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Microsoft");
@@ -42,9 +43,9 @@ public sealed class MicrosoftAuthenticationTests
     [Fact]
     public async Task EnabledMicrosoftProvider_RegistersMicrosoftScheme()
     {
-        using TemplateWebApplicationFactory factory = CreateFactory(CreateEnabledMicrosoftConfiguration());
+        using ServiceProvider services = CreateServiceProvider(CreateEnabledMicrosoftConfiguration());
 
-        IAuthenticationSchemeProvider schemeProvider = factory.Services
+        IAuthenticationSchemeProvider schemeProvider = services
             .GetRequiredService<IAuthenticationSchemeProvider>();
 
         AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Microsoft");
@@ -60,9 +61,9 @@ public sealed class MicrosoftAuthenticationTests
     [Fact]
     public void EnabledMicrosoftProvider_ConfiguresMicrosoftHandlerOptions()
     {
-        using TemplateWebApplicationFactory factory = CreateFactory(CreateEnabledMicrosoftConfiguration());
+        using ServiceProvider services = CreateServiceProvider(CreateEnabledMicrosoftConfiguration());
 
-        IOptionsMonitor<MicrosoftAccountOptions> optionsMonitor = factory.Services
+        IOptionsMonitor<MicrosoftAccountOptions> optionsMonitor = services
             .GetRequiredService<IOptionsMonitor<MicrosoftAccountOptions>>();
 
         MicrosoftAccountOptions options = optionsMonitor.Get("Microsoft");
@@ -80,9 +81,9 @@ public sealed class MicrosoftAuthenticationTests
     [Fact]
     public void MicrosoftProviderScopes_AreBoundFromConfiguration()
     {
-        using TemplateWebApplicationFactory factory = CreateFactory(CreateEnabledMicrosoftConfiguration());
+        using ServiceProvider services = CreateServiceProvider(CreateEnabledMicrosoftConfiguration());
 
-        TemplateAuthenticationOptions options = factory.Services
+        TemplateAuthenticationOptions options = services
             .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
             .Value;
 
@@ -109,13 +110,16 @@ public sealed class MicrosoftAuthenticationTests
         };
     }
 
-    /// <summary>
-    /// Creates a test application factory with the supplied in-memory configuration overrides.
-    /// </summary>
-    /// <param name="configurationValues">The configuration key/value pairs used to override template settings for a test.</param>
-    /// <returns>A configured <see cref="TemplateWebApplicationFactory"/> instance.</returns>
-    private static TemplateWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
+    private static ServiceProvider CreateServiceProvider(IReadOnlyDictionary<string, string?> configurationValues)
     {
-        return new TemplateWebApplicationFactory(configurationValues);
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+
+        ServiceCollection services = [];
+        services.AddLogging();
+        services.AddTemplateAuthentication(configuration);
+
+        return services.BuildServiceProvider(validateScopes: true);
     }
 }

--- a/tests/Template.Web.Tests/MicrosoftAuthenticationTests.cs
+++ b/tests/Template.Web.Tests/MicrosoftAuthenticationTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Template.Web.Authentication.Options;
+using Template.Web.Tests.Infrastructure;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides integration tests for Microsoft external authentication provider registration.
+/// </summary>
+public sealed class MicrosoftAuthenticationTests
+{
+    /// <summary>
+    /// Verifies that the Microsoft authentication provider is not registered when disabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DisabledMicrosoftProvider_DoesNotRegisterMicrosoftScheme()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Providers:Microsoft:Enabled"] = "false",
+            ["Template:Authentication:Providers:Microsoft:ClientId"] = "",
+            ["Template:Authentication:Providers:Microsoft:ClientSecret"] = ""
+        });
+
+        IAuthenticationSchemeProvider schemeProvider = factory.Services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Microsoft");
+
+        Assert.Null(scheme);
+    }
+
+    /// <summary>
+    /// Verifies that the Microsoft authentication provider is registered when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledMicrosoftProvider_RegistersMicrosoftScheme()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(CreateEnabledMicrosoftConfiguration());
+
+        IAuthenticationSchemeProvider schemeProvider = factory.Services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Microsoft");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("Microsoft", scheme.Name);
+        Assert.Equal("Microsoft", scheme.DisplayName);
+    }
+
+    /// <summary>
+    /// Verifies that Microsoft provider options are applied to the registered Microsoft handler.
+    /// </summary>
+    [Fact]
+    public void EnabledMicrosoftProvider_ConfiguresMicrosoftHandlerOptions()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(CreateEnabledMicrosoftConfiguration());
+
+        IOptionsMonitor<MicrosoftAccountOptions> optionsMonitor = factory.Services
+            .GetRequiredService<IOptionsMonitor<MicrosoftAccountOptions>>();
+
+        MicrosoftAccountOptions options = optionsMonitor.Get("Microsoft");
+
+        Assert.Equal(CookieAuthenticationDefaults.AuthenticationScheme, options.SignInScheme);
+        Assert.Equal("test-microsoft-client-id", options.ClientId);
+        Assert.Equal("test-microsoft-client-secret", options.ClientSecret);
+        Assert.Equal("/signin-microsoft", options.CallbackPath);
+        Assert.Contains("User.Read", options.Scope);
+    }
+
+    /// <summary>
+    /// Verifies that Microsoft provider scopes are bound from template authentication configuration.
+    /// </summary>
+    [Fact]
+    public void MicrosoftProviderScopes_AreBoundFromConfiguration()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(CreateEnabledMicrosoftConfiguration());
+
+        TemplateAuthenticationOptions options = factory.Services
+            .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
+            .Value;
+
+        Assert.Equal(["User.Read"], options.Providers.Microsoft.Scopes);
+    }
+
+    private static Dictionary<string, string?> CreateEnabledMicrosoftConfiguration()
+    {
+        return new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Enabled"] = "true",
+            ["Template:Authentication:DefaultScheme"] = "Cookies",
+            ["Template:Authentication:DefaultChallengeScheme"] = "Microsoft",
+            ["Template:Authentication:DefaultSignInScheme"] = "Cookies",
+            ["Template:Authentication:Cookie:Enabled"] = "true",
+            ["Template:Authentication:Cookie:Scheme"] = "Cookies",
+            ["Template:Authentication:Providers:Microsoft:Enabled"] = "true",
+            ["Template:Authentication:Providers:Microsoft:Scheme"] = "Microsoft",
+            ["Template:Authentication:Providers:Microsoft:DisplayName"] = "Microsoft",
+            ["Template:Authentication:Providers:Microsoft:ClientId"] = "test-microsoft-client-id",
+            ["Template:Authentication:Providers:Microsoft:ClientSecret"] = "test-microsoft-client-secret",
+            ["Template:Authentication:Providers:Microsoft:CallbackPath"] = "/signin-microsoft",
+            ["Template:Authentication:Providers:Microsoft:Scopes:0"] = "User.Read"
+        };
+    }
+
+    /// <summary>
+    /// Creates a test application factory with the supplied in-memory configuration overrides.
+    /// </summary>
+    /// <param name="configurationValues">The configuration key/value pairs used to override template settings for a test.</param>
+    /// <returns>A configured <see cref="TemplateWebApplicationFactory"/> instance.</returns>
+    private static TemplateWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        return new TemplateWebApplicationFactory(configurationValues);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Microsoft external authentication provider support using the existing template authentication module structure.

This replaces the Microsoft provider placeholder with a real `AddMicrosoftAccount` registration while keeping the provider optional and disabled by default.

## Changes

- Added `Microsoft.AspNetCore.Authentication.MicrosoftAccount` package reference.
- Implemented Microsoft provider registration in `MicrosoftAuthenticationServiceExtensions`.
- Configured Microsoft authentication to use the local cookie sign-in scheme.
- Added optional external provider `Scopes` support.
- Added `Scopes` configuration to the Microsoft provider section in `appsettings.json`.
- Added focused tests for Microsoft provider registration and configuration binding.

## Validation

- Verified Microsoft provider does not register when disabled.
- Verified Microsoft provider registers when enabled.
- Verified Microsoft handler options are configured from template authentication settings.
- Verified Microsoft scopes bind from configuration.
- Confirmed all tests pass.

## Test Results

```bash
dotnet test --configuration Release

Restore complete (1.3s)
  Template.Web net10.0 succeeded (10.3s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (2.7s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.61]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.14]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.59]   Starting:    Template.Web.Tests
[xUnit.net 00:00:07.77]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (9.5s)

Test summary: total: 62, failed: 0, succeeded: 62, skipped: 0, duration: 9.5s
Build succeeded in 24.5s
```
Closes #76