### PR TITLE
Fix ADR appsettings reference

### DIFF
--- a/docs/adr/0001-use-structured-serilog-logging.md
+++ b/docs/adr/0001-use-structured-serilog-logging.md
@@ -53,4 +53,4 @@ Trade-offs and risks:
 
 - [`docs/articles/logging.md`](../articles/logging.md)
 - [`docs/articles/configuration.md`](../articles/configuration.md)
-- [`src/ProjectTemplate.Web/appsettings.json`](../../src/ProjectTemplate.Web/appsettings.json)
+- `src/ProjectTemplate.Web/appsettings.json` repository source file


### PR DESCRIPTION
## Summary

- Fixed the ADR-0001 `appsettings.json` reference so DocFX no longer generates a broken GitHub Pages link.
- Left the source file path as inline code with a repository-source note instead of a relative link that escapes the published documentation site.

## Validation

- Documentation-only change.
- Reviewed diff: one-line ADR reference change only.