### PR TITLE
ci: correct pinned GitHub Actions and document Zenodo DOI

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -154,13 +154,13 @@ jobs:
 
     steps:
       - name: Download scanned image artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: container-image
           path: artifacts
 
       - name: Download release evidence artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: container-release-evidence
           path: artifacts/container-release

--- a/.github/workflows/publish-template-package.yml
+++ b/.github/workflows/publish-template-package.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Download template package artifact
-        uses: actions/download-artifact@2acb014e84f7653fdc25869b3cb6aa3d10b3a7f4 # v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: template-package
           path: ./artifacts/template-package

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 [![Coverage Gate](https://img.shields.io/badge/coverage%20gate-60%25-brightgreen)](#github-actions)
 [![Documentation](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/publish-docs.yml)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://cdcavell.github.io/NetCoreApplicationTemplate/)
-[![GitHub Release](https://img.shields.io/github/v/release/cdcavell/NetCoreApplicationTemplate?display_name=tag)](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/latest)
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/github/license/cdcavell/NetCoreApplicationTemplate)](LICENSE.txt)
+[![GitHub Release](https://img.shields.io/github/v/release/cdcavell/NetCoreApplicationTemplate?display_name=tag)](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/latest)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373042.svg)](https://doi.org/10.5281/zenodo.20373042)
 
 A reusable, production-oriented .NET application template designed to provide a secure, maintainable, and extensible baseline for building ASP.NET Core applications.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.4.2](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.4.2)__
+Current release: __[Release 0.5.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.0)__
 
-Tag: `v0.4.2`
+Tag: `v0.5.0`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals


### PR DESCRIPTION
## Summary

- Corrects pinned GitHub Actions references used by release publishing workflows.
- Keeps action pinning aligned with the repository's security-first CI posture.
- Adds the Zenodo Concept DOI badge to `README.md` so the repository citation points to the latest archived version.
- Updates README release metadata from `0.4.2` to `0.5.0`.

## Notes

The Zenodo badge uses the Concept DOI rather than the version-specific DOI so the README does not need to be updated for each future release.

## Validation

- Verified workflow action pins resolve correctly.
```powershell
gh api repos/actions/download-artifact/commits/018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 --jq .sha
gh api repos/actions/upload-artifact/commits/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a --jq .sha
```
- Verified the Zenodo DOI resolves to the archived repository record.
- Confirmed README badge renders using the Concept DOI.
<img width="1212" height="121" alt="image" src="https://github.com/user-attachments/assets/263c2fce-72aa-4016-b04d-d6c4c871bd70" />
<img width="1030" height="112" alt="image" src="https://github.com/user-attachments/assets/0edf3fd1-41a4-4d4e-bd3d-49f8b8c1751f" />


## Related

- Supports release hardening and citation readiness following `v0.5.0`.