### PR TITLE
docs: verify runtime readiness baseline

### DIFF
--- a/docs/articles/authorization.md
+++ b/docs/articles/authorization.md
@@ -8,9 +8,9 @@ Default policy names:
 
 | Policy | Purpose |
 |---|---|
-| `ProjectTemplate.AuthenticatedUser` | Requires an authenticated user. |
-| `ProjectTemplate.Role.Administrator` | Requires a normalized role claim. |
-| `ProjectTemplate.Permission.ManageApplication` | Requires a normalized permission claim. |
+| `application.AuthenticatedUser` | Requires an authenticated user. |
+| `application.Role.Administrator` | Requires a normalized role claim. |
+| `application.Permission.ManageApplication` | Requires a normalized permission claim. |
 
 Default normalized claim types:
 
@@ -35,11 +35,27 @@ Configuration example:
   }
 }
 ```
-Example usage:
-```csharp
-[Authorize(Policy = ApplicationAuthorizationPolicyNames.AdministratorRole)]
-public IActionResult AdminOnly()
-{
-    return View();
-}
-```
+
+## Default Authorization Posture
+
+The template registers named policies but does not force every endpoint to require authorization by default.
+
+Application authors should apply authorization intentionally at the controller, Razor Page, endpoint, folder, or convention level. This keeps the base template runnable while still providing clear policy names for protected application areas.
+
+For production applications, review whether a fallback policy or broader default authorization convention should be added by the consuming application.
+
+## Sample Policy Purposes
+
+| Policy constant | Policy name | Recommended use |
+|:---|:---|:---|
+| `ApplicationAuthorizationPolicyNames.AuthenticatedUser` | `application.AuthenticatedUser` | Protect pages or endpoints that require any signed-in user. |
+| `ApplicationAuthorizationPolicyNames.AdministratorRole` | `application.Role.Administrator` | Protect administrative UI or operations. |
+| `ApplicationAuthorizationPolicyNames.ManageApplicationPermission` | `application.Permission.ManageApplication` | Protect management actions that should be permission-driven rather than purely role-driven. |
+
+## Claims Normalization Relationship
+
+Authorization policies are designed to work with the claims transformation layer documented in [Authentication](authentication.md).
+
+External providers often emit different role, group, permission, or scope claim names. The template can normalize these claims into application-owned claim names so authorization policies can remain stable across providers.
+
+See [Runtime Readiness Baseline](runtime-readiness.md) for the consolidated release-readiness view.

--- a/docs/articles/error-handling.md
+++ b/docs/articles/error-handling.md
@@ -7,29 +7,37 @@ Error handling is configured through the application pipeline using:
 ```csharp
 app.UseApplicationErrorHandling();
 ```
+
 The error handling behavior is environment-aware:
 
 - In Development, the application uses the developer exception page.
 - In non-development environments, unhandled exceptions are routed to `/Home/Error/500`.
-- HTTP status code responses are re-executed through `/Home/Error/{statusCode}`.
-- Error responses are user-safe and do not expose exception details.
+- HTTP status code responses are re-executed through `/Home/Error/{statusCode}` for browser-oriented requests.
+- API, AJAX, and JSON-oriented requests receive Problem Details responses.
+- Error responses are user-safe and do not expose exception details in production.
 - Error events are logged using source-generated `LoggerMessage` methods.
 - The request ID displayed on the error page matches the request ID written to the application logs.
 
 ## Status Code Pages
 
 Status code pages are handled centrally using:
+
 ```csharp
 app.UseStatusCodePagesWithReExecute("/Home/Error/{0}");
 ```
-This allows common HTTP responses such as `404 Not Found`, `401 Unauthorized`, `403 Forbidden`, and `429 Too Many Requests` to use the shared error page strategy.
+
+This allows common HTTP responses such as `404 Not Found`, `401 Unauthorized`, `403 Forbidden`, and `429 Too Many Requests` to use the shared error page strategy for browser-oriented requests.
+
+Problem Details requests use ASP.NET Core status code pages without re-executing the browser error page.
 
 ## Unhandled Exceptions
 
 In non-development environments, unhandled exceptions are routed through:
+
 ```csharp
 app.UseExceptionHandler("/Home/Error/500");
 ```
+
 This allows unhandled exceptions to be logged and displayed using the shared error page strategy without exposing sensitive exception details to end users.
 
 ## Request ID Correlation
@@ -37,25 +45,30 @@ This allows unhandled exceptions to be logged and displayed using the shared err
 The error page displays the same request ID that is written to the log entry.
 
 Example browser output:
+
 ```text
 Request ID: 0HNL9ADUFCPUT:00000009
 ```
+
 Example log output:
+
 ```text
 Status code page routed to error page. StatusCode: 404; OriginalPath: /invalid; RemoteIpAddress: ::1; RequestId: 0HNL9ADUFCPUT:00000009
 ```
+
 This makes it easier to match a user-facing error page with the corresponding application log entry.
 
 ## Logging
 
 Error handling logs include:
+
 - Status code routed to the error page.
 - Original request path.
 - Remote IP address when available.
 - Request ID.
 - Exception details for unhandled exceptions.
 
-Log event IDs are centralized in ApplicationLogEventIds to keep application logging consistent.
+Log event IDs are centralized in `ApplicationLogEventIds` to keep application logging consistent.
 
 ## Centralized Problem Details Error Handling
 
@@ -65,12 +78,24 @@ Browser requests are routed to the standard application error page, such as `/Ho
 
 Problem Details responses include safe metadata such as:
 
-- HTTP status code
-- Error title
-- Request path
-- Trace ID
-- Request ID
+- HTTP status code.
+- Error title.
+- Request path.
+- Trace ID.
+- Request ID.
 
-Detailed exception information is only exposed in the Development environment. Production responses avoid leaking stack traces, exception messages, connection details, or internal implementation information.
+Detailed exception information is only exposed in the Development environment. Production responses avoid leaking stack traces, exception messages, connection details, secret values, provider metadata, or internal implementation information.
 
 Unhandled exceptions are logged centrally and converted into safe Problem Details responses when the request expects JSON.
+
+## Production Response Safety
+
+For server-side failures in non-development environments, Problem Details responses use a generic detail message:
+
+```text
+An unexpected error occurred. Contact support with the request ID.
+```
+
+This message gives operators a correlation handle without exposing application internals to the client. Full exception details remain in server-side logs, subject to logging configuration and secret-handling policy.
+
+See [Runtime Readiness Baseline](runtime-readiness.md) for the consolidated release-readiness view.

--- a/docs/articles/logging.md
+++ b/docs/articles/logging.md
@@ -5,76 +5,124 @@ This application uses Serilog for structured application logging.
 Serilog is configured as the primary logging provider so that application events, startup events, errors, and HTTP request activity are written using a consistent structured format.
 
 ## Bootstrap Logging
+
 The application logs a bootstrap message when the web application begins provider configuration:
+
 ```csharp
 Log.Information("Bootstrapping ProjectTemplate.Web application");
 ```
 
 ## Startup Logging
+
 The application logs a startup message when the web application begins initialization:
+
 ```csharp
 Log.Information("Starting ProjectTemplate.Web application");
 ```
 
 ## Pipeline Logging 
+
 The application logs a startup message when the web application begins configuring the middleware pipeline:
+
 ```csharp
 Log.Information("Configuring pipeline for ProjectTemplate.Web application");
 ```
 
 ## Runtime Logging
+
 The application logs a startup message when the web application begins running:
+
 ```csharp
 Log.Information("Running ProjectTemplate.Web application");
 ```
 
 ## Ongoing Application Logging
+
 While the application is running, structured logs are written for normal application activity, warnings, errors, and HTTP request processing. These logs help provide visibility into the current behavior of the application without requiring a debugger to be attached.
 
 Runtime logging may include:
 
-- Application lifecycle events
-- Controller or endpoint activity
-- HTTP request completion details
-- Warnings from expected but noteworthy conditions
-- Exceptions and unexpected failures
-- Framework or infrastructure messages based on configured log levels
+- Application lifecycle events.
+- Controller or endpoint activity.
+- HTTP request completion details.
+- Warnings from expected but noteworthy conditions.
+- Exceptions and unexpected failures.
+- Framework or infrastructure messages based on configured log levels.
 
 The default logging configuration is intended to capture useful operational information while avoiding sensitive data such as passwords, authentication tokens, cookies, request bodies, and response bodies.
 
-Additional logging can be added throughout the application by injecting ILogger<T> into services, controllers, middleware, or other application components.
+Additional logging can be added throughout the application by injecting `ILogger<T>` into services, controllers, middleware, or other application components.
+
+## Production Log-Level Defaults
+
+The default production-oriented log-level posture is configured in `appsettings.json`:
+
+| Source | Default level |
+|:---|:---|
+| Application | `Information` |
+| `Microsoft` | `Warning` |
+| `Microsoft.AspNetCore` | `Warning` |
+| `Microsoft.AspNetCore.Hosting` | `Warning` |
+| `Microsoft.AspNetCore.Mvc` | `Warning` |
+| `Microsoft.AspNetCore.Routing` | `Warning` |
+| `System` | `Warning` |
+
+This keeps normal application lifecycle and request activity visible while reducing framework noise. Production applications should tune these levels according to environment, hosting platform, alerting needs, and incident-response requirements.
+
+## Structured Output Format
+
+The console sink writes structured messages with this default template:
+
+```text
+[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}
+```
+
+The rolling file sink writes structured messages with this default template:
+
+```text
+[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}
+```
+
+The default file sink writes to `Logs/application-web-.log`, rolls daily, keeps 14 retained files, and rolls when the file reaches the configured size limit.
 
 ## Bootstrap Exception Logging
+
 The application logs any exceptions that occur during the bootstrapping process or while configuring the middleware pipeline:
+
 ```csharp
 Log.Fatal(ex, "ProjectTemplate.Web application terminated unexpectedly");
 ```
+
 ## Structured Request Logging
 
 The application includes structured HTTP request logging through Serilog.
 
 Request logging records a single completion event for each normal request and includes:
 
-- HTTP method
-- Request path
-- Response status code
-- Elapsed request duration
-- Request ID
-- Correlation ID
-- Request scheme and host
-- Remote IP address, when enabled
-- Authenticated user name, when enabled
+- HTTP method.
+- Request path.
+- Response status code.
+- Elapsed request duration.
+- Request ID.
+- Correlation ID.
+- Request scheme and host.
+- Remote IP address, when enabled.
+- Authenticated user name, when enabled.
 
 Request logging is configured through:
 
 ```csharp
 builder.Services.AddApplicationRequestLogging(builder.Configuration);
 ```
+
 And applied through the standard application pipeline:
+
 ```csharp
 app.UseApplicationRequestLogging();
 ```
+
 Configuration is controlled through `appsettings.json`:
+
 ```json
 "ProjectTemplate": {
   "RequestLogging": {
@@ -95,4 +143,7 @@ Configuration is controlled through `appsettings.json`:
   }
 }
 ```
+
 Query string logging is disabled by default because query strings may contain sensitive values. Applications should avoid logging request bodies, response bodies, cookies, authorization headers, access tokens, refresh tokens, or authentication payloads unless a specific, reviewed diagnostic need exists.
+
+See [Runtime Readiness Baseline](runtime-readiness.md) for the consolidated release-readiness view.

--- a/docs/articles/rate-limiting.md
+++ b/docs/articles/rate-limiting.md
@@ -1,4 +1,5 @@
 # Rate Limiting
+
 The application includes baseline ASP.NET Core rate limiting support to help protect applications from accidental request floods, scraping, repeated automated requests, and concurrency-heavy operations.
 
 Rate limiting is registered through the application service extension:
@@ -6,13 +7,17 @@ Rate limiting is registered through the application service extension:
 ```csharp
 builder.Services.AddApplicationRateLimiting(builder.Configuration, builder.Environment);
 ```
+
 The middleware is applied in the standard application pipeline:
+
 ```csharp
 app.UseRateLimiter();
 ```
+
 `UseRateLimiter()` is intentionally placed after routing so endpoint-specific rate limiting policies can be applied, and before endpoint execution so requests can be rejected before reaching controllers, Razor Pages, or minimal API handlers.
 
 ## Default Behavior
+
 The application supports:
 
 - A global fixed-window limiter for baseline request protection.
@@ -23,6 +28,7 @@ The application supports:
 - Logging for rejected requests.
 
 Rejected requests return a response similar to:
+
 ```json
 {
   "error": "Too many requests.",
@@ -31,7 +37,9 @@ Rejected requests return a response similar to:
 ```
 
 ## Configuration
+
 Rate limiting values can be configured from `appsettings.json`:
+
 ```json
 "ProjectTemplate": {
   "RateLimiting": {
@@ -54,22 +62,29 @@ Rate limiting values can be configured from `appsettings.json`:
   }
 }
 ```
+
 These defaults are intentionally conservative and should be reviewed before production use.
 
 ## Endpoint-Specific Policies
+
 Named policies can be applied to specific endpoints when stricter or specialized protection is needed.
 
 Minimal API example:
+
 ```csharp
 app.MapGet("/api/data", () => "Limited endpoint")
     .RequireRateLimiting("fixed");
 ```
+
 Concurrency-sensitive endpoint example:
+
 ```csharp
 app.MapPost("/admin/export", () => "Export started")
     .RequireRateLimiting("concurrency");
 ```
+
 Controller or Razor Page handlers can also use rate limiting attributes:
+
 ```csharp
 using Microsoft.AspNetCore.RateLimiting;
 
@@ -78,9 +93,26 @@ public class ReportsController : Controller
 {
 }
 ```
+
+## Production Tuning Guidance
+
+Before production use, review the configured limits against expected traffic and endpoint cost.
+
+Consider:
+
+- Anonymous versus authenticated traffic volume.
+- Reverse proxy and load balancer behavior.
+- Whether client IP, user identity, tenant ID, or API key should define the partition.
+- Login, registration, export, report, file upload, and external-service endpoints that may need stricter limits.
+- Queue behavior. The template defaults to `QueueLimit: 0` so rejected requests fail quickly instead of building server-side backlog.
+- Whether upstream infrastructure such as a CDN, ingress controller, API gateway, or web application firewall already applies additional limits.
+
+If a policy needs authenticated user, tenant, role, or permission data, review middleware ordering. The template currently places rate limiting before authentication so default protections can reject requests before authentication work is performed.
+
 ## Middleware Order
 
 The application pipeline applies rate limiting after routing:
+
 ```csharp
 app.UseRouting();
 
@@ -88,9 +120,11 @@ app.UseCors();
 
 app.UseRateLimiter();
 ```
+
 If a future policy depends on the authenticated user identity, rate limiting may need to move after authentication so user-specific partitioning can be applied.
 
 ## Automated Test Strategy
+
 Rate limiting behavior is covered by integration tests under `tests/ProjectTemplate.Web.Tests`.
 
 The tests use `WebApplicationFactory<Program>` to boot the real `ProjectTemplate.Web` pipeline in memory, override rate limiting configuration with in-memory settings, and register a test-only MVC controller from the test assembly.
@@ -103,3 +137,5 @@ This keeps production endpoints unchanged while allowing the tests to verify:
 - JSON `429 Too Many Requests` rejection responses.
 - Disabled rate limiting behavior.
 - Configuration binding for application rate limiting options.
+
+See [Runtime Readiness Baseline](runtime-readiness.md) for the consolidated release-readiness view.

--- a/docs/articles/runtime-readiness.md
+++ b/docs/articles/runtime-readiness.md
@@ -1,0 +1,123 @@
+# Runtime Readiness Baseline
+
+This page summarizes the runtime foundations that are considered part of the `v1.0.0` readiness baseline. It is intended as a review map across observability, error handling, authentication, authorization, and request protection.
+
+## Baseline Registration
+
+The application registers the runtime baseline during startup in `Program.cs`:
+
+- Serilog and structured request logging.
+- Forwarded headers.
+- Security headers.
+- Rate limiting.
+- OpenTelemetry tracing and metrics.
+- Centralized Problem Details.
+- Authentication and authorization.
+- EF Core-ready data access.
+
+The middleware pipeline applies forwarded headers early, then request logging, centralized error handling, Problem Details, security headers, HTTPS redirection, static files, routing, CORS, rate limiting, authentication, authorization, controllers, and Razor Pages.
+
+## Observability Baseline
+
+OpenTelemetry is included as the tracing and metrics baseline.
+
+Default behavior:
+
+- `ProjectTemplate:OpenTelemetry:Enabled` is `true`.
+- Tracing is enabled.
+- Metrics are enabled.
+- ASP.NET Core instrumentation is enabled.
+- HTTP client instrumentation is enabled.
+- OTLP export is disabled until an endpoint is configured.
+
+The template does not map a direct `/metrics` scraping endpoint by default. Prometheus scraping should be added through an OpenTelemetry collector, a Prometheus-compatible exporter, or a deliberate application-specific endpoint. If a direct scraping endpoint is added later, it should be reviewed with security headers, request logging exclusions, authentication, and deployment network controls.
+
+## W3C Trace Context
+
+The template uses ASP.NET Core and OpenTelemetry defaults for request activity creation and propagation. It does not replace the default propagator or force a custom trace identifier format.
+
+Problem Details responses include `traceId` from `Activity.Current?.Id` when available, falling back to the ASP.NET Core request trace identifier. This preserves the connection between incoming trace context, server-side logs, and API error responses when tracing is active.
+
+## Structured Logging Baseline
+
+Serilog is the structured logging provider.
+
+The default production-oriented log-level posture is:
+
+| Source | Default level |
+|:---|:---|
+| Application | `Information` |
+| `Microsoft` | `Warning` |
+| `Microsoft.AspNetCore` | `Warning` |
+| `Microsoft.AspNetCore.Hosting` | `Warning` |
+| `Microsoft.AspNetCore.Mvc` | `Warning` |
+| `Microsoft.AspNetCore.Routing` | `Warning` |
+| `System` | `Warning` |
+
+Console and rolling file sinks use templates that include timestamp, level, source context, request ID, request path, and exception details when present. Request logging adds correlation ID, scheme, host, remote IP address when enabled, authenticated user name when enabled, elapsed time, and response status.
+
+Sensitive values such as credentials, cookies, authentication tokens, request bodies, and response bodies are not logged by default.
+
+## Problem Details Baseline
+
+Centralized Problem Details support is registered through `AddApplicationProblemDetails` and applied in the pipeline through `UseProblemDetails`.
+
+For API, AJAX, and JSON-oriented requests, the application returns safe Problem Details responses. These responses include status, title, instance path, trace ID, and request ID.
+
+In Development, detailed exception messages may be included to support local troubleshooting. Outside Development, server errors use a generic detail message and do not expose stack traces, exception messages, connection details, secret values, or internal implementation details in the response.
+
+Browser-oriented requests use the shared error-page flow instead of JSON Problem Details.
+
+## Authentication Baseline
+
+Application authentication is enabled by default with local cookie authentication.
+
+Default behavior:
+
+- `ProjectTemplate:Authentication:Enabled` is `true`.
+- The default authenticate, challenge, and sign-in schemes use `Cookies`.
+- Local cookie authentication is enabled.
+- External OpenID Connect, SAML2, Microsoft, Google, and GitHub providers are disabled until explicitly configured.
+- Enabled external providers are validated during startup and fail fast when required values are missing.
+
+External provider secrets, certificates, client secrets, tokens, and real identity-provider metadata must be supplied through user secrets, environment variables, deployment secrets, or an approved secret store.
+
+## Authorization Baseline
+
+The application includes named baseline authorization policies for authenticated users, administrator role checks, and manage-application permission checks.
+
+| Policy | Purpose |
+|:---|:---|
+| `application.AuthenticatedUser` | Requires an authenticated user. |
+| `application.Role.Administrator` | Requires an authenticated user with a configured administrator role claim. |
+| `application.Permission.ManageApplication` | Requires an authenticated user with a configured manage-application permission claim. |
+
+The default role claim type is `application:role`, and the default permission claim type is `application:permission`.
+
+## Rate Limiting Baseline
+
+Rate limiting is enabled and configurable by default.
+
+Default behavior:
+
+- A global fixed-window limiter is available for baseline request protection.
+- A named fixed-window policy is available for endpoint-specific request protection.
+- A named concurrency policy is available for sensitive or resource-heavy operations.
+- Rejected requests return HTTP `429 Too Many Requests`.
+- Rejections are logged.
+
+Default limits are intentionally conservative starter values. Production applications should tune limits based on traffic profile, endpoint sensitivity, reverse proxy behavior, authenticated versus anonymous traffic, and whether an endpoint performs expensive I/O or external service calls.
+
+If rate limiting needs to partition by authenticated user, tenant, API key, or role, review middleware ordering and move rate limiting after authentication only when the policy requires authenticated identity information.
+
+## Follow-up Gap Review
+
+No new implementation gaps were identified during this documentation pass. Remaining production decisions are deployment-specific tuning items rather than template blockers:
+
+- OTLP collector and metrics exporter selection.
+- Prometheus scrape strategy, if required.
+- Production log sink selection and retention policy.
+- Environment-specific authentication provider configuration.
+- Production rate-limit values and partitioning strategy.
+
+If any of these become template-level requirements before `v1.0.0`, they should be split into dedicated implementation issues rather than being folded into release checklist work.

--- a/docs/articles/telemetry.md
+++ b/docs/articles/telemetry.md
@@ -2,12 +2,14 @@
 
 The application includes baseline [OpenTelemetry](https://opentelemetry.io/) support for tracing and metrics.
 
-[OpenTelemetry](https://opentelemetry.io/) is registered through:
+OpenTelemetry is registered through:
 
 ```csharp
 builder.Services.AddApplicationOpenTelemetry(builder.Configuration, builder.Environment);
 ```
+
 Configuration is controlled through `appsettings.json`:
+
 ```json
 "ProjectTemplate": {
   "OpenTelemetry": {
@@ -26,11 +28,50 @@ Configuration is controlled through `appsettings.json`:
   }
 }
 ```
+
 By default, the application collects local tracing and metrics instrumentation but does not export telemetry to an external collector. To enable OTLP export, configure an OTLP endpoint and set `ProjectTemplate:OpenTelemetry:Otlp:Enabled` to `true`.
 
 Common local OTLP collector endpoints:
+
 ```text
 http://localhost:4317
 http://localhost:4318
 ```
+
 The OTLP exporter can also be configured through standard OpenTelemetry environment variables such as `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL`.
+
+## v1.0.0 Baseline
+
+For `v1.0.0`, the telemetry baseline is:
+
+- OpenTelemetry service/resource registration.
+- ASP.NET Core request tracing instrumentation.
+- HTTP client tracing instrumentation.
+- ASP.NET Core metrics instrumentation.
+- HTTP client metrics instrumentation.
+- Optional OTLP trace and metric export.
+- Environment tagging through `deployment.environment.name`.
+
+The template validates the configured service name and validates the OTLP endpoint when OTLP export is enabled.
+
+## W3C Trace Context
+
+The template relies on ASP.NET Core and OpenTelemetry defaults for request activity creation and trace propagation. It does not override the default propagator or force a custom trace identifier format.
+
+When an incoming request includes a valid trace context, the ASP.NET Core and OpenTelemetry pipeline can attach server-side activity to that context. Error responses that use Problem Details include a `traceId` value from `Activity.Current?.Id` when available, falling back to the ASP.NET Core request trace identifier.
+
+This gives operators a consistent path from an API error response to application logs and telemetry traces.
+
+## Metrics Endpoint Behavior
+
+The template does not expose a direct Prometheus `/metrics` scraping endpoint by default.
+
+Metrics are collected through OpenTelemetry instrumentation and can be exported through OTLP when an OTLP collector endpoint is configured. Prometheus support should be added through one of these deployment-specific approaches:
+
+- Configure an OpenTelemetry Collector to receive OTLP and expose Prometheus-compatible scraping.
+- Add a Prometheus-compatible OpenTelemetry exporter in the application through a dedicated implementation change.
+- Add a deliberate application-specific metrics endpoint with security, routing, and deployment review.
+
+A direct scraping endpoint should not be added casually because it may expose operational metadata and may need network restrictions, authentication, request logging exclusions, and security-header review.
+
+See [Runtime Readiness Baseline](runtime-readiness.md) for the consolidated release-readiness view.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -19,6 +19,9 @@
 - name: Deployment
   href: deployment.md
 
+- name: Runtime Readiness
+  href: runtime-readiness.md
+
 - name: Middleware
   items:
     - name: Middleware Pipeline


### PR DESCRIPTION
## Summary

- Adds a runtime readiness baseline page for observability, ProblemDetails, authentication, authorization, and rate limiting.
- Documents OpenTelemetry tracing, metrics, W3C trace context behavior, and metrics endpoint expectations.
- Clarifies structured logging output and production-oriented log-level defaults.
- Clarifies ProblemDetails production response safety and API/browser response behavior.
- Aligns authorization policy names with the implementation and adds default authorization posture guidance.
- Adds rate limiting production tuning guidance.

## Validation

- Documentation-only change.
- Reviewed issue acceptance criteria against existing implementation and documentation.

Closes #151