### PR TITLE
Define v1.0 public surface and breaking-change contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/github/license/cdcavell/NetCoreApplicationTemplate)](LICENSE.txt)
 [![GitHub Release](https://img.shields.io/github/v/release/cdcavell/NetCoreApplicationTemplate?display_name=tag)](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/latest)
+[![NuGet](https://img.shields.io/nuget/v/CDCavell.NetCoreApplicationTemplate?label=NuGet)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373042.svg)](https://doi.org/10.5281/zenodo.20373042)
+<!--[![NuGet Downloads](https://img.shields.io/nuget/dt/CDCavell.NetCoreApplicationTemplate?label=downloads)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)-->
 
 A reusable, production-oriented .NET application template designed to provide a secure, maintainable, and extensible baseline for building ASP.NET Core applications.
 

--- a/README.md
+++ b/README.md
@@ -362,12 +362,14 @@ See [ADR-0003: Record Release Surface and Distribution Strategy](docs/adr/0003-r
 
 ## Citation
 
-Citation metadata is available in [CITATION.cff](CITATION.cff). GitHub can use this file to generate citation formats from the repository sidebar.
+If you use this repository, please cite it using the metadata in [`CITATION.cff`](./CITATION.cff) or one of the following: 
 
-Suggested plain-text citation:
+- Author ORCID: [0009-0002-2113-0245](https://orcid.org/0009-0002-2113-0245)
+- Zenodo Concept DOI: [10.5281/zenodo.20373042](https://doi.org/10.5281/zenodo.20373042)
+- Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.4. MIT License. https://github.com/cdcavell/NetCoreApplicationTemplate
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.4. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,8 @@ Use this checklist before publishing a stable template package or creating the f
 - Run the release build quality commands documented in `docs/articles/build-quality.md`.
 - Run the template smoke-test workflow on the release candidate branch or tag.
 - Confirm the template package ID is still `CDCavell.NetCoreApplicationTemplate`.
+- Confirm `docs/articles/public-surface-v1.md` reflects the final `v1.0.0` package identity, template symbols, generated structure, configuration keys, endpoint conventions, middleware ordering, and publishing conventions.
+- Confirm `docs/articles/v1-upgrade-notes.md` is current before tagging `v1.0.0`.
 
 ## 2. NuGet package identity and publish gate
 

--- a/docs/adr/0003-record-release-surface-and-distribution-strategy.md
+++ b/docs/adr/0003-record-release-surface-and-distribution-strategy.md
@@ -21,6 +21,8 @@ This ADR records the release-readiness decisions needed before that stable relea
 
 Use this ADR as the release-readiness decision record for SemVer, template distribution, API versioning, container image strategy, and repository metadata cross-linking.
 
+The concrete `v1.0.0` consumer contract is defined in [`docs/articles/public-surface-v1.md`](../articles/public-surface-v1.md). This ADR records the governing decision; the public-surface article lists the committed identifiers, generated structure, configuration keys, endpoint conventions, middleware invariants, and publishing conventions.
+
 ### Semantic Versioning Public Surface
 
 The public SemVer surface includes template behavior that consumers are expected to rely on after `v1.0.0`:
@@ -166,3 +168,7 @@ Trade-offs and risks:
 - [`docs/articles/deployment.md`](../articles/deployment.md)
 - [`README.md`](https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/README.md)
 - [`CITATION.cff`](https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/CITATION.cff)
+- [`docs/articles/public-surface-v1.md`](../articles/public-surface-v1.md)
+- [`docs/articles/v1-upgrade-notes.md`](../articles/v1-upgrade-notes.md)
+- [`RELEASE.md`](https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/RELEASE.md)
+- [`CHANGELOG.md`](https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/CHANGELOG.md)

--- a/docs/articles/public-surface-v1.md
+++ b/docs/articles/public-surface-v1.md
@@ -1,0 +1,226 @@
+# Public Surface v1.0
+
+This article defines the public compatibility surface for the `v1.0.0` release of the .NET Core Application Template.
+
+After `v1.0.0`, this document should be used with [ADR-0003](../adr/0003-record-release-surface-and-distribution-strategy.md), [Release Checklist](../../RELEASE.md), and the [v1.0 Upgrade Notes](v1-upgrade-notes.md) to decide whether a future change is SemVer-major, SemVer-minor, SemVer-patch, or internal-only.
+
+## Purpose
+
+The v1.0 public surface is the set of template behaviors, generated artifacts, configuration keys, routes, conventions, and distribution identifiers that consumers may reasonably depend on after the stable release.
+
+A change is breaking when it causes an application generated from the previous stable version to require code, configuration, deployment, or usage changes that were not clearly optional.
+
+## Package and Template Identity
+
+The following identifiers are part of the v1.0 public surface.
+
+| Surface | Committed value |
+|:---|:---|
+| NuGet package ID | `CDCavell.NetCoreApplicationTemplate` |
+| Template identity | `CDCavell.NetCoreApplicationTemplate.CSharp` |
+| Template group identity | `CDCavell.NetCoreApplicationTemplate` |
+| Template name | `.NET Core Application Template` |
+| `dotnet new` short name | `cdcavell-netcoreapp` |
+| Source replacement name | `ProjectTemplate` |
+| Preferred name directory | `true` |
+
+Changing, removing, or repurposing these values after `v1.0.0` is a breaking change unless the old value remains supported through an intentional compatibility path.
+
+## Template Symbols and Defaults
+
+The following template symbols are part of the v1.0 public surface.
+
+| Symbol | Type | Default | Contract |
+|:---|:---|:---|:---|
+| `skipRestore` | `bool` | `false` | Controls whether the post-create NuGet restore action runs. |
+
+Breaking changes include renaming the symbol, removing it, inverting its meaning, changing its default in a behavior-changing way, or making generated output depend on it differently without a migration path.
+
+Adding a new optional symbol with a safe default is normally a minor change.
+
+## Generated Output Structure
+
+The following generated structure is part of the v1.0 public surface.
+
+```text
+/
+├── ProjectTemplate.slnx
+├── src/
+│   ├── ProjectTemplate.Web/
+│   └── ProjectTemplate.Infrastructure/
+├── tests/
+│   └── ProjectTemplate.Web.Tests/
+├── scripts/
+├── Dockerfile
+├── docker-compose.yml
+├── Directory.Build.props
+├── Directory.Packages.props
+├── global.json
+├── .editorconfig
+├── .env.example
+├── .dockerignore
+├── .gitattributes
+├── .gitignore
+├── ASSETS-LICENSES.md
+└── LICENSE.txt
+```
+
+The generated project responsibilities are:
+
+| Project | Contract |
+|:---|:---|
+| `ProjectTemplate.Web` | ASP.NET Core host, startup composition, middleware pipeline, authentication and authorization registration, endpoint mapping, Razor Pages, MVC controllers, health checks, request logging, error handling, and web-facing configuration. |
+| `ProjectTemplate.Infrastructure` | Infrastructure and persistence concerns used by the web application, including EF Core data access and related implementation details. |
+| `ProjectTemplate.Web.Tests` | Tests for startup, configuration, middleware, authentication, authorization, and runtime behavior. |
+
+Breaking changes include removing, renaming, or relocating these projects, changing the generated solution entry point, or changing the expected namespace replacement behavior in a way that breaks generated applications.
+
+Adding optional folders, examples, or additional projects without disrupting the existing structure is normally a minor change.
+
+## Configuration Surface
+
+The following root configuration sections are part of the v1.0 public surface.
+
+|Section|Contract|
+|:---|:---|
+|`ConnectionStrings`|Contains named database connection strings used by the generated application.|
+|`AllowedHosts`|Uses standard ASP.NET Core host filtering configuration.|
+|`Serilog`|Defines default structured logging configuration.|
+|`ProjectTemplate`|Contains application-owned template configuration.|
+
+The following ProjectTemplate:* sections are part of the v1.0 public surface.
+
+|Section|Contract|
+|:---|:---|
+|`ProjectTemplate:ForwardedHeaders`|Reverse proxy and forwarded header behavior.|
+|`ProjectTemplate:SecurityHeaders`|Security header and CSP behavior.|
+|`ProjectTemplate:RateLimiting`|Global, fixed-window, and concurrency rate-limiting options.|
+|`ProjectTemplate:RequestLogging`|Correlation ID and request logging behavior.|
+|`ProjectTemplate:OpenTelemetry`|Tracing, metrics, service metadata, and OTLP exporter settings.|
+|`ProjectTemplate:Authentication`|Cookie authentication and external provider configuration.|
+|`ProjectTemplate:ClaimsTransformation`|Claim normalization and provider mapping behavior.|
+|`ProjectTemplate:Authorization`|Application role and permission claim conventions.|
+|`ProjectTemplate:DataAccess`|Data provider, connection string name, and auditing defaults.|
+|`ProjectTemplate:ApiVersioning`|API versioning defaults and supported readers.|
+
+Breaking changes include renaming or removing documented keys, changing value types, changing defaults in a way that materially changes runtime behavior, or moving settings to a different section without compatibility support.
+
+Adding optional keys with safe defaults is normally a minor change.
+
+Correcting descriptions, examples, comments, or validation messages without behavior changes is normally a patch change.
+
+## Route and Endpoint Conventions
+
+The following endpoint conventions are part of the v1.0 public surface.
+
+|Endpoint or convention|Contract|
+|:---|:---|
+|`/health`|General application health endpoint.|
+|`/health/ready`|Readiness endpoint for dependency-aware checks.|
+|`/health/live`|Lightweight liveness endpoint.|
+|`/Home/Error/500`|Non-development unhandled exception route.|
+|`/Home/Error/{statusCode}`|Browser-oriented HTTP status code error route.|
+|`/api/v{version}/<resource>`|Canonical API versioning route convention.|
+|`X-API-Version`|Supported secondary API version reader.|
+
+Changing or removing these conventions after `v1.0.0` is breaking unless the previous convention continues to work or a clear migration path is provided.
+
+Adding new endpoints or optional route forms while preserving existing routes is normally a minor change.
+
+## Middleware Ordering Contract
+
+The v1.0 middleware order is part of the public runtime contract because it affects proxy behavior, logging, error handling, security headers, routing, CORS, rate limiting, authentication, authorization, and endpoint mapping.
+
+The committed order is:
+
+&emsp;**1.** Forwarded headers<br />
+&emsp;**2.** Structured request logging<br />
+&emsp;**3.** Centralized error handling<br />
+&emsp;**4.** Problem Details handling<br />
+&emsp;**5.** Security headers<br />
+&emsp;**6.** HTTPS redirection<br />
+&emsp;**7.** Static files<br />
+&emsp;**8.** Routing<br />
+&emsp;**9.** CORS<br />
+&emsp;**10.** Rate limiting<br />
+&emsp;**11.** Authentication<br />
+&emsp;**12.** Authorization<br />
+&emsp;**13.** Controller and Razor Page endpoint mapping
+
+Reordering, removing, or replacing middleware in a way that changes documented runtime behavior is breaking.
+
+Adding optional middleware or documented extension points without disrupting the order is normally a minor change.
+
+Fixing narrow bugs while preserving the documented order is normally a patch change.
+
+## Container and Publishing Surface
+
+The repository-maintained container image is part of the release evidence and distribution surface, but generated consumer applications may choose their own image names, registries, and deployment process.
+
+The documented repository image is:
+```
+ghcr.io/cdcavell/netcoreapplicationtemplate
+```
+
+Stable semantic version tags publish:
+```
+ghcr.io/cdcavell/netcoreapplicationtemplate:<major>.<minor>.<patch>
+ghcr.io/cdcavell/netcoreapplicationtemplate:<major>
+ghcr.io/cdcavell/netcoreapplicationtemplate:latest
+```
+
+Prerelease tags publish the full version tag only and do not update `latest` or the major tag.
+
+The documented local development image tag is:
+```
+projecttemplate-web:dev
+```
+
+The container listens on port `8080`.
+
+Recommended probe paths are:
+```
+/health/live
+/health/ready
+```
+
+Breaking changes include renaming the documented repository image, removing documented stable tag forms, changing the default container port, or changing the health probe contract without a compatibility path.
+
+Adding new image variants, additional tags, or additional examples while preserving the existing contract is normally a minor change.
+
+## Internal-Only Changes
+
+The following changes are normally internal-only when they do not affect generated consumer behavior or documented extension points:
+
+- Refactoring private implementation details.
+- Reorganizing repository-only documentation that is not included in generated output.
+- Updating CI implementation details without changing release outputs.
+- Improving tests without changing generated behavior.
+- Updating comments or formatting.
+- Rebuilding against compatible patch-level dependencies.
+- Improving maintainability without changing documented keys, routes, defaults, generated structure, or package identity.
+
+## Breaking Change Test
+
+When classification is ambiguous, ask:
+
+> Would an application generated from the previous stable version break, require reconfiguration, require a deployment change, or require consumers to learn a new documented usage pattern?
+
+f yes, the change is probably SemVer-major unless the old behavior remains supported.
+
+If the change only adds optional capability, it is probably SemVer-minor.
+
+If the change corrects behavior without changing the documented contract, it is probably SemVer-patch.
+
+If the change affects only repository internals and not generated or documented consumer behavior, it is internal-only.
+
+## Related Documents
+- [ADR-0003: Record Release Surface and Distribution Strategy](../adr/0003-record-release-surface-and-distribution-strategy.md)
+- [v1.0 Upgrade Notes](v1-upgrade-notes.md)
+- [Template Packaging](template-packaging.md)
+- [Project Structure](project-structure.md)
+- [Configuration](configuration.md)
+- [Middleware Pipeline](middleware.md)
+- [Health Checks](health-checks.md)
+- [Error Handling](error-handling.md)
+- [Container Release Publishing](container-publish.md)

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -60,6 +60,12 @@
 - name: Build Quality and Reproducibility
   href: build-quality.md
 
+- name: Public Surface v1.0
+  href: public-surface-v1.md
+
+- name: v1.0 Upgrade Notes
+  href: v1-upgrade-notes.md
+
 - name: GitHub Workflow
   href: github-workflow.md
 

--- a/docs/articles/v1-upgrade-notes.md
+++ b/docs/articles/v1-upgrade-notes.md
@@ -1,0 +1,37 @@
+
+# v1.0 Upgrade Notes
+
+This article records upgrade guidance for the first stable `v1.0.0` release of the .NET Core Application Template.
+
+## 0.x to 1.0.0
+
+The `v1.0.0` release establishes the first stable public surface for the template. Pre-1.0 releases are preview releases and may contain release-readiness, packaging, documentation, and workflow changes that are finalized by the stable release.
+
+Before upgrading or generating production applications from `v1.0.0`, review:
+
+- [Public Surface v1.0](public-surface-v1.md)
+- [ADR-0003: Record Release Surface and Distribution Strategy](../adr/0003-record-release-surface-and-distribution-strategy.md)
+- [Template Packaging](template-packaging.md)
+- [Release Checklist](../../RELEASE.md)
+- [Changelog](../../CHANGELOG.md)
+
+## Consumer Review Checklist
+
+For applications generated from a pre-1.0 version, compare the generated application against the v1.0 public surface:
+
+```text
+[ ] Package ID and template short name are correct.
+[ ] Generated solution and project structure match expected names and layout.
+[ ] ProjectTemplate configuration sections and option keys are still valid.
+[ ] Health endpoints are available at /health, /health/ready, and /health/live.
+[ ] Error handling routes are still available.
+[ ] Middleware ordering has not been locally modified in a way that breaks documented behavior.
+[ ] Container port and probe paths match deployment expectations.
+[ ] Any local customizations are documented before adopting v1.0.0 as a baseline.
+```
+
+## After v1.0.0
+
+After `v1.0.0`, future changes should be classified using [Public Surface v1.0](public-surface-v1.md).
+
+Breaking changes should be reserved for a future major release and should include explicit migration notes.


### PR DESCRIPTION
## Summary

- Added `Public Surface v1.0` documentation defining the stable consumer contract for the template.
- Added `v1.0 Upgrade Notes` to anchor future migration guidance.
- Cross-linked the public-surface contract from ADR-0003, release validation, and the docs table of contents.

## Details

The new public-surface article documents:

- NuGet package ID and `dotnet new` short name.
- Template identity, source replacement name, symbols, and defaults.
- Generated solution/project structure.
- Committed `ProjectTemplate:*` configuration sections.
- Health, error, and API versioning endpoint conventions.
- Middleware ordering invariants.
- Container image, tag, port, and probe conventions.
- SemVer classification rules for major, minor, patch, and internal-only changes.

## Validation

- Documentation-only change.
- No runtime code changes.
- No package output changes expected.

Closes #183