### PR TITLE
docs: evaluate OpenIddict client provider strategy - Issue #95

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,33 @@ The template provides minimal account and external authentication endpoints:
 
 Return URLs are validated as local URLs before redirecting to avoid open redirect vulnerabilities. Unknown provider schemes are rejected safely. Provider secrets, tokens, cookies, and sensitive query-string values should not be logged.
 
+### External Social Provider Strategy and OpenIddict Client Evaluation
+
+The template currently uses provider-specific ASP.NET Core authentication handlers for Microsoft, Google, and GitHub. This keeps the implementation simple, scheme-based, and consistent with the existing authentication module structure.
+
+Current provider-specific packages remain supported and are the active implementation path for this template. They are disabled by default, registered only when enabled, validated during startup, and configured through:
+
+```text
+Template:Authentication:Providers:Microsoft
+Template:Authentication:Providers:Google
+Template:Authentication:Providers:GitHub
+```
+OpenIddict Client was evaluated as a future external social provider architecture. OpenIddict Client provides a broader OAuth 2.0/OpenID Connect client stack with web-provider integrations for many external providers, including GitHub, Microsoft, and Google. It also provides stronger long-term capabilities such as OpenID Connect support, stateful client behavior, replay protections, discovery support, token introspection/revocation support, and resilient backchannel behavior.
+
+However, adopting OpenIddict Client would be an architectural migration rather than a direct package swap. A migration would need to account for:
+- OpenIddict client/core service registration.
+- Token/state storage requirements.
+- Provider-specific redirect endpoint design.
+- Callback endpoint/controller handling.
+- Existing `/External/Challenge` behavior.
+- Existing startup validation behavior.
+- Existing tests and documentation.
+- Compatibility with Microsoft, Google, GitHub, and future providers.
+
+OpenIddict Client may be implemented as the preferred candidate for a future broader social-provider architecture if the template later needs a unified OAuth/OIDC client model across many providers or advanced token-handling features.
+
+Any future migration would be handled through a dedicated implementation issue and should preserve the existing working Microsoft, Google, and GitHub behavior until a replacement path is fully tested.
+
 ## Data Access
 
 This section will document EF Core and database patterns.

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -8,12 +8,12 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <VersionPrefix>0.2.4</VersionPrefix>
+    <VersionPrefix>0.2.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.2.4.0</AssemblyVersion>
-    <FileVersion>0.2.4.0</FileVersion>
+    <AssemblyVersion>0.2.5.0</AssemblyVersion>
+    <FileVersion>0.2.5.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
 
   </PropertyGroup>

--- a/tests/Template.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/Template.Web.Tests/OpenTelemetryTests.cs
@@ -16,7 +16,7 @@ namespace Template.Web.Tests;
 /// </summary>
 public sealed class OpenTelemetryTests
 {
-    private const string _releaseVersion = "0.2.4";
+    private const string _releaseVersion = "0.2.5";
 
     /// <summary>
     /// Verifies that template OpenTelemetry options are bound from configuration.


### PR DESCRIPTION
## Summary

- Documents the OpenIddict Client evaluation for external social provider integration.
- Recommends keeping the current provider-specific package approach for Microsoft, Google, and GitHub.
- Identifies OpenIddict Client as a future migration candidate rather than an immediate replacement.
- Notes migration considerations for state storage, callbacks, challenge flow, validation, tests, and documentation.
- Corrects the GitHub provider documentation wording.

## Testing

- Documentation-only change.
- Ran `dotnet test` to confirm the solution remains healthy.

Closes #95

```bash
Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.65]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.19]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.62]   Starting:    Template.Web.Tests
[xUnit.net 00:00:07.94]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (9.8s)

Test summary: total: 77, failed: 0, succeeded: 77, skipped: 0, duration: 9.8s
Build succeeded in 13.4s
```