### PR TITLE
Harden template consumer scaffold and smoke-test package install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ env:
   DOTNET_VERSION: '10.0.x'
   CONFIGURATION: Release
   COVERAGE_THRESHOLD: '60'
+  SOLUTION_FILE: './NetCoreApplicationTemplate.slnx'
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
@@ -70,13 +71,13 @@ jobs:
         run: dotnet --info
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
 
       - name: Build solution
-        run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore
 
       - name: Verify formatting
-        run: dotnet format --verify-no-changes --verbosity minimal
+        run: dotnet format ${{ env.SOLUTION_FILE }} --verify-no-changes --verbosity minimal
 
       - name: Run tests
         shell: pwsh
@@ -255,13 +256,13 @@ jobs:
         shell: pwsh
         working-directory: ./artifacts/scaffold/ContosoSecurityPortal
         run: |
-          dotnet restore
-          dotnet build --configuration $env:CONFIGURATION --no-restore
+          dotnet restore ./ContosoSecurityPortal.slnx
+          dotnet build ./ContosoSecurityPortal.slnx --configuration $env:CONFIGURATION --no-restore
 
       - name: Test scaffolded output
         shell: pwsh
         working-directory: ./artifacts/scaffold/ContosoSecurityPortal
-        run: dotnet test --configuration $env:CONFIGURATION --no-build --verbosity normal
+        run: dotnet test ./ContosoSecurityPortal.slnx --configuration $env:CONFIGURATION --no-build --verbosity normal
 
       - name: Uninstall template package
         if: always()
@@ -293,10 +294,10 @@ jobs:
           build-mode: none
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
 
       - name: Build solution for CodeQL
-        run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,12 @@ jobs:
       - name: Uninstall template package
         if: always()
         shell: pwsh
-        run: dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+        run: |
+          dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+          if ($LASTEXITCODE -ne 0) {
+              Write-Host "Template package was not installed or was already removed. Continuing cleanup."
+              exit 0
+          }
 
   codeql-analysis:
     name: CodeQL analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
       - 'refactor/**'
       - 'test/**'
       - 'chore/**'
+    tags:
+      - 'v*.*.*'
 
   workflow_dispatch:
 
@@ -23,6 +25,7 @@ permissions:
 env:
   DOTNET_VERSION: '10.0.x'
   CONFIGURATION: Release
+  COVERAGE_THRESHOLD: '60'
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
@@ -72,7 +75,6 @@ jobs:
       - name: Build solution
         run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
 
-      # Optional: enable later once formatting/analyzer noise is cleaned up.
       - name: Verify formatting
         run: dotnet format --verify-no-changes --verbosity minimal
 
@@ -120,16 +122,16 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish coverage report artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: ./artifacts/coverage-report
           if-no-files-found: warn
 
-      - name: Enforce initial coverage threshold
+      - name: Enforce coverage threshold
         shell: pwsh
         run: |
-          $threshold = 60
+          $threshold = [double]$env:COVERAGE_THRESHOLD
           $coverageFile = Get-ChildItem -Path "./artifacts/coverage-report" -Recurse -Filter "*.xml" |
             Where-Object { $_.Name -match "Cobertura|coverage" } |
             Select-Object -First 1
@@ -144,11 +146,127 @@ jobs:
           $percentage = [math]::Round($lineRate * 100, 2)
 
           Write-Host "Line coverage: $percentage%"
+          Write-Host "Required line coverage threshold: $threshold%"
 
           if ($percentage -lt $threshold) {
               Write-Error "Coverage $percentage% is below required threshold of $threshold%."
               exit 1
           }
+
+  template-smoke-test:
+    name: Template smoke test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Pack template package
+        shell: pwsh
+        run: |
+          dotnet pack ./NetCoreApplicationTemplate.Template.csproj `
+            --configuration $env:CONFIGURATION `
+            --output ./artifacts/template-package
+
+      - name: Install template package
+        shell: pwsh
+        run: |
+          $package = Get-ChildItem -Path ./artifacts/template-package -Filter *.nupkg | Select-Object -First 1
+
+          if (-not $package) {
+              Write-Error "Template package was not created."
+              exit 1
+          }
+
+          dotnet new install $package.FullName
+          dotnet new list cdcavell-netcoreapp
+
+      - name: Scaffold consumer project
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path ./artifacts/scaffold -Force | Out-Null
+          dotnet new cdcavell-netcoreapp `
+            --name ContosoSecurityPortal `
+            --output ./artifacts/scaffold/ContosoSecurityPortal
+
+      - name: Validate scaffolded consumer output
+        shell: pwsh
+        run: |
+          $root = Resolve-Path ./artifacts/scaffold/ContosoSecurityPortal
+
+          $expected = @(
+            "README.md",
+            "LICENSE.txt",
+            "ASSETS-LICENSES.md",
+            "ContosoSecurityPortal.slnx",
+            "src/ContosoSecurityPortal.Web/ContosoSecurityPortal.Web.csproj",
+            "tests/ContosoSecurityPortal.Web.Tests/ContosoSecurityPortal.Web.Tests.csproj"
+          )
+
+          foreach ($path in $expected) {
+              $fullPath = Join-Path $root $path
+              if (-not (Test-Path $fullPath)) {
+                  Write-Error "Expected scaffolded path was missing: $path"
+                  exit 1
+              }
+          }
+
+          $forbidden = @(
+            ".github",
+            ".template.config",
+            ".template.content",
+            "docs",
+            "CHANGELOG.md",
+            "CITATION.cff",
+            "CONTRIBUTING.md",
+            "NetCoreApplicationTemplate.Template.csproj",
+            "PACKAGE-README.md",
+            "SECURITY.md"
+          )
+
+          foreach ($path in $forbidden) {
+              $fullPath = Join-Path $root $path
+              if (Test-Path $fullPath) {
+                  Write-Error "Maintainer-only path was scaffolded unexpectedly: $path"
+                  exit 1
+              }
+          }
+
+          $readme = Get-Content (Join-Path $root "README.md") -Raw
+          if ($readme -match "github.com/cdcavell/NetCoreApplicationTemplate/actions" -or $readme -match "Current release:") {
+              Write-Error "Generated README appears to contain repository maintainer content."
+              exit 1
+          }
+
+      - name: Build scaffolded output
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: |
+          dotnet restore
+          dotnet build --configuration $env:CONFIGURATION --no-restore
+
+      - name: Test scaffolded output
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: dotnet test --configuration $env:CONFIGURATION --no-build --verbosity normal
+
+      - name: Uninstall template package
+        if: always()
+        shell: pwsh
+        run: dotnet new uninstall CDCavell.NetCoreApplicationTemplate
 
   codeql-analysis:
     name: CodeQL analysis

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -20,6 +20,25 @@
     "language": "C#",
     "type": "project"
   },
+  "symbols": {
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Skips the post-create NuGet restore action when set to true."
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "ProjectTemplate.slnx"
+    },
+    {
+      "path": "src/ProjectTemplate.Web/ProjectTemplate.Web.csproj"
+    },
+    {
+      "path": "tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj"
+    }
+  ],
   "guids": [
     "1e92d402-e410-4f7f-8483-de6af17d61a2"
   ],
@@ -28,32 +47,65 @@
       "source": "./",
       "target": "./",
       "include": [
+        ".dockerignore",
         ".editorconfig",
         ".gitattributes",
         ".gitignore",
-        "LICENSE.txt",
         "ASSETS-LICENSES.md",
+        "Dockerfile",
+        "docker-compose.yml",
+        "LICENSE.txt",
         "NetCoreApplicationTemplate.slnx",
-        "src/**/*",
-        "tests/**/*",
-        "docs/**/*",
         "scripts/**/*",
-        ".github/**/*"
+        "src/**/*",
+        "tests/**/*"
       ],
       "exclude": [
         "**/[Bb]in/**",
         "**/[Oo]bj/**",
-        ".template.config/**/*",
+        ".git/**",
+        ".github/**",
+        ".template.config/**",
+        ".template.content/**",
+        "artifacts/**",
+        "docs/**",
         "**/*.filelist",
         "**/*.user",
         "**/*.suo",
         "**/*.lock.json",
         "**/Logs/**",
-        "**/*.log"
+        "**/*.log",
+        "CHANGELOG.md",
+        "CITATION.cff",
+        "CODE_OF_CONDUCT.md",
+        "CONTRIBUTING.md",
+        "NetCoreApplicationTemplate.Template.csproj",
+        "PACKAGE-README.md",
+        "SECURITY.md"
       ],
       "rename": {
         "NetCoreApplicationTemplate.slnx": "ProjectTemplate.slnx"
       }
+    },
+    {
+      "source": "./.template.content/",
+      "target": "./",
+      "include": [
+        "README.md"
+      ]
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by the generated project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore' from the generated solution directory."
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }

--- a/.template.content/README.md
+++ b/.template.content/README.md
@@ -1,0 +1,81 @@
+# ProjectTemplate
+
+ProjectTemplate is a scaffolded ASP.NET Core application created from the `cdcavell-netcoreapp` template.
+
+The generated solution includes a production-oriented baseline for common web application infrastructure concerns:
+
+- ASP.NET Core web application structure.
+- Centralized middleware organization.
+- Structured Serilog logging.
+- Security headers.
+- Forwarded headers and reverse proxy support.
+- Rate limiting.
+- Centralized exception and status-code handling.
+- Problem Details responses.
+- Authentication-ready and authorization-ready structure.
+- EF Core-ready data access structure.
+- Health checks.
+- Baseline automated tests.
+
+## Prerequisites
+
+- .NET SDK 10.0 or later.
+- Docker Desktop or a compatible container runtime, only if you plan to use Docker Compose.
+
+## Restore
+
+```powershell
+dotnet restore
+```
+
+## Build
+
+```powershell
+dotnet build --configuration Release
+```
+
+## Test
+
+```powershell
+dotnet test --configuration Release
+```
+
+## Run Locally
+
+```powershell
+dotnet run --project src/ProjectTemplate.Web
+```
+
+## Run with Docker Compose
+
+```powershell
+docker compose up --build
+```
+
+The Docker-hosted application is available at:
+
+```text
+http://localhost:8080
+```
+
+Health endpoints are available at:
+
+```text
+http://localhost:8080/health
+http://localhost:8080/health/ready
+http://localhost:8080/health/live
+```
+
+## Generated Content
+
+This scaffold intentionally includes source projects, baseline tests, Docker support, license files, and third-party asset notices.
+
+This scaffold intentionally excludes repository-maintainer files such as GitHub issue templates, release workflows, DocFX documentation source, ADRs, contribution policy, citation metadata, and release-management instructions.
+
+## License
+
+This generated project includes the template license in `LICENSE.txt`.
+
+Third-party asset and notice information is included in `ASSETS-LICENSES.md`.
+
+Review both files before publishing or redistributing an application created from this scaffold.

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <PackageId>CDCavell.NetCoreApplicationTemplate</PackageId>
+    <Title>.NET Core Application Template</Title>
+    <Authors>Christopher D. Cavell</Authors>
+    <Description>Production-oriented ASP.NET Core application template with structured logging, security headers, forwarded headers, rate limiting, centralized error handling, authentication-ready architecture, and EF Core-ready structure.</Description>
+    <PackageTags>dotnet-new;templates;aspnetcore;mvc;web;enterprise;security</PackageTags>
+    <PackageProjectUrl>https://github.com/cdcavell/NetCoreApplicationTemplate</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cdcavell/NetCoreApplicationTemplate</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
+    <VersionPrefix>0.4.2</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
+    <Version>$(VersionPrefix)</Version>
+    <PackageType>Template</PackageType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include=".dockerignore" Pack="true" PackagePath="content/" />
+    <Content Include=".editorconfig" Pack="true" PackagePath="content/" />
+    <Content Include=".gitattributes" Pack="true" PackagePath="content/" />
+    <Content Include=".gitignore" Pack="true" PackagePath="content/" />
+    <Content Include=".template.config/**/*" Pack="true" PackagePath="content/.template.config/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include=".template.content/**/*" Pack="true" PackagePath="content/.template.content/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include="ASSETS-LICENSES.md" Pack="true" PackagePath="content/" />
+    <Content Include="Dockerfile" Pack="true" PackagePath="content/" />
+    <Content Include="docker-compose.yml" Pack="true" PackagePath="content/" />
+    <Content Include="LICENSE.txt" Pack="true" PackagePath="content/" />
+    <Content Include="LICENSE.txt" Pack="true" PackagePath="" />
+    <Content Include="NetCoreApplicationTemplate.slnx" Pack="true" PackagePath="content/" />
+    <Content Include="PACKAGE-README.md" Pack="true" PackagePath="" />
+    <Content Include="scripts/**/*" Pack="true" PackagePath="content/scripts/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include="src/**/*" Pack="true" PackagePath="content/src/%(RecursiveDir)%(Filename)%(Extension)" Exclude="src/**/bin/**;src/**/obj/**;src/**/Logs/**" />
+    <Content Include="tests/**/*" Pack="true" PackagePath="content/tests/%(RecursiveDir)%(Filename)%(Extension)" Exclude="tests/**/bin/**;tests/**/obj/**;tests/**/Logs/**" />
+  </ItemGroup>
+
+</Project>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -18,6 +18,7 @@
     <PackageType>Template</PackageType>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeContentInPack>true</IncludeContentInPack>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <NoDefaultExcludes>true</NoDefaultExcludes>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -1,0 +1,40 @@
+# .NET Core Application Template Package
+
+This package installs the `cdcavell-netcoreapp` project template for `dotnet new`.
+
+## Install from a local package
+
+```powershell
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
+```
+
+## Generate a project
+
+```powershell
+dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
+```
+
+## Build and test generated output
+
+```powershell
+cd ContosoSecurityPortal
+dotnet restore
+dotnet build --configuration Release
+dotnet test --configuration Release
+```
+
+## Update
+
+Install the newer package version with `dotnet new install`.
+
+```powershell
+dotnet new install <path-or-package-id-for-new-version>
+```
+
+## Uninstall
+
+```powershell
+dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+```
+
+This package README is intended for template package distribution. Generated projects receive their own consumer README from the scaffold.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # .NET Core Application Template 
 [![CI](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/ci.yml/badge.svg)](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/ci.yml)
+[![Coverage Gate](https://img.shields.io/badge/coverage%20gate-60%25-brightgreen)](#github-actions)
 [![Documentation](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/publish-docs.yml)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://cdcavell.github.io/NetCoreApplicationTemplate/)
 [![GitHub Release](https://img.shields.io/github/v/release/cdcavell/NetCoreApplicationTemplate?display_name=tag)](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/latest)
@@ -8,7 +9,7 @@
 
 A reusable, production-oriented .NET application template designed to provide a secure, maintainable, and extensible baseline for building ASP.NET Core applications.
 
-This repository provides a working application baseline with common infrastructure concerns already organized, including middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, GitHub Actions validation, DocFX documentation, and local dotnet new template scaffold support, with NuGet package publishing planned for a future release.
+This repository provides a working application baseline with common infrastructure concerns already organized, including middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, GitHub Actions validation, DocFX documentation, and local dotnet new template scaffold support.
 
 ## Current Release
 
@@ -33,9 +34,8 @@ The template focuses on:
 - Baseline rate limiting and health checks.
 - Authentication-ready and authorization-ready structure.
 - EF Core data access patterns.
-- Automated build, test, coverage, and documentation workflows.
-- Local `dotnet new` template scaffold support, with NuGet package publishing planned for a future release.
-
+- Automated build, test, coverage, template smoke-test, and documentation workflows.
+- Local and package-based `dotnet new` template scaffold support.
 
 ## Who This Template Is For
 
@@ -76,7 +76,7 @@ The default ASP.NET Core templates are intentionally minimal. This repository st
 - Problem Details responses.
 - Authentication and authorization foundations.
 - EF Core provider structure.
-- CI validation and documentation publishing.
+- CI validation, template package smoke testing, and documentation publishing.
 - Repository governance files for public review and release readiness.
 
 ## Application Preview
@@ -85,7 +85,7 @@ The starter application includes a simple default Razor Pages landing page that 
 
 ![Application preview](docs/images/application-preview.svg)
 
-## Quick Start
+## Quick Start from Source
 
 Clone the repository:
 
@@ -93,31 +93,45 @@ Clone the repository:
 git clone https://github.com/cdcavell/NetCoreApplicationTemplate.git
 cd NetCoreApplicationTemplate
 ```
+
 Restore dependencies:
+
 ```powershell
 dotnet restore
 ```
+
 Build the solution:
+
 ```powershell
-dotnet build
+dotnet build --configuration Release
 ```
+
 Run tests:
+
 ```powershell
-dotnet test
+dotnet test --configuration Release
 ```
+
 Run the web application from source:
+
 ```powershell
 dotnet run --project src/ProjectTemplate.Web
 ```
+
 Run with Docker Compose:
+
 ```powershell
 docker compose up --build
 ```
+
 The Docker-hosted application is available at:
+
 ```powershell
 http://localhost:8080
 ```
+
 Docker health endpoints are available at:
+
 ```powershell
 http://localhost:8080/health
 http://localhost:8080/health/ready
@@ -126,24 +140,70 @@ http://localhost:8080/health/live
 
 ## Template Scaffold Status
 
-This repository currently includes a local `dotnet new` template scaffold through `.template.config/template.json`.
+This repository includes a `dotnet new` template scaffold through `.template.config/template.json` and a package project at `NetCoreApplicationTemplate.Template.csproj`.
 
-Current supported local workflow:
+The scaffolded consumer output intentionally includes:
+
+- Source projects under `src/`.
+- Baseline tests under `tests/`.
+- Docker support files.
+- `LICENSE.txt`.
+- `ASSETS-LICENSES.md`.
+- A consumer-oriented `README.md` generated from `.template.content/README.md`.
+
+The scaffolded consumer output intentionally excludes repository-maintainer content such as `.github/`, DocFX documentation source, ADRs, release-management files, citation metadata, contribution policy, security policy, and repository badges.
+
+### Pack and Install Locally
+
+Pack the template package:
+
+```powershell
+dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release --output ./artifacts/template-package
+```
+
+Install the generated package:
+
+```powershell
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
+```
+
+Generate a consumer project:
+
+```powershell
+dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
+```
+
+Build and test the generated output:
+
+```powershell
+cd ContosoSecurityPortal
+dotnet restore
+dotnet build --configuration Release
+dotnet test --configuration Release
+```
+
+Update the installed template by installing a newer package version:
+
+```powershell
+dotnet new install <path-or-package-id-for-new-version>
+```
+
+Uninstall the template package:
+
+```powershell
+dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+```
+
+### Local Repository Install
+
+For local development, the template can also be installed from the repository root:
 
 ```powershell
 dotnet new install .\
 dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
 ```
 
-The repository is not yet published as a NuGet template package. Future stable distribution is expected to use a published package install path such as:
-
-```powershell
-dotnet new install <published-template-package-id>
-dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
-```
-
-Until a package is published, local installation from the repository root should be treated as the supported preview/scaffold validation path.
-
+Package-based install remains the preferred validation path because it more closely matches consumer distribution.
 
 ## Documentation
 
@@ -186,6 +246,7 @@ Repository-level guidance is maintained in root-level files:
 - [Third-Party Asset Notices](ASSETS-LICENSES.md)
 
 ## Repository Structure
+
 ```text
 /
 ├── .github/
@@ -198,6 +259,9 @@ Repository-level guidance is maintained in root-level files:
 │
 ├── .template.config/
 │   └── dotnet new template metadata
+│
+├── .template.content/
+│   └── consumer scaffold content
 │
 ├── docs/
 │   ├── adr/
@@ -230,19 +294,28 @@ Repository-level guidance is maintained in root-level files:
 ├── docker-compose.yml
 ├── LICENSE.txt
 ├── NetCoreApplicationTemplate.slnx
+├── NetCoreApplicationTemplate.Template.csproj
+├── PACKAGE-README.md
 ├── README.md
 └── SECURITY.md
 ```
+
 ## Local Documentation Build
+
 Restore local tools:
+
 ```powershell
 dotnet tool restore
 ```
+
 Build the DocFX site:
+
 ```powershell
 dotnet tool run docfx -- docs/docfx.json
 ```
+
 Serve the generated site locally:
+
 ```powershell
 dotnet tool run docfx -- serve docs/_site
 ```
@@ -256,19 +329,28 @@ The repository currently includes workflows for:
 - Verifying formatting.
 - Running tests.
 - Generating test result and coverage artifacts.
-- Enforcing the initial coverage threshold.
+- Enforcing a 60% minimum line coverage threshold in CI.
+- Failing CI when coverage regresses below the threshold.
+- Packing the template package.
+- Installing the generated `.nupkg` into a clean SDK environment.
+- Scaffolding a consumer project with `dotnet new cdcavell-netcoreapp`.
+- Validating expected consumer files and excluded maintainer files.
+- Building and testing scaffolded output on Linux, Windows, and macOS.
 - Running CodeQL analysis.
 - Building and publishing DocFX documentation to GitHub Pages.
 
-The repository does not yet include an automated NuGet template package publishing workflow. Release publishing and package distribution remain part of the v1.0.0 readiness work.
+Template smoke testing runs on pull requests, supported branch pushes, manual workflow dispatch, and release-style version tags matching `v*.*.*`.
 
 See [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html), [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html), and [ADR-0003](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for details.
 
 ## Versioning
+
 This project follows Semantic Versioning using the format:
-```
+
+```text
 MAJOR.MINOR.PATCH
 ```
+
 Version numbers are centrally managed through project build metadata so assemblies, future packages, and releases can share a consistent version identity.
 
 See [ADR-0003: Record Release Surface and Distribution Strategy](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for the release-surface decision.
@@ -284,6 +366,7 @@ Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.4.2. MIT License. h
 ```
 
 ## Roadmap
+
 The project is being developed toward a reusable .NET application template. Future work may include additional provider modules, stronger packaging support, template parameterization, expanded examples, and release-ready template distribution.
 
 See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -1,45 +1,128 @@
 # Template Packaging
 
-This repository includes an initial `dotnet new` template scaffold.
+This repository includes a `dotnet new` template scaffold and a NuGet template package project.
 
-The scaffold allows the repository to be installed locally as a project template and used to generate a new application from the current source structure.
+The scaffold can be installed locally from source for development, or packed into a `.nupkg` and installed through the same package-based flow expected for consumers.
 
-## Install the Template Locally
+Package-based validation is preferred because it verifies the actual distribution artifact instead of only the repository working tree.
+
+## Template Identity
+
+| Field | Value |
+|:---|:---|
+| Template short name | `cdcavell-netcoreapp` |
+| Template package ID | `CDCavell.NetCoreApplicationTemplate` |
+| Source replacement token | `ProjectTemplate` |
+| Current package version | `0.4.2` |
+
+## Consumer Scaffold Boundaries
+
+The scaffolded output intentionally includes:
+
+- Source projects under `src/`.
+- Baseline tests under `tests/`.
+- Docker support files.
+- `LICENSE.txt`.
+- `ASSETS-LICENSES.md`.
+- A consumer-oriented `README.md` generated from `.template.content/README.md`.
+
+The scaffolded output intentionally excludes repository-maintainer content such as:
+
+- `.github/` workflow and issue-template files.
+- `.template.config/` and `.template.content/` authoring files.
+- DocFX documentation source and ADRs.
+- Changelog, citation, contribution, security, and release-management files.
+- Repository maintainer badges and release instructions.
+
+## Pack the Template Package
 
 From the repository root:
 
 ```powershell
-dotnet new install .\
+dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release --output ./artifacts/template-package
 ```
-On Linux or macOS:
-```bash
-dotnet new install ./
+
+## Install the Template Package
+
+```powershell
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
 ```
+
 ## Create a New Project from the Template
+
 From a separate working directory:
+
 ```powershell
 dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
 ```
-_For the initial template scaffold, use a project name that is also a valid C# identifier, such as `ContosoSecurityPortal`. Dotted project names require additional template symbol handling so namespace replacement and type-name replacement can be handled separately._
 
-This creates a new project using ContosoSecurityPortal as the replacement name for the source template namespace and project prefix.
-## Build the Generated Project
+Use a project name that is also a valid C# identifier, such as `ContosoSecurityPortal`. Dotted project names require additional template symbol handling so namespace replacement and type-name replacement can be handled separately.
+
+This creates a new project using `ContosoSecurityPortal` as the replacement name for the source template namespace and project prefix.
+
+## Restore, Build, and Test the Generated Project
+
 ```powershell
 cd ContosoSecurityPortal
-dotnet build
-dotnet test
+dotnet restore
+dotnet build --configuration Release
+dotnet test --configuration Release
 ```
 
-## Distribution Direction
+## Update the Installed Template
 
-The current scaffold supports local installation from the repository root. This is useful for development, validation, and preview use while the template is still being finalized.
+Install the newer package version:
+
+```powershell
+dotnet new install <path-or-package-id-for-new-version>
+```
+
+The .NET SDK updates the installed template package when the package identity matches and the new package version is higher.
+
+## Uninstall the Template
+
+```powershell
+dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+```
+
+## Local Repository Install
+
+For local authoring and quick iteration, the template can still be installed from the repository root.
+
+On Windows:
+
+```powershell
+dotnet new install .\
+```
+
+On Linux or macOS:
+
+```bash
+dotnet new install ./
+```
+
+Then generate from a separate working directory:
+
+```powershell
+dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
+```
+
+Local repository install is useful during template development, but package-based install should remain the primary validation path before release.
+
+## CI Smoke Test
+
+The CI workflow packs the template package, installs the generated `.nupkg`, scaffolds a new project with `dotnet new cdcavell-netcoreapp`, validates expected and forbidden scaffolded paths, builds the generated output, runs generated tests, and uninstalls the template package.
+
+The smoke test runs on Linux, Windows, and macOS so path handling and package install behavior are validated across supported runner environments.
+
+## Distribution Direction
 
 The intended stable distribution model is a published NuGet template package installable with `dotnet new install`.
 
 Future stable usage is expected to follow this pattern:
 
 ```powershell
-dotnet new install <published-template-package-id>
+dotnet new install CDCavell.NetCoreApplicationTemplate
 dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal
 ```
 


### PR DESCRIPTION
## Summary

- Updated `.template.config/template.json` with explicit symbols, primary outputs, consumer-safe scaffold sources, maintainer-file exclusions, and a restore post-action.
- Added a consumer-oriented scaffold README under `.template.content/README.md` so generated projects no longer inherit repository badges, release notes, or maintainer workflow guidance.
- Added `NetCoreApplicationTemplate.Template.csproj` and `PACKAGE-README.md` for package-based template validation and future package distribution.
- Added a cross-OS template smoke-test job that packs the template, installs the generated `.nupkg`, scaffolds a consumer project, validates expected/forbidden output, builds, tests, and uninstalls the template.
- Documented install, generate, build, test, update, and uninstall flows in the repository README and template packaging docs.
- Made the CI coverage threshold explicit through `COVERAGE_THRESHOLD` and documented the 60% gate in README.
- Fixed CI ambiguity by restoring/building explicit solution files and made template uninstall cleanup non-fatal when install did not occur.

## Validation

- GitHub Actions completed successfully for build validation, CodeQL analysis, and template smoke tests on Ubuntu, Windows, and macOS.

Closes #146
Closes #142