### PR TITLE
docs: finish community health and support lifecycle docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,45 @@
+# Repository ownership
+#
+# This project currently operates under a solo-maintainer ownership model.
+# Keep source, tests, documentation, workflows, template configuration, release,
+# and security/governance files owned by the repository maintainer until a
+# broader maintainer group is intentionally documented.
+
+* @cdcavell
+
+# Application source and tests
+/src/ @cdcavell
+/tests/ @cdcavell
+
+# Documentation and architecture decisions
+/docs/ @cdcavell
+README.md @cdcavell
+PACKAGE-README.md @cdcavell
+CHANGELOG.md @cdcavell
+
+# GitHub workflows, issue templates, and repository automation
+/.github/ @cdcavell
+/.github/workflows/ @cdcavell
+/.github/ISSUE_TEMPLATE/ @cdcavell
+/.github/CODEOWNERS @cdcavell
+
+# Template packaging and scaffold configuration
+/.template.config/ @cdcavell
+/.template.content/ @cdcavell
+NetCoreApplicationTemplate.Template.csproj @cdcavell
+Directory.Build.props @cdcavell
+Directory.Packages.props @cdcavell
+global.json @cdcavell
+nuget.config @cdcavell
+
+# Governance, security, release, citation, and archival metadata
+COMMUNITY_STANDARDS.md @cdcavell
+CONTRIBUTING.md @cdcavell
+MAINTAINERS.md @cdcavell
+RELEASE.md @cdcavell
+SECURITY.md @cdcavell
+SUPPORT.md @cdcavell
+CITATION.cff @cdcavell
+.zenodo.json @cdcavell
+LICENSE.txt @cdcavell
+ASSETS-LICENSES.md @cdcavell

--- a/COMMUNITY_STANDARDS.md
+++ b/COMMUNITY_STANDARDS.md
@@ -1,0 +1,55 @@
+# Community Standards
+
+NetCoreApplicationTemplate is a public, reusable ASP.NET Core application template maintained for practical software architecture, security-minded defaults, and release-ready template packaging.
+
+The project currently operates under a solo-maintainer model. Community participation is welcome when it keeps the template focused, respectful, reviewable, and useful to future consumers.
+
+## Expected Conduct
+
+Participants are expected to:
+
+- Communicate respectfully and assume good faith when possible.
+- Keep issues and pull requests focused on the repository's purpose.
+- Provide enough context for maintainers to reproduce bugs or evaluate proposals.
+- Respect maintainer decisions about scope, release timing, and project direction.
+- Avoid personal attacks, harassment, spam, or intentionally disruptive behavior.
+- Avoid posting secrets, private data, credentials, or sensitive operational details.
+
+## Project Scope
+
+Good-fit contributions include:
+
+- Security, reliability, and maintainability improvements.
+- Documentation fixes and practical usage guidance.
+- Template packaging, scaffold, and release-process improvements.
+- Tests that improve confidence in generated output or runtime behavior.
+- Focused issues that identify a reproducible gap in the template baseline.
+
+Out-of-scope contributions may be closed or redirected, including:
+
+- Large framework rewrites that change the template's purpose.
+- Application-specific business logic that belongs in a consuming project.
+- Unreviewable pull requests that mix unrelated changes.
+- Support requests that require private production access or environment-specific debugging.
+- Promotional, abusive, or off-topic discussions.
+
+## Issue and Discussion Tone
+
+Issues should describe the problem, expected behavior, actual behavior, and relevant environment details when applicable.
+
+Feature requests should explain the consumer scenario and why the behavior belongs in the reusable template rather than in a downstream application.
+
+Security issues should not be reported publicly. Follow [SECURITY.md](SECURITY.md) for vulnerability reporting.
+
+## Enforcement
+
+The maintainer may edit, hide, lock, or remove disruptive content; close issues or pull requests that are out of scope; and block participation when behavior creates risk for the project or its users.
+
+The goal is not to over-police normal disagreement. The goal is to keep the repository safe, useful, and maintainable.
+
+## Related Documents
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [SECURITY.md](SECURITY.md)
+- [SUPPORT.md](SUPPORT.md)
+- [MAINTAINERS.md](MAINTAINERS.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@ Thank you for helping improve the .NET Core Application Template.
 
 This project is intended to remain a clean, reusable, production-oriented ASP.NET Core baseline. Contributions should preserve that goal by keeping changes focused, documented, and easy to review.
 
+## Community Standards
+
+Participation in this repository is governed by [COMMUNITY_STANDARDS.md](COMMUNITY_STANDARDS.md).
+
+Contributors should keep discussions respectful, focused on the project scope, and safe for public review.
+
 ## Contribution Principles
 
 Contributions should favor:
@@ -42,6 +48,20 @@ Recommended flow:
 
 If work is exploratory or only partially addresses an issue, use `Related to #<issue-number>` instead of a closing keyword.
 
+## Issue Triage Expectations
+
+Issues are triaged on a best-effort basis by the maintainer.
+
+Triage considers:
+
+- Whether the issue is reproducible from the repository or generated template output.
+- Whether the issue is a security, release, packaging, documentation, or runtime concern.
+- Whether the behavior belongs in the reusable template rather than in a downstream application.
+- Whether the report includes enough details to act on.
+- Whether the proposed change can be validated by CI, tests, documentation review, or release checklist review.
+
+Issues may be closed when they are duplicated, stale, unreproducible, out of scope, missing required information, or specific to a consuming application's custom deployment.
+
 ## Branch Naming
 
 Use short branch names that include the issue number and the type of work.
@@ -57,40 +77,9 @@ test/issue-<issue-number>-short-description
 chore/issue-<issue-number>-short-description
 ```
 
-Examples:
-
-```text
-feature/issue-42-add-sample-endpoint
-fix/issue-43-correct-header-order
-docs/issue-44-update-data-access-docs
-refactor/issue-45-simplify-options-validation
-test/issue-46-add-rate-limit-tests
-chore/issue-47-update-dependencies
-```
-
-Use `docs/` for documentation-only changes and `chore/` for maintenance work such as dependency or workflow updates.
-
 ## Commit Messages
 
-Use concise imperative commit messages.
-
-Recommended examples:
-
-```text
-Add application README scaffold #12
-Configure Serilog request logging #3
-Implement security header middleware #7
-Add EF Core SQLite provider #19
-Document deployment guidance #38
-Add Dependabot configuration #56
-```
-
-Guidelines:
-
-- Start with a verb such as `Add`, `Fix`, `Update`, `Document`, `Configure`, or `Refactor`.
-- Include the issue number when practical.
-- Keep the subject line focused on the actual change.
-- Avoid vague messages such as `misc fixes` or `updates`.
+Use concise imperative commit messages. Start with a verb such as `Add`, `Fix`, `Update`, `Document`, `Configure`, or `Refactor`, and include the issue number when practical.
 
 ## Pull Request Expectations
 
@@ -101,31 +90,22 @@ Pull requests should include:
 - A closing issue reference when the work completes an issue.
 - Notes about behavior changes, migration steps, or deployment impact when relevant.
 
-Recommended pull request structure:
+Documentation-only changes may use a lighter validation note that states the change was documentation-only and links were reviewed.
 
-```markdown
-## Summary
+## Pull Request Triage Expectations
 
-- Added ...
-- Updated ...
-- Documented ...
+Pull requests are reviewed for scope, CI health, maintainability, and release impact.
 
-## Validation
+Before merge, the maintainer reviews whether:
 
-- Ran `dotnet build --configuration Release`.
-- Ran `dotnet test --configuration Release`.
+- The pull request matches the linked issue or stated purpose.
+- Required checks pass.
+- Documentation is updated when behavior, packaging, governance, or workflow expectations change.
+- Security-sensitive changes preserve safe defaults.
+- Template packaging changes preserve expected scaffolded output.
+- Release, workflow, security, and governance changes receive deliberate maintainer review.
 
-Closes #<issue-number>
-```
-
-Documentation-only changes may use a lighter validation note:
-
-```markdown
-## Validation
-
-- Documentation-only change.
-- Reviewed links and DocFX navigation scope.
-```
+Pull requests may be returned for revision when they are too broad, mix unrelated changes, lack validation, bypass documented release expectations, or create unclear downstream behavior.
 
 ## Validation Expectations
 
@@ -143,39 +123,17 @@ For formatting-sensitive changes, run:
 dotnet format --verify-no-changes --verbosity minimal
 ```
 
-For documentation changes, validate that:
-
-- New pages are included in DocFX navigation when needed.
-- Links work in the published documentation structure.
-- Examples do not include production secrets.
-- Runtime behavior is not changed unintentionally.
+For documentation changes, validate that new pages are included in navigation when needed, links work, examples are safe for public use, and runtime behavior is not changed unintentionally.
 
 ## Documentation Expectations
 
-Update documentation when a change affects:
-
-- Configuration behavior.
-- Middleware ordering.
-- Security defaults.
-- Authentication or authorization behavior.
-- Data access setup.
-- Deployment expectations.
-- GitHub workflow or release process.
-- Template packaging behavior.
+Update documentation when a change affects configuration behavior, middleware ordering, security defaults, authentication, authorization, data access, deployment, GitHub workflow, release process, or template packaging behavior.
 
 Long-term architectural decisions should be captured in an Architecture Decision Record under `docs/adr`.
 
 ## Dependency Update Expectations
 
-Dependency update pull requests should be reviewed like other pull requests.
-
-Before merging dependency updates:
-
-- Confirm CI passes.
-- Review release notes for major updates.
-- Treat security updates as higher priority.
-- Be careful with authentication, EF Core, middleware, logging, telemetry, and GitHub Actions updates.
-- Prefer separate review for major updates that may affect runtime behavior.
+Dependency update pull requests should be reviewed like other pull requests. Confirm CI passes, review release notes for major updates, treat security updates as higher priority, and be careful with authentication, EF Core, middleware, logging, telemetry, and GitHub Actions updates.
 
 ## Branch Cleanup
 
@@ -188,20 +146,9 @@ git fetch --prune
 git branch --merged
 ```
 
-Delete stale local branches only after confirming the work has been merged or is no longer needed.
-
 ## Security Notes
 
-Do not commit:
-
-- Production connection strings.
-- Client secrets.
-- API keys.
-- Signing keys or certificates.
-- Private endpoint values.
-- Generated secrets or tokens.
-
-Use environment variables, user secrets, or approved secret stores for sensitive values.
+Do not commit private operational values or credentials. Use environment variables, user secrets, or approved secret stores for sensitive configuration.
 
 ## Solo-Maintainer Hardening Profile
 
@@ -217,30 +164,18 @@ The following controls should be enabled before merging the first external pull 
 - Review of branch protection settings for `main` and any long-lived development branch.
 - Review of repository secrets, environment secrets, and package publishing permissions.
 
-Trigger conditions for moving beyond the solo-maintainer profile include:
-
-- First external pull request.
-- First repository collaborator.
-- First automated package publishing workflow.
-- First automated container image publishing workflow.
-- A confirmed credential exposure.
-- Repeated high-risk Dependabot, CodeQL, or Dependency Review findings.
+Trigger conditions for moving beyond the solo-maintainer profile include the first external pull request, first repository collaborator, first automated package publishing workflow, first automated container image publishing workflow, a confirmed credential exposure, or repeated high-risk dependency/security findings.
 
 ## GitHub Actions Supply-Chain Policy
 
-GitHub Actions workflows should follow these rules:
-
-- Use explicit workflow or job-level `permissions`.
-- Default to `contents: read` unless a job requires additional permissions.
-- Do not place plaintext credentials in workflow files.
-- Use repository or environment secrets for publish credentials.
-- Pin third-party and first-party actions to full commit SHAs when practical.
-- Preserve a version comment beside each pinned action SHA for maintainability.
-- Let Dependabot monitor GitHub Actions updates.
-- Review action updates before merging, especially actions with write permissions, release permissions, package publishing permissions, or identity-token permissions.
+GitHub Actions workflows should use explicit workflow or job-level permissions, default to read-only access unless more is required, use repository or environment secrets for publish credentials, pin actions to full commit SHAs when practical, and review action updates before merging.
 
 ## Related Documentation
 
+- [Community Standards](COMMUNITY_STANDARDS.md)
+- [Support Policy](SUPPORT.md)
+- [Maintainers](MAINTAINERS.md)
+- [Security Policy](SECURITY.md)
 - [GitHub Workflow](docs/articles/github-workflow.md)
 - [Configuration](docs/articles/configuration.md)
 - [Deployment Notes](docs/articles/deployment.md)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,79 @@
+# Maintainers
+
+NetCoreApplicationTemplate currently operates under a solo-maintainer model.
+
+## Current Maintainer
+
+| Maintainer | Role |
+|:---|:---|
+| [@cdcavell](https://github.com/cdcavell) | Repository owner, release owner, package publishing owner, documentation owner |
+
+## Maintainer Responsibilities
+
+The maintainer is responsible for:
+
+- Reviewing and merging pull requests.
+- Maintaining branch protection expectations for `main`.
+- Reviewing workflow, security, release, and template packaging changes.
+- Approving package publication through protected GitHub environments.
+- Managing NuGet package identity and publish credentials.
+- Managing GitHub release and Zenodo archival sequencing.
+- Reviewing vulnerability reports and coordinating security fixes.
+- Keeping release, support, and contribution documentation current.
+
+## Release Cadence
+
+This project does not promise a fixed release calendar.
+
+Expected release behavior:
+
+- Patch releases may be created for security fixes, packaging corrections, documentation-critical fixes, or small compatible improvements.
+- Minor releases may be created for compatible template improvements, new supported options, or expanded documentation.
+- Major releases may be created for breaking template behavior, supported framework changes, major packaging changes, or significant governance changes.
+- Pre-1.0 releases remain preview-quality and may change more frequently.
+- `v1.0.0` represents the first stable support baseline for consumers.
+
+Release timing depends on issue readiness, CI health, package validation, documentation readiness, and maintainer availability.
+
+## Publishing Ownership
+
+Official release artifacts are published only by the maintainer-controlled release workflow.
+
+Publishing ownership includes:
+
+- NuGet package publication for `CDCavell.NetCoreApplicationTemplate`.
+- GitHub Releases and release notes.
+- Zenodo archival metadata and DOI-bearing GitHub releases.
+- GitHub Container Registry publication when container releases are used.
+- Release checklist approval documented in [RELEASE.md](RELEASE.md).
+
+External contributors are not expected to sign or publish package artifacts. If NuGet package signing is introduced later, signing should use a project-controlled signing certificate and protected release workflow.
+
+## Branch Protection Expectations
+
+The `main` branch is the stable integration branch and should be protected.
+
+Expected `main` branch controls include:
+
+- Changes flow through pull requests instead of direct pushes.
+- Required status checks must pass before merge.
+- Branches should be current enough to merge cleanly.
+- Linear history or squash/rebase merge strategy should be preserved according to repository settings.
+- Administrative bypass should be avoided for normal development.
+- Workflow, release, security, package, and governance changes should receive deliberate maintainer review.
+- CODEOWNERS review should be enabled before adding collaborators or accepting external pull requests.
+- Required signed commits should be considered before adding collaborators or accepting external pull requests.
+
+## Adding Maintainers
+
+Additional maintainers should not be added casually. Before expanding maintainership, review:
+
+- Repository permissions.
+- Branch protection rules.
+- Environment protection rules.
+- NuGet and GitHub Packages publishing permissions.
+- Secret access.
+- CODEOWNERS coverage.
+- Security reporting and release ownership expectations.
+
+Update this file when maintainer ownership changes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,14 @@
 
 ## Supported Versions
 
-Security fixes are applied to the current active development line unless otherwise noted in a release announcement.
+Security fixes are applied to the current stable line unless otherwise noted in a release announcement.
 
-| Version | Supported |
-|:---|:---|
-| Current release | Yes |
-| Older releases | Best effort |
+| Version line | Supported | Notes |
+|:---|:---:|:---|
+| `1.0.x` | Yes | Supported after `v1.0.0` for reproducible security fixes and critical template defects. |
+| Pre-1.0 releases | Best effort | Preview releases are not guaranteed to receive backported security fixes. Upgrade to the current stable release when practical. |
+| Older releases | Best effort | Support depends on severity, reproducibility, release impact, and maintainer availability. |
+| `main` | Development | The development branch is not a supported release line. |
 
 ## Reporting a Vulnerability
 
@@ -27,9 +29,9 @@ When reporting a vulnerability, include:
 
 Please allow reasonable time for review and remediation before publicly discussing a suspected vulnerability.
 
-This project is a reusable application. Security reports should distinguish between:
+This project is a reusable application template. Security reports should distinguish between:
 
-- Issues in the application's default behavior.
+- Issues in the template's default behavior.
 - Issues introduced by a consuming application's custom configuration or deployment environment.
 - General dependency vulnerabilities already tracked by upstream packages or GitHub alerts.
 
@@ -45,6 +47,7 @@ Areas especially relevant to this application include:
 - Data access configuration.
 - Secret handling and configuration examples.
 - GitHub Actions workflow behavior.
+- Template packaging and release workflow behavior.
 
 Do not include production secrets, private keys, tokens, passwords, or sensitive personal data in a report.
 
@@ -71,8 +74,15 @@ Repository and environment secrets must be scoped to the narrowest workflow that
 | Secret or permission | Intended use | Scope expectation |
 |:---|:---|:---|
 | `GITHUB_TOKEN` | Built-in workflow token | Use explicit workflow or job-level permissions. Default to `contents: read` unless a job needs more. |
-| `NUGET_API_KEY` | Future NuGet package publishing | Store only as a GitHub Actions secret or protected environment secret. Do not expose to pull requests from forks. Rotate after suspected exposure. |
-| Package publishing permissions | Future package release workflow | Limit to release or manual publish workflows. Do not grant publish permissions to normal CI validation jobs. |
-| Release permissions | Future GitHub release automation | Grant `contents: write` only to the workflow/job that creates or updates releases. |
+| `NUGET_API_KEY` | NuGet package publishing | Store only as a GitHub Actions secret or protected environment secret. Do not expose to pull requests from forks. Rotate after suspected exposure. |
+| Package publishing permissions | Package release workflow | Limit to release or manual publish workflows. Do not grant publish permissions to normal CI validation jobs. |
+| Release permissions | GitHub release automation | Grant `contents: write` only to the workflow/job that creates or updates releases. |
 
 Plaintext credentials are not allowed in workflow files, repository files, examples, documentation, screenshots, or committed logs.
+
+## Related Documents
+
+- [SUPPORT.md](SUPPORT.md)
+- [MAINTAINERS.md](MAINTAINERS.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [RELEASE.md](RELEASE.md)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,62 @@
+# Support Policy
+
+This project provides a reusable ASP.NET Core application template. Support is focused on the template source, generated scaffold behavior, documentation, packaging, and release artifacts maintained in this repository.
+
+## Support Channels
+
+Use GitHub issues for:
+
+- Reproducible bugs in the template source or generated scaffold output.
+- Documentation gaps or incorrect examples.
+- Template packaging, installation, or `dotnet new` scaffold issues.
+- Security-adjacent behavior that is not a private vulnerability report.
+- Focused feature requests that improve the reusable baseline.
+
+Use the private vulnerability reporting process described in [SECURITY.md](SECURITY.md) for suspected vulnerabilities.
+
+## Support Expectations After v1.0.0
+
+After `v1.0.0`, support is provided on a best-effort basis by the repository maintainer.
+
+Users can expect:
+
+- Public issue triage when enough information is provided.
+- Security reports to receive higher priority than general feature requests.
+- Reproducible template defects to be prioritized over application-specific customization requests.
+- Documentation fixes to be accepted when they clarify supported usage.
+- Patch releases when a fix is appropriate for the current stable line.
+
+Users should not expect:
+
+- Guaranteed service-level agreements or response times.
+- Private consulting, production incident response, or environment-specific debugging.
+- Backports to every historical pre-1.0 release.
+- Support for heavily modified downstream applications unless the issue reproduces from the template baseline.
+- Support for unsupported .NET SDK versions or package versions outside the documented release line.
+
+## Version Support Lifecycle
+
+| Version line | Support expectation |
+|:---|:---|
+| `1.0.x` | Supported after `v1.0.0` for reproducible defects and security fixes. |
+| Pre-1.0 releases | Best effort only. Consumers should upgrade to the current stable release when practical. |
+| Older 1.x releases after a newer minor release | Best effort unless a release note states otherwise. |
+| Unreleased `main` branch | Development line only. Behavior may change before the next release. |
+
+## Issue Triage
+
+Issues are generally reviewed for:
+
+1. Reproducibility.
+2. Security or release impact.
+3. Whether the behavior belongs in the reusable template.
+4. Whether the report includes enough detail to act on.
+5. Whether the fix can be safely validated by CI, tests, or documentation review.
+
+Maintainers may close issues that are stale, unreproducible, out of scope, duplicated, or specific to a downstream application customization.
+
+## Pull Request Support
+
+Pull requests should follow [CONTRIBUTING.md](CONTRIBUTING.md). Maintainer review is required before merge.
+
+Large or broad pull requests may be redirected into smaller issues. Pull requests that change release, security, workflow, template packaging, or governance behavior may require additional review even when CI passes.


### PR DESCRIPTION
## Summary

- Adds repository owner coverage through CODEOWNERS.
- Adds community standards, support, and maintainer documentation.
- Updates contribution guidance with issue and pull request triage expectations.
- Updates the security policy with supported version expectations.
- Documents release cadence, publishing ownership, and main branch protection expectations.

## Validation

- Documentation-only change.
- Reviewed issue acceptance criteria.

Closes #150