### PR TITLE
Fix container release evidence upload behavior

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -248,9 +248,19 @@ jobs:
           - Cosign keyless image signature for the pushed digest.
           "@ | Set-Content -Path $notesPath -Encoding UTF8
 
-          if (gh release view $tag *> $null) {
-              gh release upload $tag artifacts/container-release/* --clobber
+          gh release view $tag --repo $env:GH_REPO 1>$null 2>$null
+
+          if ($LASTEXITCODE -eq 0) {
+              gh release upload $tag artifacts/container-release/* --clobber --repo $env:GH_REPO
+
+              if ($LASTEXITCODE -ne 0) {
+                  exit $LASTEXITCODE
+              }
           }
           else {
-              gh release create $tag artifacts/container-release/* --title "Release $tag" --notes-file $notesPath
+              gh release create $tag artifacts/container-release/* --title "Release $tag" --notes-file $notesPath --repo $env:GH_REPO
+
+              if ($LASTEXITCODE -ne 0) {
+                  exit $LASTEXITCODE
+              }
           }

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -226,6 +226,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           $tag = '${{ github.ref_name }}'
           $digestRef = '${{ steps.push.outputs.digest_ref }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 0.5.3 - 2026-05-25
+
+### Fixed
+
+- Fixed container release evidence publishing when the GitHub release already exists.
+- Updated release evidence upload logic to use explicit GitHub CLI repository context and `$LASTEXITCODE` checks.
+- Preserved signed container image publishing, SBOM, vulnerability scan, and provenance attestation behavior.
+
+## 0.5.2 - 2026-05-25
+
+### Fixed
+
+- Added explicit GitHub repository context for container release evidence publishing.
+- Fixed release evidence publishing when GitHub CLI commands run outside a checked-out repository.
+
+## 0.5.1 - 2026-05-25
+
+### Fixed
+
+- Corrected pinned GitHub Actions references used by release publishing workflows.
+- Added the Zenodo Concept DOI badge to the README.
+- Updated README release metadata for the `0.5.x` release stream.
+
+## 0.5.0 - 2026-05-25
+
+### Added
+
+- Added Zenodo archival metadata and DOI support for repository citation.
+- Added release publishing support for the template package.
+- Added container publishing, signing, SBOM, vulnerability scan, and provenance evidence workflow support.
+
+### Changed
+
+- Updated package and release metadata for `0.5.0`.
+- Prepared the repository for DOI-bearing archived releases and NuGet package distribution.
+- 
 ## 0.4.2 - 2026-05-23
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.0"
-date-released: "2026-05-23"
+version: "0.5.1"
+date-released: "2026-05-25"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.2"
+version: "0.5.3"
 date-released: "2026-05-25"
 authors:
   - family-names: "Cavell"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.1"
+version: "0.5.2"
 date-released: "2026-05-25"
 authors:
   - family-names: "Cavell"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.1</VersionPrefix>
+    <VersionPrefix>0.5.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.1.0</AssemblyVersion>
-    <FileVersion>0.5.1.0</FileVersion>
+    <AssemblyVersion>0.5.2.0</AssemblyVersion>
+    <FileVersion>0.5.2.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.2</VersionPrefix>
+    <VersionPrefix>0.5.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.2.0</AssemblyVersion>
-    <FileVersion>0.5.2.0</FileVersion>
+    <AssemblyVersion>0.5.3.0</AssemblyVersion>
+    <FileVersion>0.5.3.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <FileVersion>0.5.0.0</FileVersion>
+    <AssemblyVersion>0.5.1.0</AssemblyVersion>
+    <FileVersion>0.5.1.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.1</VersionPrefix>
+    <VersionPrefix>0.5.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.1.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.2.nupkg
 ```
 
 Generate a consumer project:
@@ -365,7 +365,7 @@ Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use t
 Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.1. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.2. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.0)__
+Current release: __[Release 0.5.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.1)__
 
-Tag: `v0.5.0`
+Tag: `v0.5.1`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -165,7 +165,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.0.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.1.nupkg
 ```
 
 Generate a consumer project:
@@ -365,7 +365,7 @@ Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use t
 Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.0. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.1. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.1)__
+Current release: __[Release 0.5.2](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.2)__
 
-Tag: `v0.5.1`
+Tag: `v0.5.2`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -165,7 +165,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.2.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.3.nupkg
 ```
 
 Generate a consumer project:
@@ -365,7 +365,7 @@ Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use t
 Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.2. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.3. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `cdcavell-netcoreapp` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.1` |
+| Current package version | `0.5.2` |
 
 ## Consumer Scaffold Boundaries
 
@@ -45,7 +45,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.1.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.2.nupkg
 ```
 
 ## Create a New Project from the Template

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `cdcavell-netcoreapp` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.4.2` |
+| Current package version | `0.5.1` |
 
 ## Consumer Scaffold Boundaries
 
@@ -45,7 +45,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.4.2.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.1.nupkg
 ```
 
 ## Create a New Project from the Template

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `cdcavell-netcoreapp` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.2` |
+| Current package version | `0.5.3` |
 
 ## Consumer Scaffold Boundaries
 
@@ -45,7 +45,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.2.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.3.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

- Updates the container publish workflow to provide explicit GitHub CLI repository context.
- Fixes release evidence publishing when the GitHub release already exists.
- Uses `$LASTEXITCODE` to determine whether `gh release view` succeeded before uploading or creating release evidence.
- Preserves the existing image push, signing, SBOM, scan, and provenance attestation flow.

## Validation

- Confirmed prior failure occurred after image signing and provenance attestation succeeded.
- Confirmed the remaining failure was caused by attempting to create a release that already existed.
- Updated release evidence logic to upload assets to the existing release when present.