### PR TITLE
data: make EF Core auditing configurable

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.4.2"
+version: "0.5.0"
 date-released: "2026-05-23"
 authors:
   - family-names: "Cavell"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.4.2</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.4.2.0</AssemblyVersion>
-    <FileVersion>0.4.2.0</FileVersion>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
@@ -16,8 +15,9 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.4.2</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -5,7 +5,7 @@ This package installs the `cdcavell-netcoreapp` project template for `dotnet new
 ## Install from a local package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.0.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.0.nupkg
 ```
 
 Generate a consumer project:
@@ -364,7 +364,7 @@ Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use t
 Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.4.2. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.0. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
 ```
 
 ## Roadmap

--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -17,6 +17,47 @@ The default connection string uses a local SQLite database file:
   "ApplicationDatabase": "Data Source=application-dev.db"
 }
 ```
+
+## Data Access Configuration
+
+Data access behavior is configured under `ProjectTemplate:DataAccess`:
+
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Provider": "Sqlite",
+    "ConnectionStringName": "ApplicationDatabase",
+    "Auditing": {
+      "Enabled": true
+    }
+  }
+}
+```
+
+The configuration values are:
+|Setting|Purpose|
+|:------|:------|
+|`Provider`|Selects the EF Core database provider used by the application. The default local development provider is `Sqlite`.
+|`ConnectionStringName`|Identifies which named connection string should be resolved from `ConnectionStrings`.
+|`Auditing:Enabled`|Enables or disables EF Core audit record creation during `SaveChanges` and `SaveChangesAsync`.
+
+By default, the application uses:
+
+```text
+ProjectTemplate:DataAccess:Provider = Sqlite
+ProjectTemplate:DataAccess:ConnectionStringName = ApplicationDatabase
+ProjectTemplate:DataAccess:Auditing:Enabled = true
+```
+
+With the default configuration, the application resolves:
+
+```text
+ConnectionStrings:ApplicationDatabase
+```
+
+
+
+
 EF Core migrations are stored in the infrastructure project because `ProjectTemplate.Infrastructure` owns the `ApplicationDbContext`, entities, and EF Core configuration.
 
 The web project is used as the startup project because it provides application configuration, dependency injection, provider setup, and connection-string resolution.
@@ -81,9 +122,11 @@ dotnet ef migrations script `
   --output migration.sql
 ```
 ## Connection String Resolution
+
 Migration commands use the startup project to resolve configuration.
 
-For this application, that means the connection string comes from:
+For this application, configuration may come from:
+
 ```powershell
 src/ProjectTemplate.Web/appsettings.json
 src/ProjectTemplate.Web/appsettings.{Environment}.json
@@ -91,20 +134,97 @@ user secrets
 environment variables
 other configured providers
 ```
-By default, the application resolves:
-```powershell
+
+The application reads the configured connection string name from:
+
+```text
+ProjectTemplate:DataAccess:ConnectionStringName
+```
+
+By default, this value is:
+
+```text
+ApplicationDatabase
+```
+
+The application then resolves the matching named connection string from:
+
+```text
 ConnectionStrings:ApplicationDatabase
 ```
+
 For local development, the default SQLite value is:
-```powershell
+```csharp
 Data Source=application-dev.db
 ```
-Applications can override this value through normal ASP.NET Core configuration sources.
 
-For example, an environment variable can override the connection string:
+Applications can override either the selected connection string name or the connection string value through normal ASP.NET Core configuration sources.
+
+For example, an environment variable can override the connection string value:
+
 ```powershell
 ConnectionStrings__ApplicationDatabase=Data Source=custom-application-dev.db
 ```
+
+An environment variable can also select a different configured connection string name:
+
+```powershell
+ProjectTemplate__DataAccess__ConnectionStringName=ApplicationSqlServer
+```
+
+When `ConnectionStringName` is set to `ApplicationSqlServer`, the application resolves:
+
+```text
+ConnectionStrings:ApplicationSqlServer
+```
+
+## EF Core Auditing
+
+The template includes a baseline EF Core audit trail.
+
+`ApplicationDbContext.SaveChanges` and `SaveChangesAsync` are overridden to generate audit records for tracked entity changes when auditing is enabled.
+
+Audit records may include:
+
+- Entity/table name
+- Entity state
+- Key values
+- Original values
+- Current values
+- Actor information
+- Application context
+- UTC timestamp
+
+Auditing is enabled by default:
+
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Auditing": {
+      "Enabled": true
+    }
+  }
+}
+```
+
+To disable audit record creation:
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Auditing": {
+      "Enabled": false
+    }
+  }
+}
+```
+
+When the application starts, the data access startup log records the configured provider, connection string name, and EF Core auditing status.
+
+When auditing is enabled, audit records are written to the application database. The template does not include automatic pruning, retention, archival, legal hold, masking, export, or purge behavior for audit records.
+
+Consuming applications are responsible for deciding how audit records are retained, archived, masked, purged, or moved to long-term storage. Before enabling auditing in production, review whether audited values may contain sensitive or regulated data.
+
+
 ## Automatic Startup Migrations
 
 The application does not automatically run EF Core migrations during application startup.
@@ -178,7 +298,8 @@ If migrations are not discovered, confirm that the command uses:
 --startup-project src/ProjectTemplate.Web
 --context ApplicationDbContext
 ```
-If SQLite provider configuration fails, confirm that the infrastructure project references the SQLite provider package and that the data access registration uses the configured ApplicationDatabase connection string.
+
+If data access provider configuration fails, confirm that `ProjectTemplate:DataAccess:Provider` is configured, that the selected provider package is referenced, and that `ProjectTemplate:DataAccess:ConnectionStringName` points to an existing named connection string under `ConnectionStrings`.
 
 Future database providers, such as SQL Server, can be added by extending the data access registration configuration.
 SQLite remains the default development provider. SQL Server can be selected through configuration. Because EF Core migrations are provider-specific, production SQL Server deployments should generate and maintain SQL Server-compatible migrations before applying database updates.

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
 
 namespace ProjectTemplate.Infrastructure.Data;
 
@@ -11,12 +13,14 @@ namespace ProjectTemplate.Infrastructure.Data;
 public sealed partial class ApplicationDbContext(
     DbContextOptions<ApplicationDbContext> options,
     ILogger<ApplicationDbContext> logger,
-    ICurrentActorAccessor currentActorAccessor
+    ICurrentActorAccessor currentActorAccessor,
+    IOptions<DataAccessOptions> dataAccessOptions
 )
     : DbContext(options)
 {
     private readonly ILogger<ApplicationDbContext> _logger = logger;
     private readonly ICurrentActorAccessor _currentActorAccessor = currentActorAccessor;
+    private readonly bool _auditOptions = dataAccessOptions.Value.Auditing.Enabled;
 
     /// <summary>
     /// Gets the audit records for the application.
@@ -69,6 +73,11 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
+        if (!_auditOptions)
+        {
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+
         List<AuditEntry> auditEntries = OnBeforeSaveChanges();
         int result = base.SaveChanges(acceptAllChangesOnSuccess);
         _ = OnAfterSaveChanges(auditEntries);
@@ -87,6 +96,11 @@ public sealed partial class ApplicationDbContext(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
+        if (!_auditOptions)
+        {
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+
         List<AuditEntry> auditEntries = OnBeforeSaveChanges();
 
         int result = await base.SaveChangesAsync(

--- a/src/ProjectTemplate.Infrastructure/Data/Options/DataAccessOptions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Options/DataAccessOptions.cs
@@ -1,0 +1,13 @@
+
+namespace ProjectTemplate.Infrastructure.Data.Options;
+
+public sealed class DataAccessOptions
+{
+    public const string SectionName = "ProjectTemplate:DataAccess";
+
+    public string Provider { get; init; } = "Sqlite";
+
+    public string ConnectionStringName { get; init; } = "ApplicationDatabase";
+
+    public DataAuditingOptions Auditing { get; init; } = new();
+}

--- a/src/ProjectTemplate.Infrastructure/Data/Options/DataAuditingOptions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Options/DataAuditingOptions.cs
@@ -1,0 +1,7 @@
+
+namespace ProjectTemplate.Infrastructure.Data.Options;
+
+public sealed class DataAuditingOptions
+{
+    public bool Enabled { get; init; } = true;
+}

--- a/src/ProjectTemplate.Web/Extensions/DataAccessServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/DataAccessServiceExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.ExternalLogins;
+using ProjectTemplate.Infrastructure.Data.Options;
+using ProjectTemplate.Infrastructure.Data.Services;
 using ProjectTemplate.Web.Accessors;
 
 namespace ProjectTemplate.Web.Extensions;
@@ -20,12 +22,21 @@ public static class DataAccessServiceExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
+        services
+            .AddOptions<DataAccessOptions>()
+            .Bind(configuration.GetSection(DataAccessOptions.SectionName))
+            .Validate(options => !string.IsNullOrWhiteSpace(options.Provider),
+                "ProjectTemplate:DataAccess:Provider must not be empty.")
+            .Validate(options => !string.IsNullOrWhiteSpace(options.ConnectionStringName),
+                "ProjectTemplate:DataAccess:ConnectionStringName must not be empty.")
+            .ValidateOnStart();
+
         DataAccessOptions dataAccessOptions = configuration
-            .GetSection("ProjectTemplate:DataAccess")
+            .GetSection(DataAccessOptions.SectionName)
             .Get<DataAccessOptions>() ?? new DataAccessOptions();
 
-        string provider = dataAccessOptions.Provider.Trim();
-        string connectionStringName = dataAccessOptions.ConnectionStringName.Trim();
+        string provider = dataAccessOptions.Provider?.Trim() ?? string.Empty;
+        string connectionStringName = dataAccessOptions.ConnectionStringName?.Trim() ?? string.Empty;
 
         if (string.IsNullOrWhiteSpace(provider))
         {
@@ -65,14 +76,8 @@ public static class DataAccessServiceExtensions
         });
 
         services.AddScoped<IExternalLoginAccountResolver, EfCoreExternalLoginAccountResolver>();
+        services.AddHostedService<DataAccessStartupLogger>();
 
         return services;
-    }
-
-    private sealed class DataAccessOptions
-    {
-        public string Provider { get; init; } = "Sqlite";
-
-        public string ConnectionStringName { get; init; } = "ApplicationDatabase";
     }
 }

--- a/src/ProjectTemplate.Web/Services/DataAccessStartupLogger.cs
+++ b/src/ProjectTemplate.Web/Services/DataAccessStartupLogger.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Infrastructure.Data.Services;
+
+internal sealed partial class DataAccessStartupLogger(
+    ILogger<DataAccessStartupLogger> logger,
+    IOptions<DataAccessOptions> options) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        LogDataAccessConfiguration(
+            logger,
+            options.Value.Provider,
+            options.Value.ConnectionStringName,
+            options.Value.Auditing.Enabled ? "enabled" : "disabled");
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        EventId = 19100,
+        Level = LogLevel.Information,
+        Message = "Data access configured. Provider: {Provider}; ConnectionStringName: {ConnectionStringName}; EF Core auditing: {AuditingStatus}.")]
+    private static partial void LogDataAccessConfiguration(
+        ILogger logger,
+        string provider,
+        string connectionStringName,
+        string auditingStatus);
+}

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -221,7 +221,10 @@
     },
     "DataAccess": {
       "Provider": "Sqlite",
-      "ConnectionStringName": "ApplicationDatabase"
+      "ConnectionStringName": "ApplicationDatabase",
+      "Auditing": {
+        "Enabled": true
+      }
     },
     "ApiVersioning": {
       "DefaultMajorVersion": 1,

--- a/tests/ProjectTemplate.Web.Tests/DataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/DataAccessServiceExtensionsTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Options;
 using ProjectTemplate.Web.Extensions;
 
 namespace ProjectTemplate.Web.Tests;
@@ -190,6 +192,75 @@ public sealed class DataAccessServiceExtensionsTests
             "Connection string 'MissingDatabase' was not configured.",
             exception.Message,
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that EF Core audit record creation is enabled when configured.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_AuditingEnabled_BindsAuditOptions()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ApplicationDatabase"] = "Data Source=:memory:",
+                ["ProjectTemplate:DataAccess:Provider"] = "Sqlite",
+                ["ProjectTemplate:DataAccess:ConnectionStringName"] = "ApplicationDatabase",
+                ["ProjectTemplate:DataAccess:Auditing:Enabled"] = "true"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        DataAccessOptions options = serviceProvider
+            .GetRequiredService<IOptions<DataAccessOptions>>()
+            .Value;
+
+        Assert.True(options.Auditing.Enabled);
+    }
+
+    /// <summary>
+    /// Verifies that EF Core audit record creation can be disabled through configuration.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_AuditingDisabled_BindsAuditOptions()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ApplicationDatabase"] = "Data Source=:memory:",
+                ["ProjectTemplate:DataAccess:Provider"] = "Sqlite",
+                ["ProjectTemplate:DataAccess:ConnectionStringName"] = "ApplicationDatabase",
+                ["ProjectTemplate:DataAccess:Auditing:Enabled"] = "false"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        DataAccessOptions options = serviceProvider
+            .GetRequiredService<IOptions<DataAccessOptions>>()
+            .Value;
+
+        Assert.False(options.Auditing.Enabled);
+    }
+
+    /// <summary>
+    /// Verifies that EF Core audit record creation is enabled by default when not explicitly configured.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_AuditingNotConfigured_DefaultsToEnabled()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ApplicationDatabase"] = "Data Source=:memory:"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        DataAccessOptions options = serviceProvider
+            .GetRequiredService<IOptions<DataAccessOptions>>()
+            .Value;
+
+        Assert.True(options.Auditing.Enabled);
     }
 
     private static ServiceProvider CreateServiceProvider(IConfiguration configuration)

--- a/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountResolverTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountResolverTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
 using ProjectTemplate.Infrastructure.Data.ExternalLogins;
+using ProjectTemplate.Infrastructure.Data.Options;
 
 namespace ProjectTemplate.Web.Tests;
 
@@ -298,16 +299,27 @@ public sealed class ExternalLoginAccountResolverTests
         return connection;
     }
 
-    private static ApplicationDbContext CreateContext(SqliteConnection connection)
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled = true)
     {
         DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseSqlite(connection)
             .Options;
 
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor());
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor


### PR DESCRIPTION
## Summary

- Adds `ProjectTemplate:DataAccess:Auditing:Enabled` configuration.
- Preserves existing EF Core audit record behavior when auditing is enabled.
- Skips audit record creation when auditing is disabled.
- Registers `DataAccessOptions` for dependency injection and startup validation.
- Logs configured data access provider, connection string name, and EF Core auditing status at startup.
- Updates data access documentation to reflect the current `ProjectTemplate:DataAccess` configuration shape.
- Documents that audit retention, pruning, archival, masking, export, and purge behavior are consuming-application responsibilities.
- Adds test coverage for auditing enabled and auditing disabled configuration binding.

## Validation

- [x] Ran `dotnet build --configuration Release`.
```powershell
Restore complete (1.3s)
  ProjectTemplate.Infrastructure net10.0 succeeded (5.7s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (5.2s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (5.0s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll

Build succeeded in 17.6s
```
- [x] Ran `dotnet test --configuration Release`.
```powershell
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.3s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.9s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (0.8s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.94]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.54]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.98]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:12.86]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (14.8s)

Test summary: total: 122, failed: 0, succeeded: 122, skipped: 0, duration: 14.8s
Build succeeded in 18.8s
```
- [x] Ran `dotnet format --verify-no-changes --verbosity minimal`.
- [x] Ran `dotnet tool run docfx -- docs/docfx.json`.
```powershell
Loading project NetCoreApplicationTemplate/NetCoreApplicationTemplate.Template.csproj
Restore complete (1.4s)

Build succeeded in 2.1s
Loading project NetCoreApplicationTemplate/src/ProjectTemplate.Infrastructure/ProjectTemplate.Infrastructure.csproj
Restore complete (0.6s)

Build succeeded in 1.2s
Loading project NetCoreApplicationTemplate/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
Restore complete (0.8s)

Build succeeded in 1.5s
warning: FailedToLoadAnalyzer: Failed to load .NET Analyzer. AnalyzerName: Microsoft.CodeAnalysis.Razor.Compiler, ErrorCode: ReferencesNewerCompiler, ReferencedCompilerVersion: 5.5.0.0
Loading project NetCoreApplicationTemplate/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
Restore complete (0.9s)

Build succeeded in 1.6s
Processing NetCoreApplicationTemplate.Template
Processing ProjectTemplate.Infrastructure
Processing ProjectTemplate.Web
Processing ProjectTemplate.Web.Tests
Creating output...
Searching built-in plugins in directory .nuget\packages\docfx\2.78.5\tools\net10.0\any\...
Post processor ExtractSearchIndex loaded.
7 plug-in(s) loaded.
ExtractSearchIndex: UseMetadata = False, UseMetadataTitle = True
Building 4 file(s) in TocDocumentProcessor(BuildTocDocument)...
Building 29 file(s) in ConceptualDocumentProcessor(BuildConceptualDocument=>ValidateConceptualDocumentMetadata)...
Building 5 file(s) in ResourceDocumentProcessor(ValidateResourceMetadata)...
Building 122 file(s) in ManagedReferenceDocumentProcessor(BuildManagedReferenceDocument=>SplitClassPageToMemberLevel=>ValidateManagedReferenceDocumentMetadata=>ApplyOverwriteDocumentForMref=>FillReferenceInformation=>FillMetadata)...
Applying templates to 160 model(s)...
XRef map exported.
Extracting index data from 151 html files


Build succeeded with warning.

    1 warning(s)
    0 error(s)
```


## Notes

This change does not add audit archival or retention automation. It only makes audit record creation configurable and documents that long-term audit record maintenance remains the responsibility of the consuming application.
