### PR TITLE
Add external login account-linking persistence model - Issue #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,6 +979,27 @@ _Update the Database:_
 ```
 Future database providers, such as SQL Server, can be added by extending the data access registration configuration.
 
+### External Login Account Linking Persistence
+
+The template includes an optional EF Core persistence model for applications that need to link external provider identities to local application users.
+
+This is different from claims-only sign-in.
+
+Claims-only sign-in uses the external provider claims from the current authentication session and does not require a local account-linking table. This is sufficient when the application only needs to authenticate the current request.
+
+Local account linking is useful when an application needs to associate one or more external identities with a local application user profile, preserve account-link audit history, support provider migration, or allow multiple providers to sign in to the same local account.
+
+The external login persistence model stores:
+
+- Local user ID
+- Provider name
+- Provider user ID
+- Display name
+- Email
+- Created, updated, and last-login timestamps
+
+Provider tokens are not stored by default. Applications that need token persistence should add that behavior intentionally and review the security, encryption, rotation, and retention requirements before enabling it.
+
 ## Configuration
 
 This section will document application configuration strategy.

--- a/src/Template.Infrastructure/Data/Configurations/ExternalLoginAccountConfiguration.cs
+++ b/src/Template.Infrastructure/Data/Configurations/ExternalLoginAccountConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Template.Infrastructure.Data.Entities;
+
+namespace Template.Infrastructure.Data.Configurations;
+
+/// <summary>
+/// Configures the EF Core mapping for <see cref="ExternalLoginAccount" />.
+/// </summary>
+public sealed class ExternalLoginAccountConfiguration : IEntityTypeConfiguration<ExternalLoginAccount>
+{
+    public void Configure(EntityTypeBuilder<ExternalLoginAccount> entity)
+    {
+        entity.ToTable("ExternalLoginAccounts");
+
+        entity.HasKey(x => x.Id);
+
+        entity.Property(x => x.Id)
+            .ValueGeneratedNever();
+
+        entity.Property(x => x.LocalUserId)
+            .IsRequired();
+
+        entity.Property(x => x.ProviderName)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        entity.Property(x => x.ProviderUserId)
+            .HasMaxLength(256)
+            .IsRequired();
+
+        entity.Property(x => x.DisplayName)
+            .HasMaxLength(200);
+
+        entity.Property(x => x.Email)
+            .HasMaxLength(320);
+
+        entity.Property(x => x.CreatedOnUtc)
+            .IsRequired();
+
+        entity.HasIndex(x => new { x.ProviderName, x.ProviderUserId })
+            .IsUnique();
+
+        entity.HasIndex(x => x.LocalUserId);
+
+        entity.HasIndex(x => x.Email);
+    }
+}

--- a/src/Template.Infrastructure/Data/Entities/ExternalLoginAccount.cs
+++ b/src/Template.Infrastructure/Data/Entities/ExternalLoginAccount.cs
@@ -1,0 +1,47 @@
+namespace Template.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Represents a persisted link between a local application user and an external authentication provider identity.
+/// </summary>
+public sealed class ExternalLoginAccount : DataEntity
+{
+    /// <summary>
+    /// Local application user ID to which this external login account is linked.
+    /// </summary>
+    public Guid LocalUserId { get; set; }
+
+    /// <summary>
+    /// Provider name of the external authentication service (e.g., "Google", "Facebook", "Microsoft").
+    /// </summary>
+    public string ProviderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Provider-specific unique identifier for the user (e.g., the "sub" claim from an OpenID Connect token).
+    /// </summary>
+    public string ProviderUserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name or email associated with the external account, for informational purposes. This is not used for authentication but can be helpful for administrators to identify linked accounts.
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// Email address associated with the external account, if available. This is not used for authentication but can be helpful for administrators to identify linked accounts and for potential communication purposes.
+    /// </summary>
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Creation timestamp in UTC when this external login account was linked to the local user. This can be useful for auditing and tracking purposes.
+    /// </summary>
+    public DateTime CreatedOnUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Update timestamp in UTC when this external login account was last modified. This can be useful for auditing and tracking purposes, especially if the display name or email associated with the external account changes over time.
+    /// </summary>
+    public DateTime? UpdatedOnUtc { get; set; }
+
+    /// <summary>
+    /// Last login timestamp in UTC when the user authenticated using this external login account. This can be useful for auditing and tracking purposes, as well as for identifying inactive linked accounts.
+    /// </summary>
+    public DateTime? LastLoginOnUtc { get; set; }
+}

--- a/src/Template.Infrastructure/Data/ExternalLogins/EfCoreExternalLoginAccountResolver.cs
+++ b/src/Template.Infrastructure/Data/ExternalLogins/EfCoreExternalLoginAccountResolver.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using Template.Infrastructure.Data.Entities;
+
+namespace Template.Infrastructure.Data.ExternalLogins;
+
+/// <summary>
+/// EF Core implementation of <see cref="IExternalLoginAccountResolver" />.
+/// </summary>
+public sealed class EfCoreExternalLoginAccountResolver(TemplateDbContext dbContext)
+    : IExternalLoginAccountResolver
+{
+    private readonly TemplateDbContext _dbContext = dbContext;
+
+    /// <summary>
+    /// Finds an external login account by the provider name and provider user ID.
+    /// </summary>
+    /// <param name="providerName">Provider name (e.g., "Google", "Facebook"). This value is case-insensitive and will be trimmed of whitespace.</param>
+    /// <param name="providerUserId">Provider user ID (the unique identifier for the user from the external provider). This value is case-insensitive and will be trimmed of whitespace.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation if needed.</param>
+    /// <returns>Returns the matching <see cref="ExternalLoginAccount" /> if found; otherwise, returns null.</returns>
+    public async Task<ExternalLoginAccount?> FindByProviderUserIdAsync(
+        string providerName,
+        string providerUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerName) || string.IsNullOrWhiteSpace(providerUserId))
+        {
+            return null;
+        }
+
+        string normalizedProviderName = providerName.Trim();
+        string normalizedProviderUserId = providerUserId.Trim();
+
+        return await _dbContext.ExternalLoginAccounts
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                x => x.ProviderName == normalizedProviderName
+                    && x.ProviderUserId == normalizedProviderUserId,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Finds all external login accounts associated with a specific local user ID.
+    /// </summary>
+    /// <param name="localUserId">
+    /// Local user ID (the unique identifier for the user in the local system). If this value is Guid.Empty, an empty list will be returned.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token to cancel the operation if needed.
+    /// </param>
+    /// <returns>
+    /// Returns a list of <see cref="ExternalLoginAccount" /> instances associated with the specified local user ID. If no accounts are found, an empty list is returned.
+    /// </returns>
+    public async Task<IReadOnlyList<ExternalLoginAccount>> FindByLocalUserIdAsync(
+        Guid localUserId,
+        CancellationToken cancellationToken = default)
+    {
+        return localUserId == Guid.Empty
+            ? []
+            : (IReadOnlyList<ExternalLoginAccount>)await _dbContext.ExternalLoginAccounts
+            .AsNoTracking()
+            .Where(x => x.LocalUserId == localUserId)
+            .OrderBy(x => x.ProviderName)
+            .ThenBy(x => x.ProviderUserId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Template.Infrastructure/Data/ExternalLogins/IExternalLoginAccountResolver.cs
+++ b/src/Template.Infrastructure/Data/ExternalLogins/IExternalLoginAccountResolver.cs
@@ -1,0 +1,18 @@
+using Template.Infrastructure.Data.Entities;
+
+namespace Template.Infrastructure.Data.ExternalLogins;
+
+/// <summary>
+/// Resolves persisted external login account links.
+/// </summary>
+public interface IExternalLoginAccountResolver
+{
+    Task<ExternalLoginAccount?> FindByProviderUserIdAsync(
+        string providerName,
+        string providerUserId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ExternalLoginAccount>> FindByLocalUserIdAsync(
+        Guid localUserId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Template.Infrastructure/Data/Migrations/20260519001004_AddExternalLoginAccounts.Designer.cs
+++ b/src/Template.Infrastructure/Data/Migrations/20260519001004_AddExternalLoginAccounts.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Template.Infrastructure.Data;
 
@@ -10,9 +11,11 @@ using Template.Infrastructure.Data;
 namespace Template.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(TemplateDbContext))]
-    partial class TemplateDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519001004_AddExternalLoginAccounts")]
+    partial class AddExternalLoginAccounts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/src/Template.Infrastructure/Data/Migrations/20260519001004_AddExternalLoginAccounts.cs
+++ b/src/Template.Infrastructure/Data/Migrations/20260519001004_AddExternalLoginAccounts.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Template.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddExternalLoginAccounts : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "ExternalLoginAccounts",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                LocalUserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                ProviderName = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                ProviderUserId = table.Column<string>(type: "TEXT", maxLength: 256, nullable: false),
+                DisplayName = table.Column<string>(type: "TEXT", maxLength: 200, nullable: true),
+                Email = table.Column<string>(type: "TEXT", maxLength: 320, nullable: true),
+                CreatedOnUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                UpdatedOnUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                LastLoginOnUtc = table.Column<DateTime>(type: "TEXT", nullable: true)
+            },
+            constraints: table => table.PrimaryKey("PK_ExternalLoginAccounts", x => x.Id));
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ExternalLoginAccounts_Email",
+            table: "ExternalLoginAccounts",
+            column: "Email");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ExternalLoginAccounts_LocalUserId",
+            table: "ExternalLoginAccounts",
+            column: "LocalUserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
+            table: "ExternalLoginAccounts",
+            columns: ["ProviderName", "ProviderUserId"],
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "ExternalLoginAccounts");
+    }
+}

--- a/src/Template.Infrastructure/Data/TemplateDbContext.cs
+++ b/src/Template.Infrastructure/Data/TemplateDbContext.cs
@@ -22,6 +22,10 @@ public sealed partial class TemplateDbContext(
     /// Gets the audit records for the application.
     /// </summary>
     public DbSet<AuditRecord> AuditRecords => Set<AuditRecord>();
+    /// <summary>
+    /// Gets the external login account links for the application.
+    /// </summary>
+    public DbSet<ExternalLoginAccount> ExternalLoginAccounts => Set<ExternalLoginAccount>();
 
     [LoggerMessage(
         EventId = 19000,

--- a/src/Template.Web/Extensions/DataAccessServiceExtensions.cs
+++ b/src/Template.Web/Extensions/DataAccessServiceExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Template.Infrastructure.Data;
+using Template.Infrastructure.Data.ExternalLogins;
 using Template.Web.Accessors;
 
 namespace Template.Web.Extensions;
@@ -27,6 +28,7 @@ public static class DataAccessServiceExtensions
         services.AddScoped<ICurrentActorAccessor, HttpContextCurrentActorAccessor>();
 
         services.AddDbContext<TemplateDbContext>(options => options.UseSqlite(connectionString));
+        services.AddScoped<IExternalLoginAccountResolver, EfCoreExternalLoginAccountResolver>();
 
         return services;
     }

--- a/tests/Template.Web.Tests/ExternalLoginAccountResolverTests.cs
+++ b/tests/Template.Web.Tests/ExternalLoginAccountResolverTests.cs
@@ -1,0 +1,317 @@
+using System.Reflection;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Template.Infrastructure.Data;
+using Template.Infrastructure.Data.Entities;
+using Template.Infrastructure.Data.ExternalLogins;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides tests for the EF Core external login account-linking resolver.
+/// </summary>
+public sealed class ExternalLoginAccountResolverTests
+{
+    /// <summary>
+    /// Verifies that an existing provider/user key resolves to the linked external login account.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FindByProviderUserIdAsync_ExistingProviderUserId_ReturnsLinkedAccount()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var localUserId = Guid.NewGuid();
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = localUserId,
+            ProviderName = "GitHub",
+            ProviderUserId = "github-user-123",
+            DisplayName = "Test GitHub User",
+            Email = "github-user@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        ExternalLoginAccount? result = await resolver.FindByProviderUserIdAsync(
+            "GitHub",
+            "github-user-123",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(account.Id, result.Id);
+        Assert.Equal(localUserId, result.LocalUserId);
+        Assert.Equal("GitHub", result.ProviderName);
+        Assert.Equal("github-user-123", result.ProviderUserId);
+        Assert.Equal("Test GitHub User", result.DisplayName);
+        Assert.Equal("github-user@example.com", result.Email);
+    }
+
+    /// <summary>
+    /// Verifies that an unknown provider/user key returns null.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FindByProviderUserIdAsync_UnknownProviderUserId_ReturnsNull()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        ExternalLoginAccount? result = await resolver.FindByProviderUserIdAsync(
+            "Google",
+            "missing-user",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that blank provider lookup values return null without querying for an invalid link.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Theory]
+    [InlineData("", "provider-user-id")]
+    [InlineData("   ", "provider-user-id")]
+    [InlineData("GitHub", "")]
+    [InlineData("GitHub", "   ")]
+    public async Task FindByProviderUserIdAsync_BlankLookupValues_ReturnsNull(
+        string providerName,
+        string providerUserId)
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        ExternalLoginAccount? result = await resolver.FindByProviderUserIdAsync(
+            providerName,
+            providerUserId,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that lookup values are trimmed before provider/user key matching.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FindByProviderUserIdAsync_TrimmedLookupValues_ReturnsLinkedAccount()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "Microsoft",
+            ProviderUserId = "microsoft-user-123",
+            DisplayName = "Test Microsoft User",
+            Email = "microsoft-user@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        ExternalLoginAccount? result = await resolver.FindByProviderUserIdAsync(
+            " Microsoft ",
+            " microsoft-user-123 ",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(account.Id, result.Id);
+    }
+
+    /// <summary>
+    /// Verifies that all external login links for a local user are returned.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FindByLocalUserIdAsync_ExistingLocalUserId_ReturnsLinkedAccounts()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var localUserId = Guid.NewGuid();
+
+        await context.ExternalLoginAccounts.AddRangeAsync(
+            [
+                new ExternalLoginAccount
+                {
+                    LocalUserId = localUserId,
+                    ProviderName = "GitHub",
+                    ProviderUserId = "github-user-123",
+                    DisplayName = "GitHub User",
+                    Email = "github-user@example.com",
+                    CreatedOnUtc = DateTime.UtcNow
+                },
+                new ExternalLoginAccount
+                {
+                    LocalUserId = localUserId,
+                    ProviderName = "Google",
+                    ProviderUserId = "google-user-123",
+                    DisplayName = "Google User",
+                    Email = "google-user@example.com",
+                    CreatedOnUtc = DateTime.UtcNow
+                },
+                new ExternalLoginAccount
+                {
+                    LocalUserId = Guid.NewGuid(),
+                    ProviderName = "Microsoft",
+                    ProviderUserId = "different-user-123",
+                    DisplayName = "Different User",
+                    Email = "different-user@example.com",
+                    CreatedOnUtc = DateTime.UtcNow
+                }
+            ],
+            TestContext.Current.CancellationToken);
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        IReadOnlyList<ExternalLoginAccount> results = await resolver.FindByLocalUserIdAsync(
+            localUserId,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, account => Assert.Equal(localUserId, account.LocalUserId));
+        Assert.Equal(["GitHub", "Google"], [.. results.Select(account => account.ProviderName)]);
+    }
+
+    /// <summary>
+    /// Verifies that an empty local user ID returns an empty result set.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FindByLocalUserIdAsync_EmptyLocalUserId_ReturnsEmptyResult()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        IReadOnlyList<ExternalLoginAccount> results = await resolver.FindByLocalUserIdAsync(
+            Guid.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    /// <summary>
+    /// Verifies that duplicate provider/user keys are rejected by the relational database index.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExternalLoginAccounts_DuplicateProviderUserId_ThrowsDbUpdateException()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using TemplateDbContext context = CreateContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        await context.ExternalLoginAccounts.AddRangeAsync(
+            [
+                new ExternalLoginAccount
+                {
+                    LocalUserId = Guid.NewGuid(),
+                    ProviderName = "GitHub",
+                    ProviderUserId = "duplicate-provider-user",
+                    DisplayName = "First User",
+                    Email = "first-user@example.com",
+                    CreatedOnUtc = DateTime.UtcNow
+                },
+                new ExternalLoginAccount
+                {
+                    LocalUserId = Guid.NewGuid(),
+                    ProviderName = "GitHub",
+                    ProviderUserId = "duplicate-provider-user",
+                    DisplayName = "Second User",
+                    Email = "second-user@example.com",
+                    CreatedOnUtc = DateTime.UtcNow
+                }
+            ],
+            TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAnyAsync<DbUpdateException>(
+            async () => await context.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Verifies that the default external login persistence model does not include token storage properties.
+    /// </summary>
+    [Fact]
+    public void ExternalLoginAccount_DoesNotExposeProviderTokenStorageProperties()
+    {
+        string[] disallowedPropertyNames =
+        [
+            "AccessToken",
+            "RefreshToken",
+            "IdToken",
+            "Token",
+            "Tokens",
+            "ProviderToken",
+            "ProviderTokens"
+        ];
+
+        string[] propertyNames = [.. typeof(ExternalLoginAccount)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Select(property => property.Name)];
+
+        Assert.False(
+            propertyNames.Any(propertyName => disallowedPropertyNames.Contains(
+                propertyName,
+                StringComparer.OrdinalIgnoreCase)),
+            "ExternalLoginAccount should not store provider tokens by default.");
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static TemplateDbContext CreateContext(SqliteConnection connection)
+    {
+        DbContextOptions<TemplateDbContext> options = new DbContextOptionsBuilder<TemplateDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        return new TemplateDbContext(
+            options,
+            NullLogger<TemplateDbContext>.Instance,
+            new TestCurrentActorAccessor());
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "UnitTest";
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional EF Core persistence support for linking external authentication provider identities to local application users.

This introduces a lightweight account-linking model for applications that need local user profiles, provider migration support, audit/history scenarios, or multiple external providers linked to the same local user.

Closes #83

## Changes

- Added `ExternalLoginAccount` entity for persisted external login links.
- Added EF Core configuration for external login account mapping.
- Added indexed provider/user lookup support.
- Added unique provider name + provider user ID constraint.
- Added local user ID lookup support.
- Added `IExternalLoginAccountResolver` abstraction.
- Added EF Core resolver implementation.
- Registered the external login resolver with data access services.
- Added EF Core migration for `ExternalLoginAccounts`.
- Documented claims-only sign-in vs. local account linking.
- Documented that provider tokens are not stored by default.
- Added resolver tests for provider lookup, local user lookup, duplicate provider keys, blank inputs, and token-storage exclusion.

## Security Notes

- Provider access tokens, refresh tokens, ID tokens, and token payloads are not stored by default.
- The persistence model stores only provider identity metadata needed for account-linking scenarios.
- Token persistence remains an intentional future extension if an application explicitly requires it.

## Validation

- Ran `dotnet format NetCoreApplicationTemplate.slnx`
- Ran `dotnet build --configuration Release`
- Ran `dotnet test --configuration Release`

Test result:

```text
Restore complete (1.2s)
  Template.Infrastructure net10.0 succeeded (1.0s) → src\Template.Infrastructure\bin\Release\net10.0\Template.Infrastructure.dll
  Template.Web net10.0 succeeded (3.0s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (3.3s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll

Build succeeded in 8.9s
```
```text
Restore complete (1.2s)
  Template.Infrastructure net10.0 succeeded (0.4s) → src\Template.Infrastructure\bin\Release\net10.0\Template.Infrastructure.dll
  Template.Web net10.0 succeeded (0.9s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.09]   Discovering: Template.Web.Tests
[xUnit.net 00:00:01.66]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:02.10]   Starting:    Template.Web.Tests
[xUnit.net 00:00:13.12]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (15.0s)

Test summary: total: 102, failed: 0, succeeded: 102, skipped: 0, duration: 14.9s
Build succeeded in 19.0s
```