### PR TITLE
Add environment-specific configuration examples - Issue #58

### DIFF
--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -1,18 +1,183 @@
 # Configuration
 
-This section will document application configuration strategy.
+This section documents the application configuration strategy used by the .NET Core Application Template.
 
-Planned areas:
+The template uses ASP.NET Core configuration conventions and groups application-owned options under the `ProjectTemplate` configuration section. Shared defaults live in `appsettings.json`, while environment-specific files, environment variables, user secrets, or deployment secret stores can override values for a specific environment.
 
-- appsettings.json.
-- appsettings.Development.json.
-- User secrets.
-- Environment variables.
-- Provider-specific configuration.
-- Options pattern.
-- Strongly typed settings.
-- Validation on startup.
-- Sensitive configuration handling.
+## Configuration Sources
+
+Common configuration sources include:
+
+- `appsettings.json` for shared defaults.
+- `appsettings.Development.json` for local development overrides.
+- `appsettings.Production.json` or platform-provided configuration for production overrides.
+- Environment variables for deployment-specific values.
+- User secrets for local-only sensitive development values.
+- External secret stores or hosting platform secret managers for production secrets.
+
+The repository includes safe example files under `docs/examples`:
+
+- [`appsettings.Development.example.json`](../examples/appsettings.Development.example.json)
+- [`appsettings.Production.example.json`](../examples/appsettings.Production.example.json)
+
+These files are examples only. They should be copied and adapted by consuming applications, not treated as production-ready configuration.
+
+## Configuration Precedence
+
+ASP.NET Core configuration is layered. Later configuration providers can override earlier providers.
+
+A typical application order is:
+
+```text
+1. appsettings.json
+2. appsettings.{Environment}.json
+3. User secrets, usually Development only
+4. Environment variables
+5. Command-line arguments
+```
+
+This means a value from an environment variable can override the same value from `appsettings.json` or `appsettings.Production.json`.
+
+For example, this JSON value:
+
+```json
+{
+  "ProjectTemplate": {
+    "RateLimiting": {
+      "GlobalFixedWindow": {
+        "PermitLimit": 60
+      }
+    }
+  }
+}
+```
+
+Can be overridden by this environment variable:
+
+```powershell
+$env:ProjectTemplate__RateLimiting__GlobalFixedWindow__PermitLimit = "120"
+```
+
+Double underscores map to nested configuration keys. This is useful for containers, cloud hosting platforms, CI/CD systems, and deployment pipelines.
+
+## Development Configuration Example
+
+Development configuration should favor local productivity while avoiding real production secrets.
+
+Common development overrides include:
+
+- Local SQLite database connection strings.
+- LocalDB SQL Server examples.
+- Debug-level logging.
+- Shorter log retention.
+- Disabled or relaxed CSP while debugging local assets.
+- Disabled external authentication providers unless actively testing them.
+- Local-only provider client IDs and secrets stored with user secrets.
+
+See [`appsettings.Development.example.json`](../examples/appsettings.Development.example.json) for a safe development-oriented example.
+
+## Production Configuration Example
+
+Production configuration should be explicit, conservative, and environment-specific.
+
+Common production overrides include:
+
+- Real allowed host names.
+- Trusted forwarded header proxy addresses or networks.
+- Strong Content Security Policy values.
+- Production logging retention expectations.
+- Production rate limit values.
+- SQL Server or other production data provider settings.
+- External authentication provider settings.
+- Secret values supplied from the environment or secret store instead of committed JSON.
+
+See [`appsettings.Production.example.json`](../examples/appsettings.Production.example.json) for a safe production-oriented example. The example intentionally leaves secrets and connection strings blank.
+
+## Environment Variable Overrides
+
+Environment variables are useful when configuration must vary by deployment slot, container, host, or pipeline.
+
+Examples:
+
+```powershell
+$env:ASPNETCORE_ENVIRONMENT = "Production"
+$env:AllowedHosts = "example.com"
+$env:ConnectionStrings__ApplicationSqlServer = "Server=tcp:sql.example.com,1433;Database=Application;Encrypt=True;TrustServerCertificate=False;"
+$env:ProjectTemplate__DataAccess__Provider = "SqlServer"
+$env:ProjectTemplate__DataAccess__ConnectionStringName = "ApplicationSqlServer"
+$env:ProjectTemplate__SecurityHeaders__EnableContentSecurityPolicy = "true"
+$env:ProjectTemplate__RateLimiting__GlobalFixedWindow__PermitLimit = "120"
+```
+
+For Linux shells or container environments, the same keys are usually set without `$env:`:
+
+```bash
+export ASPNETCORE_ENVIRONMENT="Production"
+export ProjectTemplate__DataAccess__Provider="SqlServer"
+export ProjectTemplate__RateLimiting__GlobalFixedWindow__PermitLimit="120"
+```
+
+## Secret Management Guidance
+
+Do not commit production secrets to the repository.
+
+Sensitive values include:
+
+- Production database connection strings.
+- External authentication client secrets.
+- API keys.
+- Signing certificates or certificate passwords.
+- Access tokens.
+- SMTP credentials.
+- Any organization-specific private endpoint values.
+
+For local development, prefer user secrets:
+
+```powershell
+dotnet user-secrets set "ConnectionStrings:ApplicationSqlServer" "Server=(localdb)\MSSQLLocalDB;Database=Application;Trusted_Connection=True;TrustServerCertificate=True" --project src/ProjectTemplate.Web
+
+dotnet user-secrets set "ProjectTemplate:Authentication:Providers:GitHub:ClientSecret" "local-development-secret" --project src/ProjectTemplate.Web
+```
+
+For production, prefer the hosting platform secret manager, environment-protected variables, or an approved external secret store. Production secret values should be injected at deployment time rather than stored in committed JSON files.
+
+## Provider-Specific Configuration
+
+The template supports configurable data access provider selection through `ProjectTemplate:DataAccess`.
+
+SQLite development example:
+
+```json
+{
+  "ConnectionStrings": {
+    "ApplicationDatabase": "Data Source=application-dev.db"
+  },
+  "ProjectTemplate": {
+    "DataAccess": {
+      "Provider": "Sqlite",
+      "ConnectionStringName": "ApplicationDatabase"
+    }
+  }
+}
+```
+
+SQL Server production-style example:
+
+```json
+{
+  "ConnectionStrings": {
+    "ApplicationSqlServer": ""
+  },
+  "ProjectTemplate": {
+    "DataAccess": {
+      "Provider": "SqlServer",
+      "ConnectionStringName": "ApplicationSqlServer"
+    }
+  }
+}
+```
+
+In production, the actual `ApplicationSqlServer` connection string should come from the environment or secret store.
 
 ## Configuration Validation
 
@@ -25,3 +190,19 @@ Validated configuration areas include:
 - `ProjectTemplate:RateLimiting`
 
 Invalid startup-sensitive values fail application startup rather than being silently corrected. This helps catch unsafe or malformed production configuration before the application begins serving requests.
+
+## Production Review Checklist
+
+Before production release, review:
+
+```text
+[ ] ASPNETCORE_ENVIRONMENT is set correctly.
+[ ] AllowedHosts matches the public host names.
+[ ] Forwarded header settings match the proxy or load balancer topology.
+[ ] Production connection strings come from environment or secret storage.
+[ ] External authentication provider secrets are not committed.
+[ ] Content Security Policy values are tested against deployed assets and auth flows.
+[ ] Rate limit values are tuned for expected traffic.
+[ ] Logging destinations, retention, and sensitive-data exposure are reviewed.
+[ ] Database provider and migration strategy are documented for the environment.
+```

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -30,7 +30,8 @@
     "resource": [
       {
         "files": [
-          "images/**"
+          "images/**",
+          "examples/**"
         ]
       }
     ],

--- a/docs/examples/appsettings.Development.example.json
+++ b/docs/examples/appsettings.Development.example.json
@@ -1,0 +1,110 @@
+{
+  "ConnectionStrings": {
+    "ApplicationDatabase": "Data Source=application-dev.db",
+    "ApplicationSqlServer": "Server=(localdb)\\MSSQLLocalDB;Database=Application;Trusted_Connection=True;TrustServerCertificate=True"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Debug",
+        "Args": {
+          "minimumLevel": "Debug",
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "minimumLevel": "Debug",
+          "path": "Logs/template-web-.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 5,
+          "fileSizeLimitBytes": 10485760,
+          "rollOnFileSizeLimit": true,
+          "shared": true,
+          "flushToDiskInterval": "00:00:01"
+        }
+      }
+    ]
+  },
+  "ProjectTemplate": {
+    "ForwardedHeaders": {
+      "Enabled": false,
+      "KnownProxies": [],
+      "KnownNetworks": [],
+      "AllowedHosts": []
+    },
+    "SecurityHeaders": {
+      "Enabled": true,
+      "EnableContentSecurityPolicy": false,
+      "EnablePermissionsPolicy": true,
+      "EnableCrossOriginHeaders": true
+    },
+    "RateLimiting": {
+      "Enabled": true,
+      "UseGlobalLimiter": true,
+      "GlobalFixedWindow": {
+        "PermitLimit": 120,
+        "WindowSeconds": 60,
+        "QueueLimit": 0
+      }
+    },
+    "RequestLogging": {
+      "Enabled": true,
+      "IncludeQueryString": true,
+      "IncludeUserName": true,
+      "IncludeRemoteIpAddress": true
+    },
+    "OpenTelemetry": {
+      "Enabled": true,
+      "ServiceName": "ProjectTemplate.Web.Development",
+      "EnableTracing": true,
+      "EnableMetrics": true,
+      "Otlp": {
+        "Enabled": false,
+        "Endpoint": "",
+        "Protocol": "Grpc"
+      }
+    },
+    "Authentication": {
+      "Providers": {
+        "OpenIdConnect": {
+          "Enabled": false,
+          "Authority": "",
+          "ClientId": "",
+          "ClientSecret": ""
+        },
+        "Microsoft": {
+          "Enabled": false,
+          "ClientId": "",
+          "ClientSecret": ""
+        },
+        "Google": {
+          "Enabled": false,
+          "ClientId": "",
+          "ClientSecret": ""
+        },
+        "GitHub": {
+          "Enabled": false,
+          "ClientId": "",
+          "ClientSecret": ""
+        }
+      }
+    },
+    "DataAccess": {
+      "Provider": "Sqlite",
+      "ConnectionStringName": "ApplicationDatabase"
+    }
+  }
+}

--- a/docs/examples/appsettings.Production.example.json
+++ b/docs/examples/appsettings.Production.example.json
@@ -1,0 +1,131 @@
+{
+  "AllowedHosts": "example.com",
+  "ConnectionStrings": {
+    "ApplicationDatabase": "",
+    "ApplicationSqlServer": ""
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "Logs/application-web-.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 30,
+          "fileSizeLimitBytes": 10485760,
+          "rollOnFileSizeLimit": true,
+          "shared": true,
+          "flushToDiskInterval": "00:00:01"
+        }
+      }
+    ]
+  },
+  "ProjectTemplate": {
+    "ForwardedHeaders": {
+      "Enabled": true,
+      "Headers": [
+        "XForwardedFor",
+        "XForwardedProto"
+      ],
+      "ForwardLimit": 1,
+      "RequireHeaderSymmetry": false,
+      "ClearKnownNetworksAndProxies": false,
+      "KnownProxies": [
+        "10.0.0.10"
+      ],
+      "KnownNetworks": [
+        "10.0.0.0/24"
+      ],
+      "AllowedHosts": [
+        "example.com"
+      ]
+    },
+    "SecurityHeaders": {
+      "Enabled": true,
+      "EnableContentSecurityPolicy": true,
+      "EnablePermissionsPolicy": true,
+      "EnableCrossOriginHeaders": true,
+      "ContentSecurityPolicy": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self';",
+      "PermissionsPolicy": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)",
+      "ExcludedPathPrefixes": [
+        "/health",
+        "/metrics"
+      ]
+    },
+    "RateLimiting": {
+      "Enabled": true,
+      "UseGlobalLimiter": true,
+      "GlobalFixedWindow": {
+        "PermitLimit": 60,
+        "WindowSeconds": 60,
+        "QueueLimit": 0
+      },
+      "FixedWindowPolicy": {
+        "PermitLimit": 60,
+        "WindowSeconds": 60,
+        "QueueLimit": 0
+      },
+      "ConcurrencyPolicy": {
+        "PermitLimit": 10,
+        "QueueLimit": 0
+      }
+    },
+    "RequestLogging": {
+      "Enabled": true,
+      "IncludeQueryString": false,
+      "IncludeUserName": true,
+      "IncludeRemoteIpAddress": true
+    },
+    "OpenTelemetry": {
+      "Enabled": true,
+      "ServiceName": "ProjectTemplate.Web",
+      "EnableTracing": true,
+      "EnableMetrics": true,
+      "Otlp": {
+        "Enabled": false,
+        "Endpoint": "",
+        "Protocol": "Grpc"
+      }
+    },
+    "Authentication": {
+      "Providers": {
+        "OpenIdConnect": {
+          "Enabled": false,
+          "Authority": "https://identity.example.com",
+          "ClientId": "",
+          "ClientSecret": ""
+        },
+        "Microsoft": {
+          "Enabled": false,
+          "ClientId": "",
+          "ClientSecret": ""
+        },
+        "Google": {
+          "Enabled": false,
+          "ClientId": "",
+          "ClientSecret": ""
+        },
+        "GitHub": {
+          "Enabled": false,
+          "ClientId": "",
+          "ClientSecret": ""
+        }
+      }
+    },
+    "DataAccess": {
+      "Provider": "SqlServer",
+      "ConnectionStringName": "ApplicationSqlServer"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Added safe development and production configuration example files under `docs/examples`.
- Expanded the Configuration article with recommended configuration layering and environment-specific usage.
- Documented configuration precedence across appsettings files, user secrets, environment variables, and command-line arguments.
- Added environment variable override examples for Windows PowerShell and Linux/container shells.
- Added secret management guidance for local development and production deployments.
- Added provider-specific configuration examples for SQLite and SQL Server.
- Added a production configuration review checklist.
- Updated DocFX resource configuration so example JSON files are published with the documentation site.

## Validation

- Documentation-only change.
- Confirmed the branch is current with `main` and only ahead by Issue #58 documentation commits.
- Reviewed the final diff for scope: configuration article, DocFX resource configuration, and example JSON files only.

Closes #58