### PR TITLE
ci: corrected release publishing flow bump to 0.5.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.0"
-date-released: "2026-05-23"
+version: "0.5.1"
+date-released: "2026-05-25"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <FileVersion>0.5.0.0</FileVersion>
+    <AssemblyVersion>0.5.1.0</AssemblyVersion>
+    <FileVersion>0.5.1.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.0)__
+Current release: __[Release 0.5.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.1)__
 
-Tag: `v0.5.0`
+Tag: `v0.5.1`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -165,7 +165,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.0.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.1.nupkg
 ```
 
 Generate a consumer project:
@@ -365,7 +365,7 @@ Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use t
 Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.0. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.1. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `cdcavell-netcoreapp` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.4.2` |
+| Current package version | `0.5.1` |
 
 ## Consumer Scaffold Boundaries
 
@@ -45,7 +45,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.1.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

This patch release corrects release publishing workflow configuration after the `v0.5.0` release archive was created successfully but downstream publish jobs failed.

## Changes

- Corrected pinned GitHub Actions references in release publishing workflows.
- Added the Zenodo Concept DOI badge to the README.
- Updated README release metadata to `v0.5.0`.
- Preserves the security-first action pinning posture for CI/CD workflows.

## Notes

`v0.5.0` remains the first Zenodo-archived DOI-bearing release. This release validates the corrected publishing pipeline using the updated workflow configuration.