### PR TITLE
Add authentication provider integration tests - Issue #80

### DIFF
--- a/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
@@ -2,11 +2,11 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Options;
 using Template.Web.Authentication.Options;
+using Template.Web.Authentication.Providers.GitHub;
 using Template.Web.Authentication.Providers.Google;
 using Template.Web.Authentication.Providers.Microsoft;
 using Template.Web.Authentication.Providers.OpenIdConnect;
 using Template.Web.Authentication.Providers.Saml2;
-using Template.Web.Authentication.Providers.GitHub;
 
 namespace Template.Web.Authentication.Extensions;
 

--- a/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
@@ -6,6 +6,7 @@ using Template.Web.Authentication.Providers.Google;
 using Template.Web.Authentication.Providers.Microsoft;
 using Template.Web.Authentication.Providers.OpenIdConnect;
 using Template.Web.Authentication.Providers.Saml2;
+using Template.Web.Authentication.Providers.GitHub;
 
 namespace Template.Web.Authentication.Extensions;
 
@@ -88,7 +89,8 @@ public static class AuthenticationServiceExtensions
             .AddTemplateOpenIdConnectAuthentication(templateAuthenticationOptions.Providers.OpenIdConnect)
             .AddTemplateSaml2Authentication(templateAuthenticationOptions.Providers.Saml2)
             .AddTemplateMicrosoftAuthentication(templateAuthenticationOptions.Providers.Microsoft)
-            .AddTemplateGoogleAuthentication(templateAuthenticationOptions.Providers.Google);
+            .AddTemplateGoogleAuthentication(templateAuthenticationOptions.Providers.Google)
+            .AddTemplateGitHubAuthentication(templateAuthenticationOptions.Providers.GitHub);
 
         return services;
     }

--- a/tests/Template.Web.Tests/AuthenticationProviderIntegrationTests.cs
+++ b/tests/Template.Web.Tests/AuthenticationProviderIntegrationTests.cs
@@ -1,0 +1,243 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Template.Web.Authentication.Extensions;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides integration tests for authentication provider registration through the template authentication module.
+/// </summary>
+public sealed class AuthenticationProviderIntegrationTests
+{
+    /// <summary>
+    /// Verifies that disabled external providers do not register provider authentication schemes.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DisabledExternalProviders_DoNotRegisterProviderSchemes()
+    {
+        using ServiceProvider services = CreateServiceProvider(CreateDisabledExternalProvidersConfiguration());
+
+        IAuthenticationSchemeProvider schemeProvider = services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        string[] providerSchemes =
+        [
+            "OpenIdConnect",
+            "Saml2",
+            "Microsoft",
+            "Google",
+            "GitHub"
+        ];
+
+        foreach (string providerScheme in providerSchemes)
+        {
+            AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync(providerScheme);
+
+            Assert.Null(scheme);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the OpenID Connect provider registers the configured scheme when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledOpenIdConnectProvider_RegistersConfiguredScheme()
+    {
+        Dictionary<string, string?> configurationValues = CreateBaseAuthenticationConfiguration();
+
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Enabled"] = "true";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Scheme"] = "OpenIdConnect";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:DisplayName"] = "OpenID Connect";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Authority"] = "https://login.example.test";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:ClientId"] = "test-oidc-client-id";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:ClientSecret"] = "test-oidc-client-secret";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:CallbackPath"] = "/signin-oidc";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:ResponseType"] = "code";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Scopes:0"] = "openid";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Scopes:1"] = "profile";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Scopes:2"] = "email";
+
+        using ServiceProvider services = CreateServiceProvider(configurationValues);
+
+        IAuthenticationSchemeProvider schemeProvider = services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("OpenIdConnect");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("OpenIdConnect", scheme.Name);
+        Assert.Equal("OpenID Connect", scheme.DisplayName);
+    }
+
+    /// <summary>
+    /// Verifies that the SAML2 provider registers the configured scheme when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledSaml2Provider_RegistersConfiguredScheme()
+    {
+        Dictionary<string, string?> configurationValues = CreateBaseAuthenticationConfiguration();
+
+        configurationValues["Template:Authentication:Providers:Saml2:Enabled"] = "true";
+        configurationValues["Template:Authentication:Providers:Saml2:Scheme"] = "Saml2";
+        configurationValues["Template:Authentication:Providers:Saml2:DisplayName"] = "SAML2";
+        configurationValues["Template:Authentication:Providers:Saml2:EntityId"] = "https://template.example.test/saml2";
+        configurationValues["Template:Authentication:Providers:Saml2:MetadataUrl"] = "https://idp.example.test/metadata";
+        configurationValues["Template:Authentication:Providers:Saml2:ModulePath"] = "/Saml2/Acs";
+        configurationValues["Template:Authentication:Providers:Saml2:LoadMetadata"] = "false";
+
+        using ServiceProvider services = CreateServiceProvider(configurationValues);
+
+        IAuthenticationSchemeProvider schemeProvider = services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Saml2");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("Saml2", scheme.Name);
+        Assert.Equal("SAML2", scheme.DisplayName);
+    }
+
+    /// <summary>
+    /// Verifies that the Microsoft provider registers the configured scheme when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledMicrosoftProvider_RegistersConfiguredScheme()
+    {
+        Dictionary<string, string?> configurationValues = CreateBaseAuthenticationConfiguration();
+
+        configurationValues["Template:Authentication:Providers:Microsoft:Enabled"] = "true";
+        configurationValues["Template:Authentication:Providers:Microsoft:Scheme"] = "Microsoft";
+        configurationValues["Template:Authentication:Providers:Microsoft:DisplayName"] = "Microsoft";
+        configurationValues["Template:Authentication:Providers:Microsoft:ClientId"] = "test-microsoft-client-id";
+        configurationValues["Template:Authentication:Providers:Microsoft:ClientSecret"] = "test-microsoft-client-secret";
+        configurationValues["Template:Authentication:Providers:Microsoft:CallbackPath"] = "/signin-microsoft";
+
+        using ServiceProvider services = CreateServiceProvider(configurationValues);
+
+        IAuthenticationSchemeProvider schemeProvider = services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Microsoft");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("Microsoft", scheme.Name);
+        Assert.Equal("Microsoft", scheme.DisplayName);
+    }
+
+    /// <summary>
+    /// Verifies that the Google provider registers the configured scheme when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledGoogleProvider_RegistersConfiguredScheme()
+    {
+        Dictionary<string, string?> configurationValues = CreateBaseAuthenticationConfiguration();
+
+        configurationValues["Template:Authentication:Providers:Google:Enabled"] = "true";
+        configurationValues["Template:Authentication:Providers:Google:Scheme"] = "Google";
+        configurationValues["Template:Authentication:Providers:Google:DisplayName"] = "Google";
+        configurationValues["Template:Authentication:Providers:Google:ClientId"] = "test-google-client-id";
+        configurationValues["Template:Authentication:Providers:Google:ClientSecret"] = "test-google-client-secret";
+        configurationValues["Template:Authentication:Providers:Google:CallbackPath"] = "/signin-google";
+        configurationValues["Template:Authentication:Providers:Google:Scopes:0"] = "profile";
+        configurationValues["Template:Authentication:Providers:Google:Scopes:1"] = "email";
+
+        using ServiceProvider services = CreateServiceProvider(configurationValues);
+
+        IAuthenticationSchemeProvider schemeProvider = services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Google");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("Google", scheme.Name);
+        Assert.Equal("Google", scheme.DisplayName);
+    }
+
+    /// <summary>
+    /// Verifies that the GitHub provider registers the configured scheme when enabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task EnabledGitHubProvider_RegistersConfiguredScheme()
+    {
+        Dictionary<string, string?> configurationValues = CreateBaseAuthenticationConfiguration();
+
+        configurationValues["Template:Authentication:Providers:GitHub:Enabled"] = "true";
+        configurationValues["Template:Authentication:Providers:GitHub:Scheme"] = "GitHub";
+        configurationValues["Template:Authentication:Providers:GitHub:DisplayName"] = "GitHub";
+        configurationValues["Template:Authentication:Providers:GitHub:ClientId"] = "test-github-client-id";
+        configurationValues["Template:Authentication:Providers:GitHub:ClientSecret"] = "test-github-client-secret";
+        configurationValues["Template:Authentication:Providers:GitHub:CallbackPath"] = "/signin-github";
+        configurationValues["Template:Authentication:Providers:GitHub:Scopes:0"] = "user:email";
+
+        using ServiceProvider services = CreateServiceProvider(configurationValues);
+
+        IAuthenticationSchemeProvider schemeProvider = services
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("GitHub");
+
+        Assert.NotNull(scheme);
+        Assert.Equal("GitHub", scheme.Name);
+        Assert.Equal("GitHub", scheme.DisplayName);
+    }
+
+    private static Dictionary<string, string?> CreateDisabledExternalProvidersConfiguration()
+    {
+        Dictionary<string, string?> configurationValues = CreateBaseAuthenticationConfiguration();
+
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Enabled"] = "false";
+        configurationValues["Template:Authentication:Providers:OpenIdConnect:Scheme"] = "OpenIdConnect";
+
+        configurationValues["Template:Authentication:Providers:Saml2:Enabled"] = "false";
+        configurationValues["Template:Authentication:Providers:Saml2:Scheme"] = "Saml2";
+
+        configurationValues["Template:Authentication:Providers:Microsoft:Enabled"] = "false";
+        configurationValues["Template:Authentication:Providers:Microsoft:Scheme"] = "Microsoft";
+
+        configurationValues["Template:Authentication:Providers:Google:Enabled"] = "false";
+        configurationValues["Template:Authentication:Providers:Google:Scheme"] = "Google";
+
+        configurationValues["Template:Authentication:Providers:GitHub:Enabled"] = "false";
+        configurationValues["Template:Authentication:Providers:GitHub:Scheme"] = "GitHub";
+
+        return configurationValues;
+    }
+
+    private static Dictionary<string, string?> CreateBaseAuthenticationConfiguration()
+    {
+        return new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Enabled"] = "true",
+            ["Template:Authentication:DefaultScheme"] = "Cookies",
+            ["Template:Authentication:DefaultChallengeScheme"] = "Cookies",
+            ["Template:Authentication:DefaultSignInScheme"] = "Cookies",
+            ["Template:Authentication:Cookie:Enabled"] = "true",
+            ["Template:Authentication:Cookie:Scheme"] = "Cookies",
+            ["Template:Authentication:Cookie:LoginPath"] = "/Account/Login",
+            ["Template:Authentication:Cookie:LogoutPath"] = "/Account/Logout",
+            ["Template:Authentication:Cookie:AccessDeniedPath"] = "/Account/AccessDenied",
+            ["Template:Authentication:Cookie:ExpireMinutes"] = "60",
+            ["Template:Authentication:Cookie:SlidingExpiration"] = "true"
+        };
+    }
+
+    private static ServiceProvider CreateServiceProvider(IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+
+        ServiceCollection services = [];
+        services.AddLogging();
+        services.AddTemplateAuthentication(configuration);
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #80

Adds integration coverage for external authentication provider registration through the main template authentication registration path.

## Changes

- Added focused authentication provider integration tests.
- Verified disabled external providers do not register authentication schemes.
- Verified enabled OIDC, SAML2, Microsoft, Google, and GitHub providers register expected schemes.
- Confirmed existing external authentication endpoint tests cover invalid provider rejection and unsafe return URL handling.
- Wired GitHub provider registration into the main template authentication chain if required by the new integration coverage.

## Validation

- Confirmed tests do not require real external provider credentials.
- Confirmed tests do not make live calls to Microsoft, Google, GitHub, OIDC, or SAML providers.
- Ran:

```bash
dotnet test --configuration Release

Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.65]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.19]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.63]   Starting:    Template.Web.Tests
[xUnit.net 00:00:07.87]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (9.7s)

Test summary: total: 77, failed: 0, succeeded: 77, skipped: 0, duration: 9.7s
Build succeeded in 13.4s
```