### PR TITLE
Fix CFF schema version in citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,8 @@
-cff-version: 0.4.0
+cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
+version: "0.4.0"
+date-released: "2026-05-21"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."


### PR DESCRIPTION
## Summary

- Updates `CITATION.cff` to use the correct Citation File Format schema version.
- Moves the project release value into the `version` field.
- Preserves repository citation metadata for ORCID, GitHub citation rendering, and future Zenodo use.

## Notes

The `cff-version` field identifies the Citation File Format schema version, not the software release version.