### PR TITLE
Fix documentation workflow restore ambiguity

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,6 +16,11 @@ concurrency:
   group: github-pages
   cancel-in-progress: false
 
+env:
+  CONFIGURATION: Release
+  DOTNET_VERSION: '10.0.x'
+  SOLUTION_FILE: './NetCoreApplicationTemplate.slnx'
+
 jobs:
   build-docs:
     name: Build documentation
@@ -28,13 +33,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore
 
       - name: Restore .NET tools
         run: dotnet tool restore


### PR DESCRIPTION
## Summary

- Updated the Publish Documentation workflow to restore and build the explicit solution file instead of relying on directory inference.
- Added workflow-level `CONFIGURATION`, `DOTNET_VERSION`, and `SOLUTION_FILE` environment values for consistency with CI.
- Prevents `MSB1011` after adding the root-level `NetCoreApplicationTemplate.Template.csproj` package project.

## Validation

- This change targets the failing GitHub Actions workflow path shown by the documentation build.
- The previous failure was `MSBUILD : error MSB1011` from bare `dotnet restore` after the repository root gained more than one project or solution candidate.

Related to #156