### PR TITLE
Implement GitHub external provider authentication - Issue #94

### DIFF
--- a/ASSETS-LICENSES.md
+++ b/ASSETS-LICENSES.md
@@ -33,6 +33,9 @@ _OpenTelemetry is a collection of tools, APIs, and SDKs that can be used to inst
 - [OpenTelemetry.Instrumentation.AspNetCore](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
 - [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http)
 
+## [AspNet.Security.OAuth.GitHub](https://www.nuget.org/packages/AspNet.Security.OAuth.GitHub)
+_This package contains the GitHub authentication middleware for ASP.NET Core. It enables an application to support authentication using GitHub accounts, allowing users to sign in with their GitHub credentials. This middleware allows applications to authenticate users by redirecting them to the GitHub login page and handling the authentication response._
+
 <br /><br />
 The following asset(s) are under the [MIT](https://licenses.nuget.org/MIT) license:
 ```text

--- a/README.md
+++ b/README.md
@@ -794,20 +794,36 @@ is set to `true`.
 }
 ```
 _Do not commit real client IDs, client secrets, certificates, tokens, or provider credentials to source control. Use user secrets, environment variables, deployment secrets, or a secure secret store._
-### External Providers
 
-The template includes foundational external provider configuration for Google, GitHub, and future OAuth/OIDC-compatible providers.
-External providers are disabled by default. This issue provides the configuration and extension-point structure only. Production provider registration, account linking, MFA enforcement, and provider-specific setup are handled by future dedicated issues.
+### GitHub External Provider
+The template includes Google external authentication support through `AspNet.Security.OAuth.GitHub`.
+
+The GitHub provider is disabled by default and only registers when:
+
+`Template:Authentication:Providers:GitHub:Enabled`
+
+is set to `true`.
+
 ```json
 "Template": {
   "Authentication": {
-    "GitHub": {
-      "Enabled": false,
-      "Scheme": "GitHub",
-      "DisplayName": "GitHub",
-      "ClientId": "",
-      "ClientSecret": "",
-      "CallbackPath": "/signin-github"
+    "Enabled": true,
+    "DefaultScheme": "Cookies",
+    "DefaultChallengeScheme": "GitHub",
+    "DefaultSignInScheme": "Cookies",
+    "Providers": {
+      "GitHub": {
+        "Enabled": true,
+        "Scheme": "GitHub",
+        "DisplayName": "GitHub",
+        "ClientId": "",
+        "ClientSecret": "",
+        "CallbackPath": "/signin-github",
+        "Scopes": [
+          "profile",
+          "email"
+        ]
+      }
     }
   }
 }

--- a/src/Template.Web/Authentication/Providers/GitHub/GitHubAuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Providers/GitHub/GitHubAuthenticationServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Template.Web.Authentication.Options;
 
 namespace Template.Web.Authentication.Providers.GitHub;
@@ -26,8 +27,19 @@ public static class GitHubAuthenticationServiceExtensions
             return builder;
         }
 
-        // GitHub provider support will be implemented in a future provider-specific issue.
-        // This placeholder intentionally does not register a concrete authentication handler yet.
+        builder.AddGitHub(options.Scheme, options.DisplayName, githubOptions =>
+        {
+            githubOptions.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            githubOptions.ClientId = options.ClientId;
+            githubOptions.ClientSecret = options.ClientSecret;
+            githubOptions.CallbackPath = options.CallbackPath;
+
+            foreach (string scope in options.Scopes.Where(scope => !string.IsNullOrWhiteSpace(scope)))
+            {
+                githubOptions.Scope.Add(scope);
+            }
+        });
+
         return builder;
     }
 }

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />

--- a/tests/Template.Web.Tests/AuthenticationTests.cs
+++ b/tests/Template.Web.Tests/AuthenticationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Template.Web.Authentication.Options;
+using Template.Web.Authentication.Providers.GitHub;
 using Template.Web.Authentication.Providers.Google;
 using Template.Web.Tests.Extensions;
 using Template.Web.Tests.Infrastructure;
@@ -531,6 +532,107 @@ public sealed class AuthenticationTests
             exception.Message,
             StringComparison.Ordinal);
     }
+
+
+
+    /// <summary>
+    /// Verifies that the GitHub authentication provider does not register a scheme when disabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DisabledGitHubProvider_DoesNotRegisterGitHubScheme()
+    {
+        ServiceCollection services = new();
+
+        AuthenticationBuilder builder = services.AddAuthentication();
+
+        builder.AddTemplateGitHubAuthentication(new TemplateExternalAuthenticationProviderOptions
+        {
+            Enabled = false,
+            Scheme = "GitHub",
+            DisplayName = "GitHub",
+            ClientId = "",
+            ClientSecret = "",
+            CallbackPath = "/signin-github"
+        });
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        IAuthenticationSchemeProvider schemeProvider = serviceProvider
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("GitHub");
+
+        Assert.Null(scheme);
+    }
+
+    /// <summary>
+    /// Verifies that the GitHub authentication provider registers a scheme when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledGitHubProvider_RegistersGitHubScheme()
+    {
+        ServiceCollection services = new();
+
+        AuthenticationBuilder builder = services.AddAuthentication();
+
+        builder.AddTemplateGitHubAuthentication(new TemplateExternalAuthenticationProviderOptions
+        {
+            Enabled = true,
+            Scheme = "GitHub",
+            DisplayName = "GitHub",
+            ClientId = "test-github-client-id",
+            ClientSecret = "test-github-client-secret",
+            CallbackPath = "/signin-github",
+            Scopes =
+            [
+                "profile",
+                "email"
+            ]
+        });
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        IAuthenticationSchemeProvider schemeProvider = serviceProvider
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("GitHub");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("GitHub", scheme.Name);
+        Assert.Equal("GitHub", scheme.DisplayName);
+    }
+
+    /// <summary>
+    /// Verifies that application startup fails with an options validation exception when the GitHub authentication
+    /// provider is enabled but the client secret is missing.
+    /// </summary>
+    [Fact]
+    public void EnabledGitHubProvider_MissingClientSecret_FailsStartup()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Providers:GitHub:Enabled"] = "true",
+            ["Template:Authentication:Providers:GitHub:Scheme"] = "GitHub",
+            ["Template:Authentication:Providers:GitHub:DisplayName"] = "GitHub",
+            ["Template:Authentication:Providers:GitHub:ClientId"] = "test-client-id",
+            ["Template:Authentication:Providers:GitHub:ClientSecret"] = "",
+            ["Template:Authentication:Providers:GitHub:CallbackPath"] = "/signin-github"
+        });
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+            factory.Services
+                .GetRequiredService<IOptions<TemplateAuthenticationOptions>>()
+                .Value);
+
+        Assert.Contains(
+            "Template:Authentication:Providers:GitHub:ClientSecret is required when the provider is enabled",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+
     /// <summary>
     /// Creates a test application factory with the supplied in-memory configuration overrides.
     /// </summary>


### PR DESCRIPTION
## Summary

Closes #94

Implemented GitHub external authentication provider support using the existing template authentication module structure.

This replaces the GitHub provider placeholder with a real provider registration while keeping the provider optional and disabled by default.

## Changes

- Added `AspNet.Security.OAuth.GitHub` package reference.
- Replaced the GitHub provider placeholder with real `AddGitHub(...)` registration.
- Configured GitHub authentication to use the local cookie sign-in scheme.
- Bound GitHub provider settings from `Template:Authentication:Providers:GitHub`.
- Added configurable GitHub OAuth scopes.
- Kept GitHub authentication disabled by default.
- Preserved provider-specific logic inside the GitHub authentication extension instead of `Program.cs`.
- Added or updated tests for GitHub provider configuration and registration behavior.

## Validation

- Confirmed restore completes successfully.
- Confirmed Release build succeeds.
- Confirmed GitHub provider does not register when disabled.
- Confirmed GitHub provider registers when enabled.
- Confirmed no real client IDs, client secrets, tokens, or provider credentials were committed.

## Testing

```bash
dotnet restore
dotnet build --configuration Release

Restore complete (1.3s)
  Template.Web net10.0 succeeded (11.2s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (5.7s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll

Build succeeded in 18.9s


dotnet test --configuration Release

Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:02.74]   Discovering: Template.Web.Tests
[xUnit.net 00:00:03.28]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:03.72]   Starting:    Template.Web.Tests
[xUnit.net 00:00:15.12]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (19.2s)

Test summary: total: 71, failed: 0, succeeded: 71, skipped: 0, duration: 19.1s
Build succeeded in 22.8s
```