### PR TITLE
Add API versioning foundation - Issue #54

### DIFF
--- a/ASSETS-LICENSES.md
+++ b/ASSETS-LICENSES.md
@@ -88,3 +88,5 @@ _Entity Framework Core (EF Core) is a modern object-database mapper for .NET. It
 - [Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer)
 ## [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common)
 _System.Drawing.Common provides access to GDI+ graphics functionality. It includes types for working with images, colors, fonts, and drawing operations. This package is cross-platform and can be used in .NET applications running on Windows, Linux, and macOS._
+## [Asp.Versioning.Mvc](https://www.nuget.org/packages/Asp.Versioning.Mvc)
+_This package contains the ASP.NET MVC integration for API versioning. It provides support for versioning ASP.NET MVC applications, allowing developers to manage and evolve their APIs over time while maintaining backward compatibility._

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Documentation areas include:
 - [Configuration](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/configuration.html)
 - [Deployment](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/deployment.html)
 - [Middleware Pipeline](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/middleware.html)
+- [API Versioning](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/api-versioning.html)
 - [Logging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/logging.html)
 - [Error Handling](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/error-handling.html)
 - [Security Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/security-headers.html)

--- a/docs/articles/api-versioning.md
+++ b/docs/articles/api-versioning.md
@@ -1,0 +1,70 @@
+# API Versioning
+
+The application includes a foundation for controller-based API versioning.
+
+API versioning helps keep public API routes stable while allowing future versions to evolve without breaking existing clients.
+
+## Default Version
+
+The default API version is configured under `ProjectTemplate:ApiVersioning`.
+
+```json
+{
+  "ProjectTemplate": {
+    "ApiVersioning": {
+      "DefaultMajorVersion": 1,
+      "DefaultMinorVersion": 0,
+      "AssumeDefaultVersionWhenUnspecified": true,
+      "ReportApiVersions": true,
+      "EnableUrlSegmentVersioning": true,
+      "EnableHeaderVersioning": true,
+      "HeaderName": "X-API-Version"
+    }
+  }
+}
+```
+The application starts with API version `1.0`.
+
+## Supported Versioning Strategies
+
+The application supports both URL segment and request header versioning.
+
+URL segment example:
+```http
+GET /api/v1/application-information
+```
+Header versioning example:
+```http
+GET /api/application-information
+X-API-Version: 1.0
+```
+URL segment versioning is usually easier to discover and debug. Header versioning can be useful for clients that prefer stable resource URLs.
+
+## Controller Convention
+
+Versioned API controllers should declare the supported API version and include a versioned route.
+```csharp
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/example")]
+public sealed class ExampleController : ControllerBase
+{
+}
+```
+If an endpoint should also support header-based versioning without the version in the URL, add an unversioned route as well.
+```charp
+[Route("api/example")]
+```
+
+## Response Headers
+
+When `ReportApiVersions` is enabled, responses include API version headers that help clients discover supported and deprecated versions.
+
+## Production Guidance
+
+For production APIs:
+- Prefer a consistent versioning strategy across the application.
+- Avoid mixing URL and header versioning on the same endpoint unless clients need both.
+- Keep old API versions available long enough for client migration.
+- Document deprecated versions before removing them.
+- Add tests for each supported API version.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -28,6 +28,9 @@
     - name: Health Checks
       href: health-checks.md
 
+- name: API Versioning
+  href: api-versioning.md
+
 - name: Observability
   items:
     - name: Logging

--- a/src/ProjectTemplate.Web/Controllers/Api/ApplicationInformationController.cs.cs
+++ b/src/ProjectTemplate.Web/Controllers/Api/ApplicationInformationController.cs.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ProjectTemplate.Web.Controllers.Api;
+
+/// <summary>
+/// Provides sample versioned API endpoints for the application.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/application-information")]
+[Route("api/application-information")]
+public sealed class ApplicationInformationController : ControllerBase
+{
+    /// <summary>
+    /// Returns application API information for the requested API version.
+    /// </summary>
+    /// <returns>Application API version information.</returns>
+    [HttpGet]
+    public ActionResult<ApplicationInformationResponse> Get()
+    {
+        return Ok(new ApplicationInformationResponse(
+            ApplicationName: "ProjectTemplate.Web",
+            ApiVersion: "1.0",
+            Message: "API versioning foundation active."));
+    }
+}
+
+/// <summary>
+/// Represents sample application API information.
+/// </summary>
+/// <param name="ApplicationName">The application name.</param>
+/// <param name="ApiVersion">The resolved API version.</param>
+/// <param name="Message">A short status message.</param>
+public sealed record ApplicationInformationResponse(
+    string ApplicationName,
+    string ApiVersion,
+    string Message);

--- a/src/ProjectTemplate.Web/Extensions/ApiVersioningServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/ApiVersioningServiceExtensions.cs
@@ -1,0 +1,106 @@
+using Asp.Versioning;
+using ProjectTemplate.Web.Options;
+
+namespace ProjectTemplate.Web.Extensions;
+
+/// <summary>
+/// Provides extension methods to register API versioning services for the application.
+/// </summary>
+public static class ApiVersioningServiceExtensions
+{
+    /// <summary>
+    /// Adds API versioning services and conventions for controller-based APIs.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The application configuration source.</param>
+    /// <returns>The same service collection instance so calls can be chained.</returns>
+    public static IServiceCollection AddApplicationApiVersioning(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ApplicationApiVersioningOptions apiVersioningOptions = new();
+
+        configuration
+            .GetSection(ApplicationApiVersioningOptions.SectionName)
+            .Bind(apiVersioningOptions);
+
+        ValidateApiVersioningOptions(apiVersioningOptions);
+
+        services
+            .AddOptions<ApplicationApiVersioningOptions>()
+            .Bind(configuration.GetSection(ApplicationApiVersioningOptions.SectionName))
+            .Validate(options => options.DefaultMajorVersion > 0,
+                "ProjectTemplate:ApiVersioning:DefaultMajorVersion must be greater than zero.")
+            .Validate(options => options.DefaultMinorVersion >= 0,
+                "ProjectTemplate:ApiVersioning:DefaultMinorVersion must be zero or greater.")
+            .Validate(options => options.EnableUrlSegmentVersioning || options.EnableHeaderVersioning,
+                "ProjectTemplate:ApiVersioning must enable URL segment versioning, header versioning, or both.")
+            .Validate(options => !options.EnableHeaderVersioning || !string.IsNullOrWhiteSpace(options.HeaderName),
+                "ProjectTemplate:ApiVersioning:HeaderName is required when header versioning is enabled.")
+            .ValidateOnStart();
+
+        IApiVersionReader[] readers = CreateApiVersionReaders(apiVersioningOptions);
+
+        services
+            .AddApiVersioning(options =>
+            {
+                options.DefaultApiVersion = new ApiVersion(
+                    apiVersioningOptions.DefaultMajorVersion,
+                    apiVersioningOptions.DefaultMinorVersion);
+
+                options.AssumeDefaultVersionWhenUnspecified =
+                    apiVersioningOptions.AssumeDefaultVersionWhenUnspecified;
+
+                options.ReportApiVersions = apiVersioningOptions.ReportApiVersions;
+                options.ApiVersionReader = ApiVersionReader.Combine(readers);
+            })
+            .AddMvc();
+
+        return services;
+    }
+
+    private static IApiVersionReader[] CreateApiVersionReaders(
+        ApplicationApiVersioningOptions options)
+    {
+        List<IApiVersionReader> readers = [];
+
+        if (options.EnableUrlSegmentVersioning)
+        {
+            readers.Add(new UrlSegmentApiVersionReader());
+        }
+
+        if (options.EnableHeaderVersioning)
+        {
+            readers.Add(new HeaderApiVersionReader(options.HeaderName));
+        }
+
+        return [.. readers];
+    }
+
+    private static void ValidateApiVersioningOptions(ApplicationApiVersioningOptions options)
+    {
+        if (options.DefaultMajorVersion <= 0)
+        {
+            throw new InvalidOperationException(
+                "ProjectTemplate:ApiVersioning:DefaultMajorVersion must be greater than zero.");
+        }
+
+        if (options.DefaultMinorVersion < 0)
+        {
+            throw new InvalidOperationException(
+                "ProjectTemplate:ApiVersioning:DefaultMinorVersion must be zero or greater.");
+        }
+
+        if (!options.EnableUrlSegmentVersioning && !options.EnableHeaderVersioning)
+        {
+            throw new InvalidOperationException(
+                "ProjectTemplate:ApiVersioning must enable URL segment versioning, header versioning, or both.");
+        }
+
+        if (options.EnableHeaderVersioning && string.IsNullOrWhiteSpace(options.HeaderName))
+        {
+            throw new InvalidOperationException(
+                "ProjectTemplate:ApiVersioning:HeaderName is required when header versioning is enabled.");
+        }
+    }
+}

--- a/src/ProjectTemplate.Web/Options/ApplicationApiVersioningOptions.cs
+++ b/src/ProjectTemplate.Web/Options/ApplicationApiVersioningOptions.cs
@@ -1,0 +1,47 @@
+namespace ProjectTemplate.Web.Options;
+
+/// <summary>
+/// Represents template-level API versioning configuration.
+/// </summary>
+public sealed class ApplicationApiVersioningOptions
+{
+    /// <summary>
+    /// Configuration section name for API versioning settings.
+    /// </summary>
+    public const string SectionName = "ProjectTemplate:ApiVersioning";
+
+    /// <summary>
+    /// Gets or sets the default major API version.
+    /// </summary>
+    public int DefaultMajorVersion { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the default minor API version.
+    /// </summary>
+    public int DefaultMinorVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an unspecified API version should use the default version.
+    /// </summary>
+    public bool AssumeDefaultVersionWhenUnspecified { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether supported and deprecated API versions should be reported in response headers.
+    /// </summary>
+    public bool ReportApiVersions { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether URL segment versioning is enabled.
+    /// </summary>
+    public bool EnableUrlSegmentVersioning { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether header-based versioning is enabled.
+    /// </summary>
+    public bool EnableHeaderVersioning { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the request header name used for header-based API versioning.
+    /// </summary>
+    public string HeaderName { get; set; } = "X-API-Version";
+}

--- a/src/ProjectTemplate.Web/Program.cs
+++ b/src/ProjectTemplate.Web/Program.cs
@@ -18,6 +18,7 @@ try
     builder.AddApplicationSerilog();
     Log.Information("Bootstrapping Template.Web application");
     builder.Services.AddControllersWithViews();
+    builder.Services.AddApplicationApiVersioning(builder.Configuration);
     builder.Services.AddRazorPages();
     builder.Services.AddApplicationHealthChecks();
     builder.Services.AddApplicationForwardedHeaders(builder.Configuration);

--- a/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
+++ b/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.8" />

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -222,6 +222,15 @@
     "DataAccess": {
       "Provider": "Sqlite",
       "ConnectionStringName": "ApplicationDatabase"
+    },
+    "ApiVersioning": {
+      "DefaultMajorVersion": 1,
+      "DefaultMinorVersion": 0,
+      "AssumeDefaultVersionWhenUnspecified": true,
+      "ReportApiVersions": true,
+      "EnableUrlSegmentVersioning": true,
+      "EnableHeaderVersioning": true,
+      "HeaderName": "X-API-Version"
     }
   }
 }

--- a/tests/ProjectTemplate.Web.Tests/ApiVersioningTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApiVersioningTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Web.Options;
+using ProjectTemplate.Web.Tests.Extensions;
+using ProjectTemplate.Web.Tests.Infrastructure;
+
+namespace ProjectTemplate.Web.Tests;
+
+/// <summary>
+/// Provides integration tests for API versioning configuration and routing.
+/// </summary>
+public sealed class ApiVersioningTests
+{
+    [Fact]
+    public async Task UrlSegmentVersionedEndpoint_ReturnsOk()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response =
+            await client.GetAsync("/api/v1/application-information", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.Contains("api-supported-versions"));
+
+        ApplicationInformationResponse? body =
+            await response.Content.ReadFromJsonAsync<ApplicationInformationResponse>(
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(body);
+        Assert.Equal("ProjectTemplate.Web", body.ApplicationName);
+        Assert.Equal("1.0", body.ApiVersion);
+    }
+
+    [Fact]
+    public async Task HeaderVersionedEndpoint_ReturnsOk()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "/api/application-information");
+        request.Headers.Add("X-API-Version", "1.0");
+
+        using HttpResponseMessage response =
+            await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnsupportedApiVersion_ReturnsNotFound()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory();
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response =
+            await client.GetAsync("/api/v2/application-information", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public void ApiVersioningOptions_AreBoundFromConfiguration()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["ProjectTemplate:ApiVersioning:DefaultMajorVersion"] = "2",
+            ["ProjectTemplate:ApiVersioning:DefaultMinorVersion"] = "1",
+            ["ProjectTemplate:ApiVersioning:AssumeDefaultVersionWhenUnspecified"] = "false",
+            ["ProjectTemplate:ApiVersioning:ReportApiVersions"] = "false",
+            ["ProjectTemplate:ApiVersioning:EnableUrlSegmentVersioning"] = "true",
+            ["ProjectTemplate:ApiVersioning:EnableHeaderVersioning"] = "true",
+            ["ProjectTemplate:ApiVersioning:HeaderName"] = "X-Test-Api-Version"
+        });
+
+        ApplicationApiVersioningOptions options = factory.Services
+            .GetRequiredService<IOptions<ApplicationApiVersioningOptions>>()
+            .Value;
+
+        Assert.Equal(2, options.DefaultMajorVersion);
+        Assert.Equal(1, options.DefaultMinorVersion);
+        Assert.False(options.AssumeDefaultVersionWhenUnspecified);
+        Assert.False(options.ReportApiVersions);
+        Assert.True(options.EnableUrlSegmentVersioning);
+        Assert.True(options.EnableHeaderVersioning);
+        Assert.Equal("X-Test-Api-Version", options.HeaderName);
+    }
+
+    private static ApplicationWebApplicationFactory CreateFactory(
+        IReadOnlyDictionary<string, string?>? configurationValues = null)
+    {
+        return new ApplicationWebApplicationFactory(
+            configurationValues ?? new Dictionary<string, string?>());
+    }
+
+    private sealed record ApplicationInformationResponse(
+        string ApplicationName,
+        string ApiVersion,
+        string Message);
+}


### PR DESCRIPTION
## Summary

- Added `Asp.Versioning.Mvc` for controller-based API versioning support.
- Added template-owned API versioning options under `ProjectTemplate:ApiVersioning`.
- Configured default API version `1.0`.
- Enabled URL segment versioning and header-based versioning with `X-API-Version`.
- Added a sample versioned API controller at `/api/v1/template-information`.
- Added documentation for API versioning conventions.
- Added tests for URL segment routing, header versioning, unsupported versions, and option binding.

## Validation

- Ran `dotnet build`.
```csharp
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (4.7s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (6.0s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (4.5s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll

Build succeeded in 17.2s
```
- Ran `dotnet test`.
```csharp
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.4s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.6s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.9s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.48]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.06]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.50]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:13.01]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (14.9s)

Test summary: total: 118, failed: 0, succeeded: 118, skipped: 0, duration: 14.9s
Build succeeded in 20.1s
```
## Release Note

Adds the initial API versioning foundation for controller-based APIs, including default v1 configuration, URL/header version readers, a sample versioned controller, tests, and documentation.

Closes #54