### PR TITLE
Add architecture decision record structure - Issue #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Detailed documentation is maintained in the `docs` folder and published with Doc
 
 - [Documentation source](docs/index.md)
 - [Published documentation](https://cdcavell.github.io/NetCoreApplicationTemplate/)
+- [Architecture Decision Records](https://cdcavell.github.io/NetCoreApplicationTemplate/adr/)
 - Generated API reference is available through the published documentation navigation.
 
 Documentation areas include:

--- a/docs/adr/0001-use-structured-serilog-logging.md
+++ b/docs/adr/0001-use-structured-serilog-logging.md
@@ -1,0 +1,56 @@
+# ADR-0001: Use Structured Serilog Logging
+
+## Status
+
+Accepted
+
+## Context
+
+The template is intended to provide a production-oriented ASP.NET Core baseline. Applications created from it need useful logs for local development, troubleshooting, request correlation, operational review, and future deployment environments.
+
+Basic framework logging is useful, but the template also needs a consistent structured logging approach that can be extended by consuming applications without scattering logging setup across startup code.
+
+The logging approach should support:
+
+- Request and application diagnostics.
+- Correlation and request identifiers.
+- Console output for local and hosted environments.
+- File output for simple deployments and local inspection.
+- Environment and thread enrichment.
+- Centralized configuration through application settings.
+- A clean path toward future sink changes without redesigning the application startup pattern.
+
+## Decision
+
+Use Serilog as the structured logging foundation for the template.
+
+Logging is configured centrally through application configuration and startup extension patterns rather than ad hoc setup across the application. The template keeps logging defaults practical for local development while allowing consuming applications to replace or extend sinks for production hosting environments.
+
+## Consequences
+
+Positive consequences:
+
+- Logs can carry structured properties such as request path, request ID, correlation ID, source context, and environment information.
+- Console logging works well for local development, containers, and hosted platforms.
+- File logging provides a simple baseline for development and small deployments.
+- Consuming applications can tune minimum levels, overrides, sinks, templates, retention, and enrichment through configuration.
+- The template has a consistent observability starting point before optional telemetry export is added.
+
+Trade-offs and risks:
+
+- Serilog adds a third-party logging dependency.
+- File logging may not be appropriate for every production environment.
+- Production deployments must review log retention and sensitive-data exposure.
+- Consuming applications may need organization-specific sinks such as Seq, Application Insights, OpenTelemetry collectors, or centralized log platforms.
+
+## Alternatives Considered
+
+- Use only built-in Microsoft.Extensions.Logging: simpler dependency posture, but less complete as a structured logging baseline for the template goals.
+- Use another structured logging library: possible, but Serilog is widely used in ASP.NET Core applications and fits the template's configuration-driven approach.
+- Defer logging decisions to consuming applications: flexible, but would weaken the template as a production-oriented baseline.
+
+## Related References
+
+- [`docs/articles/logging.md`](../articles/logging.md)
+- [`docs/articles/configuration.md`](../articles/configuration.md)
+- [`src/ProjectTemplate.Web/appsettings.json`](../../src/ProjectTemplate.Web/appsettings.json)

--- a/docs/adr/0002-use-centralized-application-middleware-pipeline.md
+++ b/docs/adr/0002-use-centralized-application-middleware-pipeline.md
@@ -1,0 +1,57 @@
+# ADR-0002: Use Centralized Application Middleware Pipeline
+
+## Status
+
+Accepted
+
+## Context
+
+ASP.NET Core middleware order is security-sensitive and behavior-sensitive. A template that includes forwarded headers, exception handling, HTTPS, static files, routing, CORS, rate limiting, authentication, authorization, request logging, security headers, health checks, and endpoint mapping needs a predictable pipeline structure.
+
+If middleware registration is scattered throughout `Program.cs`, consuming applications can accidentally reorder important components or make startup code harder to review. This is especially risky for a reusable template because future applications inherit the startup pattern.
+
+The template needs a middleware approach that is:
+
+- Easy to scan.
+- Centralized enough to preserve ordering.
+- Extensible by consuming applications.
+- Testable through integration tests.
+- Clear about where security-sensitive middleware belongs.
+- Consistent with the project's extension-method style.
+
+## Decision
+
+Use a centralized application middleware pipeline extension for template-owned middleware ordering.
+
+The application startup code delegates template-owned middleware registration to a central pipeline extension. Feature-specific middleware can still be implemented in focused extension methods, but their relative ordering is controlled from the centralized pipeline.
+
+## Consequences
+
+Positive consequences:
+
+- `Program.cs` remains concise and easier to review.
+- Middleware ordering is documented in one primary place.
+- Security-sensitive order is less likely to drift accidentally.
+- Consuming applications can see the intended baseline sequence before adding application-specific middleware.
+- Integration tests can validate behavior against the real configured pipeline.
+- Future template features have a clear place to participate in startup ordering.
+
+Trade-offs and risks:
+
+- The centralized pipeline must be kept readable as more features are added.
+- Consuming applications may need guidance on where to insert custom middleware.
+- Too much abstraction could hide important startup behavior if documentation is not maintained.
+- Changes to the central pipeline can have broad effects and should be reviewed carefully.
+
+## Alternatives Considered
+
+- Keep all middleware registration directly in `Program.cs`: more explicit in one file, but it can become noisy and easier to misorder over time.
+- Let each feature register itself independently without centralized ordering: modular, but dangerous for middleware whose position affects security or behavior.
+- Use separate startup classes: familiar to older ASP.NET Core patterns, but less aligned with modern minimal-hosting style.
+
+## Related References
+
+- [`docs/articles/middleware.md`](../articles/middleware.md)
+- [`docs/articles/forwarded-headers.md`](../articles/forwarded-headers.md)
+- [`docs/articles/security-headers.md`](../articles/security-headers.md)
+- [`docs/articles/rate-limiting.md`](../articles/rate-limiting.md)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,58 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) document long-term architectural decisions made for the .NET Core Application Template.
+
+ADRs are intended to explain why a decision was made, what alternatives were considered, and what consequences the decision introduces. They are not meant to replace code comments, API documentation, or implementation guides.
+
+## When to Add an ADR
+
+Add an ADR when a decision affects the long-term shape of the template, such as:
+
+- Application startup and middleware organization.
+- Logging, telemetry, or observability strategy.
+- Security defaults and production guardrails.
+- Authentication or authorization architecture.
+- Data access provider strategy.
+- Template packaging conventions.
+- Testing strategy or repository workflow.
+- Any decision that future maintainers may reasonably question.
+
+Small implementation details, routine refactors, and temporary fixes usually do not need ADRs.
+
+## Numbering Convention
+
+ADR files use a four-digit, zero-padded sequence number followed by a short kebab-case title:
+
+```text
+0001-use-structured-serilog-logging.md
+0002-use-centralized-application-middleware-pipeline.md
+0003-example-future-decision.md
+```
+
+Rules:
+
+- Assign the next available number when creating a new ADR.
+- Do not renumber existing ADRs after they are merged.
+- Keep filenames lowercase and use hyphens between words.
+- Keep titles short but specific.
+- Use the ADR template in [`template.md`](template.md).
+
+## ADR Status Values
+
+Use one of these status values:
+
+| Status | Meaning |
+|:---|:---|
+| `Proposed` | Under consideration but not yet accepted. |
+| `Accepted` | Current architectural decision. |
+| `Deprecated` | No longer recommended, but not directly replaced. |
+| `Superseded` | Replaced by a newer ADR. |
+
+When an ADR is superseded, keep the original file and add a link to the replacing ADR. Do not delete historical ADRs unless they were created by mistake and have not been relied on.
+
+## Current ADRs
+
+| ADR | Title | Status |
+|:---|:---|:---|
+| [0001](0001-use-structured-serilog-logging.md) | Use structured Serilog logging | Accepted |
+| [0002](0002-use-centralized-application-middleware-pipeline.md) | Use centralized application middleware pipeline | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,36 @@
+# ADR-NNNN: Title
+
+## Status
+
+Proposed
+
+## Context
+
+Describe the background, constraints, problem, and forces that led to this decision.
+
+Include relevant project goals, security considerations, maintainability concerns, deployment concerns, or template packaging concerns.
+
+## Decision
+
+Describe the decision clearly and directly.
+
+Use active language. Future readers should be able to understand what was chosen without reading the entire implementation.
+
+## Consequences
+
+Document the expected results of the decision.
+
+Include positive consequences, trade-offs, risks, and maintenance implications.
+
+## Alternatives Considered
+
+List meaningful alternatives that were considered and why they were not selected.
+
+Examples:
+
+- Alternative A: Reason it was not selected.
+- Alternative B: Reason it was not selected.
+
+## Related References
+
+Link to related issues, pull requests, documentation, or source files when useful.

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -1,0 +1,11 @@
+- name: ADR Home
+  href: index.md
+
+- name: ADR Template
+  href: template.md
+
+- name: Use Structured Serilog Logging
+  href: 0001-use-structured-serilog-logging.md
+
+- name: Use Centralized Application Middleware Pipeline
+  href: 0002-use-centralized-application-middleware-pipeline.md

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -23,6 +23,7 @@
           "index.md",
           "**/toc.yml",
           "articles/**/*.md",
+          "adr/**/*.md",
           "api/**/*.yml"
         ]
       }

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,6 +1,9 @@
 - name: Documentation
   href: articles/
 
+- name: Architecture Decisions
+  href: adr/
+
 - name: API Reference
   href: api/
 


### PR DESCRIPTION
## Summary

- Added a `docs/adr` directory for Architecture Decision Records.
- Added an ADR index that explains when to create ADRs, status values, and the numbering convention.
- Added a reusable ADR template.
- Added initial ADR-0001 documenting the structured Serilog logging decision.
- Added initial ADR-0002 documenting the centralized application middleware pipeline decision.
- Added ADR navigation through `docs/adr/toc.yml` and the top-level DocFX `docs/toc.yml`.
- Updated `docs/docfx.json` so ADR markdown files are included in the published documentation site.
- Linked Architecture Decision Records from the README documentation section.

## Validation

- Documentation-only change.
- Confirmed the branch is current with `main` and only ahead by Issue #60 documentation commits.
- Reviewed the final diff for scope: ADR files, DocFX navigation/content configuration, and README discovery link only.

Closes #60