### PR TITLE
Add claims transformation support - Issue #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,6 +890,21 @@ OpenIddict Client may be implemented as the preferred candidate for a future bro
 
 Any future migration would be handled through a dedicated implementation issue and should preserve the existing working Microsoft, Google, and GitHub behavior until a replacement path is fully tested.
 
+### Claims Transformation and Normalization
+
+The template includes an optional claims transformation layer that normalizes provider-specific claims into template-owned claim names.
+
+External identity providers often use different claim names for the same concept. For example, one provider may emit `sub`, another may emit `nameidentifier`, and another may use a SAML claim URI. The claims transformation layer allows these inputs to be mapped into consistent application claim names such as:
+
+- `template:subject`
+- `template:name`
+- `template:email`
+- `template:role`
+- `template:group`
+- `template:permission`
+
+Original provider claims are preserved by default. They are only removed when `Template:Authentication:ClaimsTransformation:RemoveOriginalClaims` is explicitly set to `true`.
+
 ## Data Access
 
 This section will document EF Core and database patterns.

--- a/src/Template.Web/Authentication/Claims/TemplateClaimMappingOptions.cs
+++ b/src/Template.Web/Authentication/Claims/TemplateClaimMappingOptions.cs
@@ -1,0 +1,83 @@
+using System.Security.Claims;
+
+namespace Template.Web.Authentication.Claims;
+
+/// <summary>
+/// Represents source claim mappings used to normalize provider-specific claims.
+/// </summary>
+public sealed class TemplateClaimMappingOptions
+{
+    /// <summary>
+    /// Gets or sets the collection of claim type identifiers used to represent the subject in security tokens.
+    /// </summary>
+    /// <remarks>This collection typically includes standard claim types such as 'sub', 'subject', 'nameid',
+    /// and the value of ClaimTypes.NameIdentifier. The identifiers are used to extract or assign the subject value when
+    /// processing security tokens.</remarks>
+    public ICollection<string> Subject { get; set; } =
+    [
+        "sub",
+        "subject",
+        "nameid",
+        ClaimTypes.NameIdentifier
+    ];
+
+    /// <summary>
+    /// Gets or sets the collection of claim type names used to identify a user's name.
+    /// </summary>
+    /// <remarks>This collection typically includes standard claim type identifiers such as "name",
+    /// "display_name", and values from <see cref="ClaimTypes"/>. The collection can be
+    /// customized to support additional or alternative claim type names as needed.</remarks>
+    public ICollection<string> Name { get; set; } =
+    [
+        "name",
+        "display_name",
+        ClaimTypes.Name
+    ];
+
+    /// <summary>
+    /// Gets or sets the collection of claim type identifiers used to represent an email address.
+    /// </summary>
+    /// <remarks>This collection typically includes standard claim type names such as "email", "emailaddress",
+    /// and the value of <see cref="ClaimTypes.Email"/>. Modify this collection to support custom
+    /// or additional claim type identifiers as needed.</remarks>
+    public ICollection<string> Email { get; set; } =
+    [
+        "email",
+        "emailaddress",
+        ClaimTypes.Email
+    ];
+
+    /// <summary>
+    /// Gets or sets the collection of claim type names that represent user roles.
+    /// </summary>
+    /// <remarks>This collection typically includes standard claim type names such as "role", "roles", and the
+    /// value of <see cref="ClaimTypes.Role"/>. Modify this collection to support custom or
+    /// additional role claim types as needed.</remarks>
+    public ICollection<string> Role { get; set; } =
+    [
+        "role",
+        "roles",
+        ClaimTypes.Role
+    ];
+
+    /// <summary>
+    /// Gets or sets the collection of group identifiers associated with the entity.
+    /// </summary>
+    public ICollection<string> Group { get; set; } =
+    [
+        "group",
+        "groups",
+        "memberOf"
+    ];
+
+    /// <summary>
+    /// Gets or sets the collection of permission identifiers associated with the current context.
+    /// </summary>
+    public ICollection<string> Permission { get; set; } =
+    [
+        "permission",
+        "permissions",
+        "scope",
+        "scp"
+    ];
+}

--- a/src/Template.Web/Authentication/Claims/TemplateClaimTypes.cs
+++ b/src/Template.Web/Authentication/Claims/TemplateClaimTypes.cs
@@ -1,0 +1,32 @@
+namespace Template.Web.Authentication.Claims;
+
+/// <summary>
+/// Defines normalized claim types used by the template application.
+/// </summary>
+public static class TemplateClaimTypes
+{
+    /// <summary>
+    /// Represents the key used to identify the subject template in configuration or metadata collections.
+    /// </summary>
+    public const string Subject = "template:subject";
+    /// <summary>
+    /// Represents the XML element name used for the template.
+    /// </summary>
+    public const string Name = "template:name";
+    /// <summary>
+    /// Represents the template identifier for email content.
+    /// </summary>
+    public const string Email = "template:email";
+    /// <summary>
+    /// Specifies the claim type for a template role.
+    /// </summary>
+    public const string Role = "template:role";
+    /// <summary>
+    /// Represents the group identifier used in template metadata.
+    /// </summary>
+    public const string Group = "template:group";
+    /// <summary>
+    /// Represents the permission identifier used for template-related authorization checks.
+    /// </summary>
+    public const string Permission = "template:permission";
+}

--- a/src/Template.Web/Authentication/Claims/TemplateClaimsTransformation.cs
+++ b/src/Template.Web/Authentication/Claims/TemplateClaimsTransformation.cs
@@ -1,0 +1,116 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Template.Web.Authentication.Options;
+
+namespace Template.Web.Authentication.Claims;
+
+/// <summary>
+/// Normalizes provider-specific claims into template-owned claim names.
+/// </summary>
+/// <param name="authenticationOptionsAccessor">The template authentication options accessor.</param>
+public sealed class TemplateClaimsTransformation(
+    IOptions<TemplateAuthenticationOptions> authenticationOptionsAccessor) : IClaimsTransformation
+{
+    private readonly IOptions<TemplateAuthenticationOptions> _authenticationOptionsAccessor =
+        authenticationOptionsAccessor ?? throw new ArgumentNullException(nameof(authenticationOptionsAccessor));
+
+    /// <inheritdoc />
+    public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        TemplateClaimsTransformationOptions options =
+            _authenticationOptionsAccessor.Value.ClaimsTransformation;
+
+        if (!options.Enabled)
+        {
+            return Task.FromResult(principal);
+        }
+
+        foreach (ClaimsIdentity identity in principal.Identities.OfType<ClaimsIdentity>())
+        {
+            TemplateClaimMappingOptions mappings = ResolveMappings(options, identity.AuthenticationType);
+
+            NormalizeClaim(identity, TemplateClaimTypes.Subject, mappings.Subject, options.RemoveOriginalClaims);
+            NormalizeClaim(identity, TemplateClaimTypes.Name, mappings.Name, options.RemoveOriginalClaims);
+            NormalizeClaim(identity, TemplateClaimTypes.Email, mappings.Email, options.RemoveOriginalClaims);
+            NormalizeClaim(identity, TemplateClaimTypes.Role, mappings.Role, options.RemoveOriginalClaims);
+            NormalizeClaim(identity, TemplateClaimTypes.Group, mappings.Group, options.RemoveOriginalClaims);
+            NormalizeClaim(identity, TemplateClaimTypes.Permission, mappings.Permission, options.RemoveOriginalClaims);
+        }
+
+        return Task.FromResult(principal);
+    }
+
+    private static TemplateClaimMappingOptions ResolveMappings(
+        TemplateClaimsTransformationOptions options,
+        string? authenticationType)
+    {
+        return !string.IsNullOrWhiteSpace(authenticationType)
+            && options.ProviderMappings.TryGetValue(authenticationType, out TemplateClaimMappingOptions? providerMappings)
+            ? providerMappings
+            : options.DefaultMappings;
+    }
+
+    private static void NormalizeClaim(
+        ClaimsIdentity identity,
+        string normalizedClaimType,
+        IEnumerable<string> sourceClaimTypes,
+        bool removeOriginalClaims)
+    {
+        var sourceTypes = sourceClaimTypes
+            .Where(claimType => !string.IsNullOrWhiteSpace(claimType))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (sourceTypes.Count == 0)
+        {
+            return;
+        }
+
+        var sourceClaims = identity.Claims
+            .Where(claim => sourceTypes.Contains(claim.Type))
+            .ToList();
+
+        if (sourceClaims.Count == 0)
+        {
+            return;
+        }
+
+        foreach (Claim sourceClaim in sourceClaims)
+        {
+            if (!HasClaim(identity, normalizedClaimType, sourceClaim.Value))
+            {
+                identity.AddClaim(new Claim(
+                    normalizedClaimType,
+                    sourceClaim.Value,
+                    sourceClaim.ValueType,
+                    sourceClaim.Issuer,
+                    sourceClaim.OriginalIssuer));
+            }
+        }
+
+        if (!removeOriginalClaims)
+        {
+            return;
+        }
+
+        foreach (Claim sourceClaim in sourceClaims)
+        {
+            if (!string.Equals(sourceClaim.Type, normalizedClaimType, StringComparison.OrdinalIgnoreCase))
+            {
+                identity.RemoveClaim(sourceClaim);
+            }
+        }
+    }
+
+    private static bool HasClaim(
+        ClaimsIdentity identity,
+        string claimType,
+        string claimValue)
+    {
+        return identity.Claims.Any(claim =>
+            string.Equals(claim.Type, claimType, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(claim.Value, claimValue, StringComparison.Ordinal));
+    }
+}

--- a/src/Template.Web/Authentication/Claims/TemplateClaimsTransformationOptions.cs
+++ b/src/Template.Web/Authentication/Claims/TemplateClaimsTransformationOptions.cs
@@ -1,0 +1,28 @@
+namespace Template.Web.Authentication.Claims;
+
+/// <summary>
+/// Represents template claims transformation options.
+/// </summary>
+public sealed class TemplateClaimsTransformationOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the feature is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the original claims should be removed after processing.
+    /// </summary>
+    public bool RemoveOriginalClaims { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default claim mappings used when no provider-specific mapping is configured.
+    /// </summary>
+    public TemplateClaimMappingOptions DefaultMappings { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets provider-specific claim mappings keyed by authentication provider scheme or authentication type.
+    /// </summary>
+    public Dictionary<string, TemplateClaimMappingOptions> ProviderMappings { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Options;
+using Template.Web.Authentication.Claims;
 using Template.Web.Authentication.Options;
 using Template.Web.Authentication.Providers.GitHub;
 using Template.Web.Authentication.Providers.Google;
@@ -28,6 +29,7 @@ public static class AuthenticationServiceExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
+        services.AddTransient<IClaimsTransformation, TemplateClaimsTransformation>();
         services.AddSingleton<IValidateOptions<TemplateAuthenticationOptions>, TemplateAuthenticationOptionsValidator>();
 
         services

--- a/src/Template.Web/Authentication/Options/TemplateAuthenticationOptions.cs
+++ b/src/Template.Web/Authentication/Options/TemplateAuthenticationOptions.cs
@@ -1,3 +1,5 @@
+using Template.Web.Authentication.Claims;
+
 namespace Template.Web.Authentication.Options;
 
 /// <summary>
@@ -39,4 +41,9 @@ public sealed class TemplateAuthenticationOptions
     /// Gets or sets provider-specific authentication options.
     /// </summary>
     public TemplateAuthenticationProviderOptions Providers { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets claims transformation and normalization options.
+    /// </summary>
+    public TemplateClaimsTransformationOptions ClaimsTransformation { get; set; } = new();
 }

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -191,6 +191,19 @@
           "CallbackPath": "/signin-github"
         }
       }
+    },
+    "ClaimsTransformation": {
+      "Enabled": true,
+      "RemoveOriginalClaims": false,
+      "DefaultMappings": {
+        "Subject": [ "sub", "subject", "nameid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" ],
+        "Name": [ "name", "display_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" ],
+        "Email": [ "email", "emailaddress", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ],
+        "Role": [ "role", "roles", "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" ],
+        "Group": [ "group", "groups", "memberOf" ],
+        "Permission": [ "permission", "permissions", "scope", "scp" ]
+      },
+      "ProviderMappings": {}
     }
   }
 }

--- a/tests/Template.Web.Tests/ClaimsTransformationTests.cs
+++ b/tests/Template.Web.Tests/ClaimsTransformationTests.cs
@@ -1,0 +1,297 @@
+using System.Security.Claims;
+using Template.Web.Authentication.Claims;
+using Template.Web.Authentication.Options;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides unit tests for template claims transformation and normalization behavior.
+/// </summary>
+public sealed class ClaimsTransformationTests
+{
+    /// <summary>
+    /// Verifies that OpenID Connect-style claims are normalized into template-owned claim types.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_NormalizesOidcStyleClaims()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation();
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "OpenIdConnect",
+            claims:
+            [
+                new Claim("sub", "user-123"),
+                new Claim("name", "Test User"),
+                new Claim("email", "test.user@example.test"),
+                new Claim("roles", "Administrator"),
+                new Claim("groups", "Developers"),
+                new Claim("scope", "template.read")
+            ]);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "user-123");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Name &&
+            claim.Value == "Test User");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Email &&
+            claim.Value == "test.user@example.test");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Role &&
+            claim.Value == "Administrator");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Group &&
+            claim.Value == "Developers");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Permission &&
+            claim.Value == "template.read");
+    }
+
+    /// <summary>
+    /// Verifies that SAML-style claims are normalized into template-owned claim types.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_NormalizesSamlStyleClaims()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation();
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "Saml2",
+            claims:
+            [
+                new Claim(ClaimTypes.NameIdentifier, "saml-user-123"),
+                new Claim(ClaimTypes.Name, "Saml Test User"),
+                new Claim(ClaimTypes.Email, "saml.user@example.test"),
+                new Claim(ClaimTypes.Role, "Manager"),
+                new Claim("memberOf", "Operations"),
+                new Claim("permission", "template.write")
+            ]);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "saml-user-123");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Name &&
+            claim.Value == "Saml Test User");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Email &&
+            claim.Value == "saml.user@example.test");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Role &&
+            claim.Value == "Manager");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Group &&
+            claim.Value == "Operations");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Permission &&
+            claim.Value == "template.write");
+    }
+
+    /// <summary>
+    /// Verifies that original provider claims are preserved by default.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_PreservesOriginalClaimsByDefault()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation();
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "OpenIdConnect",
+            claims:
+            [
+                new Claim("sub", "user-123")
+            ]);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == "sub" &&
+            claim.Value == "user-123");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "user-123");
+    }
+
+    /// <summary>
+    /// Verifies that original provider claims are removed when configured explicitly.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_RemovesOriginalClaims_WhenConfigured()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation(new TemplateClaimsTransformationOptions
+        {
+            Enabled = true,
+            RemoveOriginalClaims = true
+        });
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "OpenIdConnect",
+            claims:
+            [
+                new Claim("sub", "user-123")
+            ]);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        Assert.DoesNotContain(transformed.Claims, claim =>
+            claim.Type == "sub" &&
+            claim.Value == "user-123");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "user-123");
+    }
+
+    /// <summary>
+    /// Verifies that claims are not normalized when claims transformation is disabled.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_DoesNotAddNormalizedClaims_WhenDisabled()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation(new TemplateClaimsTransformationOptions
+        {
+            Enabled = false
+        });
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "OpenIdConnect",
+            claims:
+            [
+                new Claim("sub", "user-123")
+            ]);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == "sub" &&
+            claim.Value == "user-123");
+
+        Assert.DoesNotContain(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "user-123");
+    }
+
+    /// <summary>
+    /// Verifies that provider-specific mappings override the default mappings for the matching authentication type.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_UsesProviderSpecificMappings_WhenConfigured()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation(new TemplateClaimsTransformationOptions
+        {
+            Enabled = true,
+            ProviderMappings =
+            {
+                ["GitHub"] = new TemplateClaimMappingOptions
+                {
+                    Subject = [ "github_id" ],
+                    Name = [ "github_name" ],
+                    Email = [ "github_email" ],
+                    Role = [ "github_role" ],
+                    Group = [ "github_group" ],
+                    Permission = [ "github_permission" ]
+                }
+            }
+        });
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "GitHub",
+            claims:
+            [
+                new Claim("github_id", "github-user-123"),
+                new Claim("github_name", "GitHub Test User"),
+                new Claim("github_email", "github.user@example.test"),
+                new Claim("github_role", "Maintainer"),
+                new Claim("github_group", "Template Team"),
+                new Claim("github_permission", "repository.read")
+            ]);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "github-user-123");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Name &&
+            claim.Value == "GitHub Test User");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Email &&
+            claim.Value == "github.user@example.test");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Role &&
+            claim.Value == "Maintainer");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Group &&
+            claim.Value == "Template Team");
+
+        Assert.Contains(transformed.Claims, claim =>
+            claim.Type == TemplateClaimTypes.Permission &&
+            claim.Value == "repository.read");
+    }
+
+    /// <summary>
+    /// Verifies that duplicate normalized claims are not added when transformation runs more than once.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsTransformation_DoesNotDuplicateNormalizedClaims()
+    {
+        TemplateClaimsTransformation transformation = CreateTransformation();
+
+        ClaimsPrincipal principal = CreatePrincipal(
+            authenticationType: "OpenIdConnect",
+            claims:
+            [
+                new Claim("sub", "user-123")
+            ]);
+
+        ClaimsPrincipal transformedOnce = await transformation.TransformAsync(principal);
+        ClaimsPrincipal transformedTwice = await transformation.TransformAsync(transformedOnce);
+
+        int normalizedSubjectClaimCount = transformedTwice.Claims.Count(claim =>
+            claim.Type == TemplateClaimTypes.Subject &&
+            claim.Value == "user-123");
+
+        Assert.Equal(1, normalizedSubjectClaimCount);
+    }
+
+    private static TemplateClaimsTransformation CreateTransformation(
+        TemplateClaimsTransformationOptions? claimsTransformationOptions = null)
+    {
+        TemplateAuthenticationOptions authenticationOptions = new()
+        {
+            ClaimsTransformation = claimsTransformationOptions ?? new TemplateClaimsTransformationOptions()
+        };
+
+        return new TemplateClaimsTransformation(Microsoft.Extensions.Options.Options.Create(authenticationOptions));
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(
+        string authenticationType,
+        IEnumerable<Claim> claims)
+    {
+        ClaimsIdentity identity = new(claims, authenticationType);
+
+        return new ClaimsPrincipal(identity);
+    }
+}


### PR DESCRIPTION
## Summary

Adds provider-neutral claims transformation and normalization support for the authentication module.

This change introduces a central claims transformation layer that maps provider-specific claim names from OIDC, SAML2, Microsoft, Google, GitHub, and future external providers into consistent template-owned claim types. This keeps provider-specific claim handling out of controllers, views, and future authorization policy logic.

## Changes

- Added template claim type constants for normalized application claims.
- Added configurable claims transformation options.
- Added default claim mappings for common subject, name, email, role, group, and permission claims.
- Added provider-specific mapping support keyed by authentication provider scheme or authentication type.
- Added `TemplateClaimsTransformation` using `IClaimsTransformation`.
- Registered claims transformation in the authentication service configuration.
- Preserved original provider claims by default.
- Added optional configuration to remove original provider claims when explicitly enabled.
- Added tests for:
  - OIDC-style claim normalization.
  - SAML-style claim normalization.
  - Original claim preservation.
  - Original claim removal when configured.
  - Disabled transformation behavior.
  - Provider-specific mappings.
  - Duplicate prevention when transformation runs more than once.

## Testing

- Added claims transformation unit tests.
- Verified normalized claims are added without removing original claims by default.
- Verified transformation can be disabled through configuration.
- Verified provider-specific mappings override default mappings when configured.
```bash
dotnet build --configuration Release

Restore complete (1.3s)
  Template.Web net10.0 succeeded (11.0s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (3.6s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll

Build succeeded in 16.3s

dotnet test --configuration Release

Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.65]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.19]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.62]   Starting:    Template.Web.Tests
[xUnit.net 00:00:08.86]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (10.9s)

Test summary: total: 84, failed: 0, succeeded: 84, skipped: 0, duration: 10.9s
Build succeeded in 14.5s
```

Closes #78