### PR TITLE
ci: reduce duplicate template smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,6 @@ on:
   push:
     branches:
       - main
-      - 'feature/**'
-      - 'fix/**'
-      - 'docs/**'
-      - 'refactor/**'
-      - 'test/**'
-      - 'chore/**'
     tags:
       - 'v*.*.*'
 

--- a/docs/articles/github-workflow.md
+++ b/docs/articles/github-workflow.md
@@ -58,9 +58,11 @@ Before merging, review that:
 - The pull request scope matches the issue or stated goal.
 - Documentation has been updated when behavior or workflow expectations change.
 
+After changing workflow triggers, review branch protection required checks so old push-scoped duplicate check names are not still required.
+
 ## CI Validation
 
-The CI workflow validates pull requests and relevant branch pushes.
+The CI workflow validates pull requests, `main` branch updates, release tags, and manual workflow runs.
 
 Current validation includes:
 
@@ -73,6 +75,15 @@ Current validation includes:
 - CodeQL analysis.
 - Template package smoke testing on Linux, Windows, and macOS.
 - Scaffolded Docker support file verification.
+
+The CI trigger scope is intentionally limited to:
+
+- Pull requests targeting `main`.
+- Pushes to `main`.
+- Release-style tags matching `v*.*.*`.
+- Manual `workflow_dispatch` runs.
+
+Feature-branch pushes are not CI triggers by default. Feature branches are validated through pull requests so the same branch state does not produce duplicate push and pull-request smoke-test checks.
 
 Dependency update pull requests should be reviewed with the same CI expectations as manually authored pull requests.
 


### PR DESCRIPTION
## Summary

- Limits CI feature-branch validation to pull requests targeting main.
- Keeps CI validation for main pushes, version tags, and manual runs.
- Updates workflow documentation with the trigger scope and branch protection review note.

## Validation

- Workflow and documentation change.
- Reviewed trigger scope against issue acceptance criteria.

Closes #157