### PR TITLE
Add SQL Server EF Core provider option - Issue #105

### DIFF
--- a/ASSETS-LICENSES.md
+++ b/ASSETS-LICENSES.md
@@ -81,3 +81,4 @@ _Entity Framework Core (EF Core) is a modern object-database mapper for .NET. It
 - [Microsoft.EntityFrameworkCore.Design](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design)
 - [Microsoft.EntityFrameworkCore.Tools](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools) 
 - [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite)
+- [Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer)

--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ If migrations are not discovered, confirm that the command uses:
 If SQLite provider configuration fails, confirm that the infrastructure project references the SQLite provider package and that the data access registration uses the configured TemplateDatabase connection string.
 
 Future database providers, such as SQL Server, can be added by extending the data access registration configuration.
+SQLite remains the default development provider. SQL Server can be selected through configuration. Because EF Core migrations are provider-specific, production SQL Server deployments should generate and maintain SQL Server-compatible migrations before applying database updates.
 
 ### External Login Account Linking Persistence
 
@@ -1338,7 +1339,7 @@ Initial planned milestones:
 - [x]  Add rate limiting policies.
 - [x]  Add centralized error handling.
 - [x]  Add EF Core with SQLite.
-- [ ]  Add SQL Server provider option.
+- [x]  Add SQL Server provider option.
 - [x]  Add authentication module structure.
 - [x]  Add OIDC support.
 - [x]  Add SAML2 support.

--- a/src/Template.Infrastructure/Template.Infrastructure.csproj
+++ b/src/Template.Infrastructure/Template.Infrastructure.csproj
@@ -5,18 +5,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <FileVersion>0.3.0.0</FileVersion>
+    <AssemblyVersion>0.3.1.0</AssemblyVersion>
+    <FileVersion>0.3.1.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>    
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Template.Web/Extensions/DataAccessServiceExtensions.cs
+++ b/src/Template.Web/Extensions/DataAccessServiceExtensions.cs
@@ -20,16 +20,59 @@ public static class DataAccessServiceExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        string connectionString = configuration.GetConnectionString("TemplateDatabase")
+        DataAccessOptions dataAccessOptions = configuration
+            .GetSection("Template:DataAccess")
+            .Get<DataAccessOptions>() ?? new DataAccessOptions();
+
+        string provider = dataAccessOptions.Provider.Trim();
+        string connectionStringName = dataAccessOptions.ConnectionStringName.Trim();
+
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            throw new InvalidOperationException(
+                "Template data access provider was not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionStringName))
+        {
+            throw new InvalidOperationException(
+                "Template data access connection string name was not configured.");
+        }
+
+        string connectionString = configuration.GetConnectionString(connectionStringName)
             ?? throw new InvalidOperationException(
-                "Connection string 'TemplateDatabase' was not configured.");
+                $"Connection string '{connectionStringName}' was not configured.");
 
         services.AddHttpContextAccessor();
         services.AddScoped<ICurrentActorAccessor, HttpContextCurrentActorAccessor>();
 
-        services.AddDbContext<TemplateDbContext>(options => options.UseSqlite(connectionString));
+        services.AddDbContext<TemplateDbContext>(options =>
+        {
+            if (provider.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
+            {
+                options.UseSqlite(connectionString);
+                return;
+            }
+
+            if (provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
+            {
+                options.UseSqlServer(connectionString);
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"Unsupported template data access provider '{provider}'. Supported providers: Sqlite, SqlServer.");
+        });
+
         services.AddScoped<IExternalLoginAccountResolver, EfCoreExternalLoginAccountResolver>();
 
         return services;
+    }
+
+    private sealed class DataAccessOptions
+    {
+        public string Provider { get; init; } = "Sqlite";
+
+        public string ConnectionStringName { get; init; } = "TemplateDatabase";
     }
 }

--- a/src/Template.Web/Template.Web.csproj
+++ b/src/Template.Web/Template.Web.csproj
@@ -8,12 +8,12 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
 
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <FileVersion>0.3.0.0</FileVersion>
+    <AssemblyVersion>0.3.1.0</AssemblyVersion>
+    <FileVersion>0.3.1.0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
 
   </PropertyGroup>

--- a/src/Template.Web/appsettings.json
+++ b/src/Template.Web/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "TemplateDatabase": "Data Source=template-dev.db"
+    "TemplateDatabase": "Data Source=template-dev.db",
+    "TemplateSqlServer": "Server=(localdb)\\MSSQLLocalDB;Database=TemplateApplication;Trusted_Connection=True;TrustServerCertificate=True"
   },
   "AllowedHosts": "*",
   "Serilog": {
@@ -217,6 +218,10 @@
       "ManageApplicationPermissions": [
         "application.manage"
       ]
+    },
+    "DataAccess": {
+      "Provider": "Sqlite",
+      "ConnectionStringName": "TemplateDatabase"
     }
   }
 }

--- a/tests/Template.Web.Tests/DataAccessServiceExtensionsTests.cs
+++ b/tests/Template.Web.Tests/DataAccessServiceExtensionsTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Template.Infrastructure.Data;
+using Template.Web.Extensions;
+
+namespace Template.Web.Tests;
+
+/// <summary>
+/// Provides tests for template data access provider configuration.
+/// </summary>
+public sealed class DataAccessServiceExtensionsTests
+{
+    /// <summary>
+    /// Verifies that SQLite remains the default provider when no data access provider is explicitly configured.
+    /// </summary>
+    [Fact]
+    public void AddTemplateDataAccess_DefaultConfiguration_UsesSqliteProvider()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:TemplateDatabase"] = "Data Source=:memory:"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        using TemplateDbContext context = serviceProvider.GetRequiredService<TemplateDbContext>();
+
+        Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", context.Database.ProviderName);
+    }
+
+    /// <summary>
+    /// Verifies that SQL Server can be selected through configuration.
+    /// </summary>
+    [Fact]
+    public void AddTemplateDataAccess_SqlServerProvider_UsesSqlServerProvider()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:TemplateSqlServer"] = "Server=(localdb)\\MSSQLLocalDB;Database=TemplateApplicationTests;Trusted_Connection=True;TrustServerCertificate=True",
+                ["Template:DataAccess:Provider"] = "SqlServer",
+                ["Template:DataAccess:ConnectionStringName"] = "TemplateSqlServer"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        using TemplateDbContext context = serviceProvider.GetRequiredService<TemplateDbContext>();
+
+        Assert.Equal("Microsoft.EntityFrameworkCore.SqlServer", context.Database.ProviderName);
+    }
+
+    /// <summary>
+    /// Verifies that provider matching is case-insensitive.
+    /// </summary>
+    [Theory]
+    [InlineData("sqlite", "Microsoft.EntityFrameworkCore.Sqlite")]
+    [InlineData("SQLITE", "Microsoft.EntityFrameworkCore.Sqlite")]
+    [InlineData("sqlserver", "Microsoft.EntityFrameworkCore.SqlServer")]
+    [InlineData("SQLSERVER", "Microsoft.EntityFrameworkCore.SqlServer")]
+    public void AddTemplateDataAccess_ProviderNameMatching_IsCaseInsensitive(
+        string provider,
+        string expectedProviderName)
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:TemplateDatabase"] = "Data Source=:memory:",
+                ["ConnectionStrings:TemplateSqlServer"] = "Server=(localdb)\\MSSQLLocalDB;Database=TemplateApplicationTests;Trusted_Connection=True;TrustServerCertificate=True",
+                ["Template:DataAccess:Provider"] = provider,
+                ["Template:DataAccess:ConnectionStringName"] = provider.Equals("sqlserver", StringComparison.OrdinalIgnoreCase)
+                    ? "TemplateSqlServer"
+                    : "TemplateDatabase"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        using TemplateDbContext context = serviceProvider.GetRequiredService<TemplateDbContext>();
+
+        Assert.Equal(expectedProviderName, context.Database.ProviderName);
+    }
+
+    /// <summary>
+    /// Verifies that blank provider values fail fast during service registration.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddTemplateDataAccess_BlankProvider_ThrowsInvalidOperationException(string provider)
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:TemplateDatabase"] = "Data Source=:memory:",
+                ["Template:DataAccess:Provider"] = provider,
+                ["Template:DataAccess:ConnectionStringName"] = "TemplateDatabase"
+            });
+
+        ServiceCollection services = new();
+        services.AddLogging();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddTemplateDataAccess(configuration));
+
+        Assert.Contains(
+            "Template data access provider was not configured.",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that blank connection string names fail fast during service registration.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddTemplateDataAccess_BlankConnectionStringName_ThrowsInvalidOperationException(
+        string connectionStringName)
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:TemplateDatabase"] = "Data Source=:memory:",
+                ["Template:DataAccess:Provider"] = "Sqlite",
+                ["Template:DataAccess:ConnectionStringName"] = connectionStringName
+            });
+
+        ServiceCollection services = new();
+        services.AddLogging();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddTemplateDataAccess(configuration));
+
+        Assert.Contains(
+            "Template data access connection string name was not configured.",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that unsupported provider names fail when the DbContext provider is configured.
+    /// </summary>
+    [Fact]
+    public void AddTemplateDataAccess_UnsupportedProvider_ThrowsInvalidOperationException()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:TemplateDatabase"] = "Data Source=:memory:",
+                ["Template:DataAccess:Provider"] = "PostgreSql",
+                ["Template:DataAccess:ConnectionStringName"] = "TemplateDatabase"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            serviceProvider.GetRequiredService<TemplateDbContext>);
+
+        Assert.Contains(
+            "Unsupported template data access provider",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+
+        Assert.Contains(
+            "Sqlite, SqlServer",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that a configured provider fails fast when its configured connection string is missing.
+    /// </summary>
+    [Fact]
+    public void AddTemplateDataAccess_MissingConnectionString_ThrowsInvalidOperationException()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Template:DataAccess:Provider"] = "Sqlite",
+                ["Template:DataAccess:ConnectionStringName"] = "MissingDatabase"
+            });
+
+        ServiceCollection services = new();
+        services.AddLogging();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddTemplateDataAccess(configuration));
+
+        Assert.Contains(
+            "Connection string 'MissingDatabase' was not configured.",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ServiceProvider CreateServiceProvider(IConfiguration configuration)
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddTemplateDataAccess(configuration);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static IConfiguration CreateConfiguration(
+        IReadOnlyDictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/tests/Template.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/Template.Web.Tests/OpenTelemetryTests.cs
@@ -16,7 +16,7 @@ namespace Template.Web.Tests;
 /// </summary>
 public sealed class OpenTelemetryTests
 {
-    private const string _releaseVersion = "0.3.0";
+    private const string _releaseVersion = "0.3.1";
 
     /// <summary>
     /// Verifies that template OpenTelemetry options are bound from configuration.


### PR DESCRIPTION
## Summary

Adds SQL Server as a configurable EF Core provider option while keeping SQLite as the default development provider.

This update allows the template data access layer to select either SQLite or SQL Server through configuration without requiring consuming applications to rewrite the DbContext registration pattern.

Closes #105

## Changes

- Added SQL Server EF Core provider package support.
- Added configurable data access provider selection.
- Added configurable connection string name selection.
- Kept SQLite as the default provider for local development.
- Added fail-fast validation for:
  - blank provider values
  - blank connection string names
  - missing connection strings
  - unsupported provider names
- Added SQL Server connection string example using LocalDB only.
- Added unit tests for provider selection and invalid provider handling.
- Updated README data access documentation for SQLite and SQL Server usage.
- Documented provider-specific migration guidance.

## Validation

- Confirmed SQLite remains the default provider.
- Confirmed SQL Server can be selected through configuration.
- Confirmed unsupported provider values fail fast.
- Confirmed no production secrets or production connection strings were committed.
- Confirmed existing EF Core tests continue to pass.

## Test Results

dotnet build:
```bash
Restore complete (1.3s)
  Template.Infrastructure net10.0 succeeded (1.5s) → src\Template.Infrastructure\bin\Release\net10.0\Template.Infrastructure.dll
  Template.Web net10.0 succeeded (3.5s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (5.6s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll

Build succeeded in 12.6s
```
dotnet test:
```bash
Restore complete (1.2s)
  Template.Infrastructure net10.0 succeeded (0.4s) → src\Template.Infrastructure\bin\Release\net10.0\Template.Infrastructure.dll
  Template.Web net10.0 succeeded (0.8s) → src\Template.Web\bin\Release\net10.0\Template.Web.dll
  Template.Web.Tests net10.0 succeeded (0.8s) → tests\Template.Web.Tests\bin\Release\net10.0\Template.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:03.58]   Discovering: Template.Web.Tests
[xUnit.net 00:00:04.16]   Discovered:  Template.Web.Tests
[xUnit.net 00:00:04.62]   Starting:    Template.Web.Tests
[xUnit.net 00:00:20.58]   Finished:    Template.Web.Tests (ID = '3e2bbdfb1466259cd360623eb6ced3930f0f74321719e8cf357c6d9170bff855')
  Template.Web.Tests test net10.0 succeeded (24.7s)

Test summary: total: 114, failed: 0, succeeded: 114, skipped: 0, duration: 24.6s
Build succeeded in 28.8s
```
