### PR TITLE
ci: validate template package version against release tag

### DIFF
--- a/.github/workflows/publish-template-package.yml
+++ b/.github/workflows/publish-template-package.yml
@@ -61,6 +61,26 @@ jobs:
             --output ${{ env.PACKAGE_OUTPUT }} \
             /p:ContinuousIntegrationBuild=true
 
+      - name: Validate package version matches release tag
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        shell: bash
+        run: |
+          expected_version="${GITHUB_REF_NAME#v}"
+
+          echo "Expected package version: ${expected_version}"
+          echo "Generated packages:"
+          find "${{ env.PACKAGE_OUTPUT }}" -name "*.nupkg" -print
+
+          package_count=$(find "${{ env.PACKAGE_OUTPUT }}" -name "*.${expected_version}.nupkg" | wc -l)
+
+          echo "Matching package count: ${package_count}"
+
+          if [ "$package_count" -eq 0 ]; then
+            echo "No .nupkg found matching release tag version ${expected_version}."
+            echo "The package VersionPrefix may not match the Git tag."
+            exit 1
+          fi
+
       - name: Upload template package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 0.5.4 - 2026-05-25
+
+### Fixed
+
+- Bumped the template package version metadata to `0.5.4`.
+- Added validation to ensure the generated `.nupkg` version matches the Git release tag.
+- Prevented stale package metadata from silently republishing an older NuGet package during a new release.
+
+### Changed
+
+- Continued release pipeline hardening for template package publishing, container publishing, image signing, SBOM generation, vulnerability scan evidence, and provenance attestation.
+
 ## 0.5.3 - 2026-05-25
 
 ### Fixed
@@ -12,10 +24,16 @@ This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 - Updated release evidence upload logic to use explicit GitHub CLI repository context and `$LASTEXITCODE` checks.
 - Preserved signed container image publishing, SBOM, vulnerability scan, and provenance attestation behavior.
 
+### Notes
+
+- No new NuGet package was published for this release because the template package metadata still resolved to `0.5.2`.
+- The latest NuGet package after this release remained `0.5.2`.
+
 ## 0.5.2 - 2026-05-25
 
 ### Fixed
 
+- Published the NuGet template package for the `0.5.x` release stream.
 - Added explicit GitHub repository context for container release evidence publishing.
 - Fixed release evidence publishing when GitHub CLI commands run outside a checked-out repository.
 
@@ -39,7 +57,7 @@ This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
 - Updated package and release metadata for `0.5.0`.
 - Prepared the repository for DOI-bearing archived releases and NuGet package distribution.
-- 
+
 ## 0.4.2 - 2026-05-23
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.3"
+version: "0.5.4"
 date-released: "2026-05-25"
 authors:
   - family-names: "Cavell"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.3</VersionPrefix>
+    <VersionPrefix>0.5.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.3.0</AssemblyVersion>
-    <FileVersion>0.5.3.0</FileVersion>
+    <AssemblyVersion>0.5.4.0</AssemblyVersion>
+    <FileVersion>0.5.4.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.2</VersionPrefix>
+    <VersionPrefix>0.5.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.3.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.4.nupkg
 ```
 
 Generate a consumer project:
@@ -365,7 +365,7 @@ Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use t
 Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.3. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.4. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `cdcavell-netcoreapp` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.3` |
+| Current package version | `0.5.4` |
 
 ## Consumer Scaffold Boundaries
 
@@ -45,7 +45,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.3.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.4.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

- Adds a release-tag validation step after packing the template package.
- Fails the package workflow when the generated `.nupkg` version does not match the Git release tag.
- Prevents stale `VersionPrefix` values from republishing an older package version during a new release.

## Validation

- Confirmed the previous `v0.5.3` release packed `CDCavell.NetCoreApplicationTemplate.0.5.2.nupkg`.
- Added validation before artifact upload and NuGet publishing so future tag/package mismatches fail early.