### PR TITLE
Add role and permission authorization policies - Issue #79

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,50 @@ External identity providers often use different claim names for the same concept
 
 Original provider claims are preserved by default. They are only removed when `Template:Authentication:ClaimsTransformation:RemoveOriginalClaims` is explicitly set to `true`.
 
+### Role and Permission Authorization Policies
+
+The template includes baseline authorization policy patterns for authenticated users, role-based access, and permission-based access.
+
+Default policy names:
+
+| Policy | Purpose |
+|---|---|
+| `Template.AuthenticatedUser` | Requires an authenticated user. |
+| `Template.Role.Administrator` | Requires a normalized role claim. |
+| `Template.Permission.ManageApplication` | Requires a normalized permission claim. |
+
+Default normalized claim types:
+
+| Claim Type | Purpose |
+|---|---|
+| `template:role` | Role claim used by role-based policies. |
+| `template:permission` | Permission claim used by permission-based policies. |
+
+Configuration example:
+
+```json
+"Template": {
+  "Authorization": {
+    "RoleClaimType": "template:role",
+    "PermissionClaimType": "template:permission",
+    "AdministratorRoles": [
+      "Administrator"
+    ],
+    "ManageApplicationPermissions": [
+      "application.manage"
+    ]
+  }
+}
+```
+Example usage:
+```csharp
+[Authorize(Policy = TemplateAuthorizationPolicyNames.AdministratorRole)]
+public IActionResult AdminOnly()
+{
+    return View();
+}
+```
+
 ## Data Access
 
 This section will document EF Core and database patterns.

--- a/src/Template.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
+++ b/src/Template.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
@@ -1,3 +1,6 @@
+using Template.Web.Authentication.Claims;
+using Template.Web.Authentication.Options;
+
 namespace Template.Web.Authentication.Extensions;
 
 /// <summary>
@@ -18,8 +21,40 @@ public static class AuthorizationServiceExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
+        TemplateAuthorizationOptions options = configuration
+            .GetSection(TemplateAuthorizationOptions.SectionName)
+            .Get<TemplateAuthorizationOptions>() ?? new TemplateAuthorizationOptions();
+
+        string roleClaimType = string.IsNullOrWhiteSpace(options.RoleClaimType)
+            ? TemplateClaimTypes.Role
+            : options.RoleClaimType;
+
+        string permissionClaimType = string.IsNullOrWhiteSpace(options.PermissionClaimType)
+            ? TemplateClaimTypes.Permission
+            : options.PermissionClaimType;
+
+        services
+            .AddOptions<TemplateAuthorizationOptions>()
+            .Bind(configuration.GetSection(TemplateAuthorizationOptions.SectionName));
+
         services.AddAuthorizationBuilder()
-            .AddPolicy(TemplateAuthorizationPolicyNames.AuthenticatedUser, policy => policy.RequireAuthenticatedUser());
+            .AddPolicy(
+                TemplateAuthorizationPolicyNames.AuthenticatedUser,
+                policy => policy.RequireAuthenticatedUser())
+            .AddPolicy(
+                TemplateAuthorizationPolicyNames.AdministratorRole,
+                policy =>
+                {
+                    policy.RequireAuthenticatedUser();
+                    policy.RequireClaim(roleClaimType, options.AdministratorRoles);
+                })
+            .AddPolicy(
+                TemplateAuthorizationPolicyNames.ManageApplicationPermission,
+                policy =>
+                {
+                    policy.RequireAuthenticatedUser();
+                    policy.RequireClaim(permissionClaimType, options.ManageApplicationPermissions);
+                });
 
         return services;
     }
@@ -34,4 +69,12 @@ public static class TemplateAuthorizationPolicyNames
     /// Policy requiring the current user to be authenticated.
     /// </summary>
     public const string AuthenticatedUser = "Template.AuthenticatedUser";
+    /// <summary>
+    /// Policy defining the administrator role.
+    /// </summary>
+    public const string AdministratorRole = "Template.Role.Administrator";
+    /// <summary>
+    /// Policy defining the manage application permission.
+    /// </summary>
+    public const string ManageApplicationPermission = "Template.Permission.ManageApplication";
 }

--- a/src/Template.Web/Authentication/Options/TemplateAuthorizationOptions.cs
+++ b/src/Template.Web/Authentication/Options/TemplateAuthorizationOptions.cs
@@ -1,0 +1,32 @@
+namespace Template.Web.Authentication.Options;
+
+/// <summary>
+/// Provides configurable authorization policy options for the template.
+/// </summary>
+public sealed class TemplateAuthorizationOptions
+{
+    /// <summary>
+    /// Gets the configuration section name used to bind template authorization settings.
+    /// </summary>
+    public const string SectionName = "Template:Authorization";
+
+    /// <summary>
+    /// Gets or sets the claim type used to evaluate role-based authorization policies.
+    /// </summary>
+    public string RoleClaimType { get; set; } = "template:role";
+
+    /// <summary>
+    /// Gets or sets the claim type used to evaluate permission-based authorization policies.
+    /// </summary>
+    public string PermissionClaimType { get; set; } = "template:permission";
+
+    /// <summary>
+    /// Gets or sets the role values that satisfy the administrator authorization policy.
+    /// </summary>
+    public string[] AdministratorRoles { get; set; } = ["Administrator"];
+
+    /// <summary>
+    /// Gets or sets the permission values that satisfy the manage application authorization policy.
+    /// </summary>
+    public string[] ManageApplicationPermissions { get; set; } = ["application.manage"];
+}

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -8,12 +8,12 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <VersionPrefix>0.2.5</VersionPrefix>
+    <VersionPrefix>0.2.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.2.5.0</AssemblyVersion>
-    <FileVersion>0.2.5.0</FileVersion>
+    <AssemblyVersion>0.2.6.0</AssemblyVersion>
+    <FileVersion>0.2.6.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
 
   </PropertyGroup>

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Folder Include="Authentication\Constants\" />
     <Folder Include="Logs\" />
   </ItemGroup>
 

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -204,6 +204,16 @@
         "Permission": [ "permission", "permissions", "scope", "scp" ]
       },
       "ProviderMappings": {}
+    },
+    "Authorization": {
+      "RoleClaimType": "template:role",
+      "PermissionClaimType": "template:permission",
+      "AdministratorRoles": [
+        "Administrator"
+      ],
+      "ManageApplicationPermissions": [
+        "application.manage"
+      ]
     }
   }
 }

--- a/tests/Template.Web.Tests/AuthorizationPolicyTests.cs
+++ b/tests/Template.Web.Tests/AuthorizationPolicyTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Template.Web.Authentication.Claims;
+using Template.Web.Authentication.Options;
+using Template.Web.Tests.Extensions;
+using Template.Web.Tests.Infrastructure;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides integration tests for template authorization policy configuration and role/permission policy behavior.
+/// </summary>
+public sealed class AuthorizationPolicyTests
+{
+    private const string _testAuthenticationScheme = "TestAuthentication";
+    private const string _testUserHeaderName = "X-Test-User";
+    private const string _testRoleHeaderName = "X-Test-Role";
+    private const string _testPermissionHeaderName = "X-Test-Permission";
+
+    /// <summary>
+    /// Verifies that template authorization options are bound from configuration.
+    /// </summary>
+    [Fact]
+    public void AuthorizationOptions_AreBoundFromConfiguration()
+    {
+        using TemplateWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authorization:RoleClaimType"] = "custom:role",
+            ["Template:Authorization:PermissionClaimType"] = "custom:permission",
+            ["Template:Authorization:AdministratorRoles:0"] = "Administrator",
+            ["Template:Authorization:AdministratorRoles:1"] = "SecurityAdministrator",
+            ["Template:Authorization:ManageApplicationPermissions:0"] = "application.manage",
+            ["Template:Authorization:ManageApplicationPermissions:1"] = "application.configure"
+        });
+
+        TemplateAuthorizationOptions options = factory.Services
+            .GetRequiredService<IOptions<TemplateAuthorizationOptions>>()
+            .Value;
+
+        Assert.Equal("custom:role", options.RoleClaimType);
+        Assert.Equal("custom:permission", options.PermissionClaimType);
+        Assert.Contains("Administrator", options.AdministratorRoles);
+        Assert.Contains("SecurityAdministrator", options.AdministratorRoles);
+        Assert.Contains("application.manage", options.ManageApplicationPermissions);
+        Assert.Contains("application.configure", options.ManageApplicationPermissions);
+
+    }
+
+    /// <summary>
+    /// Verifies that the authenticated-user policy rejects unauthenticated requests.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ProtectedEndpoint_ReturnsUnauthorized_WhenUnauthenticated()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestAuthentication();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/protected",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the administrator role policy allows users with the configured administrator role.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task RolePolicy_ReturnsOk_WhenUserHasAdministratorRole()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestAuthentication();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        client.DefaultRequestHeaders.Add(_testUserHeaderName, "test-user");
+        client.DefaultRequestHeaders.Add(_testRoleHeaderName, "Administrator");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/admin",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the administrator role policy rejects authenticated users without the required role.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task RolePolicy_ReturnsForbidden_WhenUserLacksAdministratorRole()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestAuthentication();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        client.DefaultRequestHeaders.Add(_testUserHeaderName, "test-user");
+        client.DefaultRequestHeaders.Add(_testRoleHeaderName, "User");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/admin",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the manage application permission policy allows users with the configured permission.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task PermissionPolicy_ReturnsOk_WhenUserHasManagePermission()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestAuthentication();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        client.DefaultRequestHeaders.Add(_testUserHeaderName, "test-user");
+        client.DefaultRequestHeaders.Add(_testPermissionHeaderName, "application.manage");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/manage",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the manage application permission policy rejects authenticated users without the required permission.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task PermissionPolicy_ReturnsForbidden_WhenUserLacksManagePermission()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestAuthentication();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        client.DefaultRequestHeaders.Add(_testUserHeaderName, "test-user");
+        client.DefaultRequestHeaders.Add(_testPermissionHeaderName, "application.read");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/manage",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that the baseline authenticated-user policy remains available and allows authenticated users.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AuthenticatedUserPolicy_RemainsAvailable()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactoryWithTestAuthentication();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        client.DefaultRequestHeaders.Add(_testUserHeaderName, "test-user");
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/protected",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Creates a test application factory with the supplied in-memory configuration overrides.
+    /// </summary>
+    /// <param name="configurationValues">The configuration key/value pairs used to override template settings for a test.</param>
+    /// <returns>A configured <see cref="TemplateWebApplicationFactory"/> instance.</returns>
+    private static TemplateWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        return new TemplateWebApplicationFactory(configurationValues);
+    }
+
+    /// <summary>
+    /// Creates a test application factory configured to use a test-only authentication scheme.
+    /// </summary>
+    /// <returns>A configured <see cref="WebApplicationFactory{TEntryPoint}"/> instance.</returns>
+    private static WebApplicationFactory<Program> CreateFactoryWithTestAuthentication()
+    {
+        return new TemplateWebApplicationFactory(new Dictionary<string, string?>
+        {
+            ["Template:Authentication:Enabled"] = "true",
+            ["Template:Authentication:DefaultScheme"] = _testAuthenticationScheme,
+            ["Template:Authentication:DefaultChallengeScheme"] = _testAuthenticationScheme,
+            ["Template:Authentication:DefaultSignInScheme"] = _testAuthenticationScheme,
+            ["Template:Authorization:RoleClaimType"] = TemplateClaimTypes.Role,
+            ["Template:Authorization:PermissionClaimType"] = TemplateClaimTypes.Permission,
+            ["Template:Authorization:AdministratorRoles:0"] = "Administrator",
+            ["Template:Authorization:ManageApplicationPermissions:0"] = "application.manage"
+        })
+        .WithWebHostBuilder(builder => builder.ConfigureServices(services => services
+            .AddAuthentication()
+            .AddScheme<AuthenticationSchemeOptions, TestAuthorizationAuthenticationHandler>(
+                _testAuthenticationScheme,
+                _ => { })));
+    }
+
+    /// <summary>
+    /// Provides a test-only authentication handler that creates claims from request headers.
+    /// </summary>
+    private sealed class TestAuthorizationAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        /// <summary>
+        /// Authenticates the current request by creating a test principal from configured request headers.
+        /// </summary>
+        /// <returns>An authentication result for the current test request.</returns>
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(_testUserHeaderName, out StringValues userValues))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            string? userName = userValues.FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            List<Claim> claims =
+            [
+                new Claim(ClaimTypes.NameIdentifier, userName),
+                new Claim(ClaimTypes.Name, userName)
+            ];
+
+            foreach (string role in SplitHeaderValues(Request.Headers[_testRoleHeaderName]))
+            {
+                claims.Add(new Claim(TemplateClaimTypes.Role, role));
+            }
+
+            foreach (string permission in SplitHeaderValues(Request.Headers[_testPermissionHeaderName]))
+            {
+                claims.Add(new Claim(TemplateClaimTypes.Permission, permission));
+            }
+
+            ClaimsIdentity identity = new(claims, Scheme.Name);
+            ClaimsPrincipal principal = new(identity);
+            AuthenticationTicket ticket = new(principal, Scheme.Name);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+
+        private static IEnumerable<string> SplitHeaderValues(IEnumerable<string?> values)
+        {
+            return values
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .SelectMany(value => value!.Split(
+                    ',',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+    }
+}

--- a/tests/Template.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/Template.Web.Tests/OpenTelemetryTests.cs
@@ -16,7 +16,7 @@ namespace Template.Web.Tests;
 /// </summary>
 public sealed class OpenTelemetryTests
 {
-    private const string _releaseVersion = "0.2.5";
+    private const string _releaseVersion = "0.2.6";
 
     /// <summary>
     /// Verifies that template OpenTelemetry options are bound from configuration.

--- a/tests/Template.Web.Tests/TestControllers/AuthenticationTestController.cs
+++ b/tests/Template.Web.Tests/TestControllers/AuthenticationTestController.cs
@@ -32,4 +32,26 @@ public sealed class AuthenticationTestController : ControllerBase
     {
         return Ok(new { result = "protected" });
     }
+
+    /// <summary>
+    /// Returns a test response for users who satisfy the administrator role authorization policy.
+    /// </summary>
+    /// <returns>An <see cref="IActionResult"/> containing an administrator authorization test result.</returns>
+    [HttpGet("admin")]
+    [Authorize(Policy = TemplateAuthorizationPolicyNames.AdministratorRole)]
+    public IActionResult Admin()
+    {
+        return Ok(new { result = "admin" });
+    }
+
+    /// <summary>
+    /// Returns a test response for users who satisfy the manage application permission authorization policy.
+    /// </summary>
+    /// <returns>An <see cref="IActionResult"/> containing a manage application permission authorization test result.</returns>
+    [HttpGet("manage")]
+    [Authorize(Policy = TemplateAuthorizationPolicyNames.ManageApplicationPermission)]
+    public IActionResult Manage()
+    {
+        return Ok(new { result = "manage" });
+    }
 }


### PR DESCRIPTION
## Summary

This PR completes issue #79 by adding baseline role-based and permission-based authorization policy patterns to the template.

## Changes

- Added configurable template authorization options under `Template:Authorization`.
- Added centralized authorization policy names for:
  - authenticated users
  - administrator role access
  - manage application permission access
- Added normalized claim type usage for role and permission checks.
- Added role and permission protected test endpoints.
- Added integration tests for:
  - authorization option binding
  - unauthenticated protected endpoint behavior
  - administrator role policy success and forbidden scenarios
  - manage application permission policy success and forbidden scenarios
  - existing authenticated-user policy availability
- Updated README documentation with role and permission authorization examples.

## Validation

- `dotnet build --configuration Release`
```bash
Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (1.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll

Build succeeded in 4.7s
```
- `dotnet test --configuration Release`
```bash
Restore complete (1.3s)
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.7s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.47]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.01]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:01.45]   Starting:    Template.Web.Tests
[xUnit.net 00:00:08.63]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (10.4s)

Test summary: total: 91, failed: 0, succeeded: 91, skipped: 0, duration: 10.4s
Build succeeded in 14.0s
```

Closes #79