### PR TITLE
docs: document code owner review branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 # Keep source, tests, documentation, workflows, template configuration, release,
 # and security/governance files owned by the repository maintainer until a
 # broader maintainer group is intentionally documented.
+#
+# Code Owner review is required by branch protection for pull requests targeting main.
+# Approvals are dismissed when new reviewable commits are pushed.
 
 * @cdcavell
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,12 @@ Before merge, the maintainer reviews whether:
 
 Pull requests may be returned for revision when they are too broad, mix unrelated changes, lack validation, bypass documented release expectations, or create unclear downstream behavior.
 
+Pull requests targeting `main` require Code Owner review when files match `.github/CODEOWNERS`.
+
+If new reviewable commits are pushed after approval, GitHub dismisses the stale approval and the pull request must be reviewed again before merge.
+
+General required approval counts are not currently enabled while the repository is maintained under the solo-maintainer model. Required approvals may be enabled later when additional maintainers are added.
+
 ## Validation Expectations
 
 For runtime code changes, run:
@@ -160,7 +166,9 @@ The following controls should be enabled before merging the first external pull 
 
 - Signed commit requirement on protected branches.
 - Required pull request reviewer approval.
-- Code Owners review for governance files, workflow files, release files, security policy files, and template packaging files.
+- Code Owner review is required for pull requests targeting `main` when owned paths are changed.
+- Stale pull request approvals are dismissed when new reviewable commits are pushed.
+- General required approval counts remain deferred until additional maintainers are added.
 - Review of branch protection settings for `main` and any long-lived development branch.
 - Review of repository secrets, environment secrets, and package publishing permissions.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,8 @@ The maintainer is responsible for:
 - Managing GitHub release and Zenodo archival sequencing.
 - Reviewing vulnerability reports and coordinating security fixes.
 - Keeping release, support, and contribution documentation current.
+- Maintaining CODEOWNERS coverage and required Code Owner review for protected branches.
+- Reviewing stale approval behavior when branch protection settings change.
 
 ## Release Cadence
 
@@ -56,13 +58,16 @@ The `main` branch is the stable integration branch and should be protected.
 Expected `main` branch controls include:
 
 - Changes flow through pull requests instead of direct pushes.
+- Pull requests targeting `main` require Code Owner review when owned paths are changed.
+- Stale pull request approvals are dismissed when new reviewable commits are pushed.
 - Required status checks must pass before merge.
 - Branches should be current enough to merge cleanly.
 - Linear history or squash/rebase merge strategy should be preserved according to repository settings.
 - Administrative bypass should be avoided for normal development.
 - Workflow, release, security, package, and governance changes should receive deliberate maintainer review.
-- CODEOWNERS review should be enabled before adding collaborators or accepting external pull requests.
-- Required signed commits should be considered before adding collaborators or accepting external pull requests.
+- General required approvals are intentionally not enabled while the repository operates under a solo-maintainer model.
+- Required pull request approvals may be enabled later when additional maintainers are added.
+- Required approval of the most recent reviewable push is not currently enabled.
 
 ## Adding Maintainers
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Repository-level guidance is maintained in root-level files:
 - [Changelog](CHANGELOG.md)
 - [Third-Party Asset Notices](ASSETS-LICENSES.md)
 
+Pull requests targeting `main` require passing CI and Code Owner review for owned paths; stale approvals are dismissed when new reviewable commits are pushed.
+
 ## Repository Structure
 
 ```text

--- a/docs/articles/github-workflow.md
+++ b/docs/articles/github-workflow.md
@@ -51,10 +51,18 @@ Prefer small, focused pull requests. Documentation-only, dependency-only, and ru
 
 The `main` branch is treated as the stable integration branch. Changes should be made through pull requests rather than direct pushes.
 
+Pull requests targeting `main` require Code Owner review when files match `.github/CODEOWNERS`.
+
+GitHub branch protection is configured to dismiss stale pull request approvals when new reviewable commits are pushed. This ensures pull requests are re-evaluated after changes.
+
+General required approval counts are not currently enabled under the solo-maintainer model. This may be enabled later when additional maintainers are added.
+
 Before merging, review that:
 
 - The branch is current enough to merge cleanly.
 - Required validation checks have passed.
+- Required Code Owner review has been approved when owned files are changed.
+- Any stale approvals caused by new commits have been re-approved.
 - The pull request scope matches the issue or stated goal.
 - Documentation has been updated when behavior or workflow expectations change.
 


### PR DESCRIPTION
## Summary

- Documents that pull requests targeting `main` require Code Owner review for owned paths.
- Documents that stale pull request approvals are dismissed when new reviewable commits are pushed.
- Clarifies that general required approval counts are intentionally deferred while the repository remains solo-maintainer.
- Notes that required approvals may be enabled later when additional maintainers are added.

## Validation

- Documentation-only change.
- Reviewed branch protection documentation against current repository settings.
