### PR TITLE
Add automated version consistency validation - Issue #179

### DIFF
--- a/.github/workflows/publish-template-package.yml
+++ b/.github/workflows/publish-template-package.yml
@@ -48,6 +48,18 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Validate version metadata
+        shell: pwsh
+        run: |
+          $arguments = @()
+
+          if ('${{ github.ref_type }}' -eq 'tag') {
+              $arguments += '-TagName'
+              $arguments += '${{ github.ref_name }}'
+          }
+
+          ./scripts/Validate-VersionConsistency.ps1 @arguments
+
       - name: Restore dependencies
         run: dotnet restore ./NetCoreApplicationTemplate.slnx
 
@@ -61,25 +73,17 @@ jobs:
             --output ${{ env.PACKAGE_OUTPUT }} \
             /p:ContinuousIntegrationBuild=true
 
-      - name: Validate package version matches release tag
-        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-        shell: bash
+      - name: Validate generated package version
+        shell: pwsh
         run: |
-          expected_version="${GITHUB_REF_NAME#v}"
+          $arguments = @('-PackageDirectory', '${{ env.PACKAGE_OUTPUT }}')
 
-          echo "Expected package version: ${expected_version}"
-          echo "Generated packages:"
-          find "${{ env.PACKAGE_OUTPUT }}" -name "*.nupkg" -print
+          if ('${{ github.ref_type }}' -eq 'tag') {
+              $arguments += '-TagName'
+              $arguments += '${{ github.ref_name }}'
+          }
 
-          package_count=$(find "${{ env.PACKAGE_OUTPUT }}" -name "*.${expected_version}.nupkg" | wc -l)
-
-          echo "Matching package count: ${package_count}"
-
-          if [ "$package_count" -eq 0 ]; then
-            echo "No .nupkg found matching release tag version ${expected_version}."
-            echo "The package VersionPrefix may not match the Git tag."
-            exit 1
-          fi
+          ./scripts/Validate-VersionConsistency.ps1 @arguments
 
       - name: Upload template package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,42 @@
+name: Version Consistency
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-version-consistency:
+    name: Validate version consistency
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate version consistency
+        shell: pwsh
+        run: |
+          $arguments = @()
+
+          if ('${{ github.ref_type }}' -eq 'tag') {
+              $arguments += '-TagName'
+              $arguments += '${{ github.ref_name }}'
+          }
+
+          ./scripts/Validate-VersionConsistency.ps1 @arguments

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -5,7 +5,7 @@ This package installs the `cdcavell-netcoreapp` project template for `dotnet new
 ## Install from a local package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.0.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.4.nupkg
 ```
 
 ## Generate a project

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,8 @@ Use this checklist before publishing a stable template package or creating the f
 ## 1. Pre-release validation
 
 - Confirm `main` is green in CI.
-- Confirm the version in `Directory.Build.props`, `NetCoreApplicationTemplate.Template.csproj`, `CITATION.cff`, README examples, and package documentation is aligned.
+- Run `./scripts/Validate-VersionConsistency.ps1` locally before opening the release PR.
+- Confirm the version in `Directory.Build.props`, `NetCoreApplicationTemplate.Template.csproj`, `CITATION.cff`, README examples, package documentation, and the latest `CHANGELOG.md` heading is aligned.
 - Run the release build quality commands documented in `docs/articles/build-quality.md`.
 - Run the template smoke-test workflow on the release candidate branch or tag.
 - Confirm the template package ID is still `CDCavell.NetCoreApplicationTemplate`.
@@ -60,15 +61,16 @@ Recommended order:
 Recommended stable release order:
 
 1. Merge release-readiness work to `main`.
-2. Confirm CI, CodeQL, template smoke tests, documentation build, and package workflow dry-run pass.
+2. Confirm CI, CodeQL, template smoke tests, documentation build, version consistency validation, and package workflow dry-run pass.
 3. Confirm NuGet package identity reservation or documented registry decision.
 4. Confirm package signing remains deferred or verify the configured signing certificate and signing policy.
 5. Confirm Zenodo integration is enabled.
 6. Create a dry-run release tag and verify NuGet/Zenodo outputs.
 7. Correct metadata if necessary.
 8. Tag `v1.0.0`.
-9. Approve protected publish environments only after reviewing generated artifacts.
-10. Update README with final NuGet install command, Zenodo DOI badge, and copyable citation block.
+9. Confirm tag-triggered version consistency validation passes before approving protected publish environments.
+10. Approve protected publish environments only after reviewing generated artifacts.
+11. Update README with final NuGet install command, Zenodo DOI badge, and copyable citation block.
 
 ## 6. Rollback notes
 

--- a/scripts/Validate-VersionConsistency.ps1
+++ b/scripts/Validate-VersionConsistency.ps1
@@ -163,11 +163,12 @@ if (-not [string]::IsNullOrWhiteSpace($templatePackageVersion)) {
 }
 
 $escapedVersion = [regex]::Escape($ExpectedVersion)
+$escapedReleaseTag = [regex]::Escape('`v' + $ExpectedVersion + '`')
 $escapedPackageId = [regex]::Escape('CDCavell.NetCoreApplicationTemplate')
 
 $readme = Get-RequiredFileText 'README.md'
 Assert-Matches $readme "Current release:\s*__\[Release $escapedVersion\]\([^\)]*/releases/tag/v$escapedVersion\)__" 'README current-release block'
-Assert-Matches $readme "Tag:\s*`v$escapedVersion`" 'README current-release tag'
+Assert-Matches $readme "Tag:\s*$escapedReleaseTag" 'README current-release tag'
 Assert-Matches $readme "$escapedPackageId\.$escapedVersion\.nupkg" 'README package install example'
 Assert-Matches $readme "Version $escapedVersion\. Zenodo\. MIT License\." 'README citation version'
 

--- a/scripts/Validate-VersionConsistency.ps1
+++ b/scripts/Validate-VersionConsistency.ps1
@@ -1,0 +1,233 @@
+[CmdletBinding()]
+param(
+    [string]$ExpectedVersion,
+    [string]$TagName,
+    [string]$PackageDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$failures = [System.Collections.Generic.List[string]]::new()
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Add-Failure {
+    param([string]$Message)
+
+    $script:failures.Add($Message)
+}
+
+function Resolve-RepositoryPath {
+    param([string]$RelativePath)
+
+    return Join-Path $repoRoot $RelativePath
+}
+
+function Get-RequiredFileText {
+    param([string]$RelativePath)
+
+    $path = Resolve-RepositoryPath $RelativePath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Add-Failure "Required file was not found: $RelativePath"
+        return ''
+    }
+
+    return Get-Content -LiteralPath $path -Raw
+}
+
+function Get-ProjectProperty {
+    param(
+        [string]$RelativePath,
+        [string]$PropertyName,
+        [bool]$Required = $true
+    )
+
+    $path = Resolve-RepositoryPath $RelativePath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Add-Failure "Required project file was not found: $RelativePath"
+        return $null
+    }
+
+    [xml]$project = Get-Content -LiteralPath $path -Raw
+    $nodes = @($project.Project.PropertyGroup.ChildNodes | Where-Object {
+        $_.NodeType -eq [System.Xml.XmlNodeType]::Element -and $_.Name -eq $PropertyName
+    })
+
+    if ($nodes.Count -eq 0) {
+        if ($Required) {
+            Add-Failure "Property '$PropertyName' was not found in $RelativePath."
+        }
+
+        return $null
+    }
+
+    return $nodes[0].InnerText.Trim()
+}
+
+function Resolve-Version {
+    param(
+        [string]$VersionPrefix,
+        [string]$VersionSuffix
+    )
+
+    if ([string]::IsNullOrWhiteSpace($VersionSuffix)) {
+        return $VersionPrefix
+    }
+
+    return "$VersionPrefix-$VersionSuffix"
+}
+
+function Assert-Equal {
+    param(
+        [string]$Actual,
+        [string]$Expected,
+        [string]$Description
+    )
+
+    if ($Actual -ne $Expected) {
+        Add-Failure "$Description expected '$Expected' but found '$Actual'."
+    }
+}
+
+function Assert-Matches {
+    param(
+        [string]$Text,
+        [string]$Pattern,
+        [string]$Description
+    )
+
+    if ($Text -notmatch $Pattern) {
+        Add-Failure "$Description was not found or did not match expected version '$ExpectedVersion'."
+    }
+}
+
+function Get-RegexGroupValue {
+    param(
+        [string]$Text,
+        [string]$Pattern,
+        [string]$GroupName,
+        [string]$Description,
+        [bool]$Required = $true
+    )
+
+    $match = [regex]::Match($Text, $Pattern)
+    if (-not $match.Success) {
+        if ($Required) {
+            Add-Failure "$Description was not found."
+        }
+
+        return $null
+    }
+
+    return $match.Groups[$GroupName].Value
+}
+
+$directoryVersionPrefix = Get-ProjectProperty 'Directory.Build.props' 'VersionPrefix'
+$directoryVersionSuffix = Get-ProjectProperty 'Directory.Build.props' 'VersionSuffix' $false
+$directoryVersionSuffix = if ($null -eq $directoryVersionSuffix) { '' } else { $directoryVersionSuffix }
+$resolvedDirectoryVersion = Resolve-Version $directoryVersionPrefix $directoryVersionSuffix
+
+if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
+    $ExpectedVersion = $resolvedDirectoryVersion
+}
+
+if ($ExpectedVersion -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
+    Add-Failure "Expected version '$ExpectedVersion' is not a supported semantic version. Use MAJOR.MINOR.PATCH with an optional prerelease suffix."
+}
+
+Assert-Equal $resolvedDirectoryVersion $ExpectedVersion 'Directory.Build.props resolved version'
+Assert-Equal (Get-ProjectProperty 'Directory.Build.props' 'AssemblyVersion') "$directoryVersionPrefix.0" 'Directory.Build.props AssemblyVersion'
+Assert-Equal (Get-ProjectProperty 'Directory.Build.props' 'FileVersion') "$directoryVersionPrefix.0" 'Directory.Build.props FileVersion'
+
+$templateVersionPrefix = Get-ProjectProperty 'NetCoreApplicationTemplate.Template.csproj' 'VersionPrefix'
+$templateVersionSuffix = Get-ProjectProperty 'NetCoreApplicationTemplate.Template.csproj' 'VersionSuffix' $false
+$templateVersionSuffix = if ($null -eq $templateVersionSuffix) { '' } else { $templateVersionSuffix }
+$templateResolvedVersion = Resolve-Version $templateVersionPrefix $templateVersionSuffix
+
+Assert-Equal $templateResolvedVersion $ExpectedVersion 'NetCoreApplicationTemplate.Template.csproj resolved package version'
+
+$templateVersion = Get-ProjectProperty 'NetCoreApplicationTemplate.Template.csproj' 'Version' $false
+if (-not [string]::IsNullOrWhiteSpace($templateVersion)) {
+    $allowedVersionValues = @($ExpectedVersion, '$(VersionPrefix)', '$(Version)')
+    if ($allowedVersionValues -notcontains $templateVersion) {
+        Add-Failure "NetCoreApplicationTemplate.Template.csproj Version should be '$ExpectedVersion' or derive from VersionPrefix, but found '$templateVersion'."
+    }
+}
+
+$templatePackageVersion = Get-ProjectProperty 'NetCoreApplicationTemplate.Template.csproj' 'PackageVersion' $false
+if (-not [string]::IsNullOrWhiteSpace($templatePackageVersion)) {
+    $allowedPackageVersionValues = @($ExpectedVersion, '$(VersionPrefix)', '$(Version)')
+    if ($allowedPackageVersionValues -notcontains $templatePackageVersion) {
+        Add-Failure "NetCoreApplicationTemplate.Template.csproj PackageVersion should be '$ExpectedVersion' or derive from VersionPrefix, but found '$templatePackageVersion'."
+    }
+}
+
+$escapedVersion = [regex]::Escape($ExpectedVersion)
+$escapedPackageId = [regex]::Escape('CDCavell.NetCoreApplicationTemplate')
+
+$readme = Get-RequiredFileText 'README.md'
+Assert-Matches $readme "Current release:\s*__\[Release $escapedVersion\]\([^\)]*/releases/tag/v$escapedVersion\)__" 'README current-release block'
+Assert-Matches $readme "Tag:\s*`v$escapedVersion`" 'README current-release tag'
+Assert-Matches $readme "$escapedPackageId\.$escapedVersion\.nupkg" 'README package install example'
+Assert-Matches $readme "Version $escapedVersion\. Zenodo\. MIT License\." 'README citation version'
+
+$packageReadme = Get-RequiredFileText 'PACKAGE-README.md'
+Assert-Matches $packageReadme "$escapedPackageId\.$escapedVersion\.nupkg" 'PACKAGE-README package install example'
+
+$citation = Get-RequiredFileText 'CITATION.cff'
+$citationVersion = Get-RegexGroupValue $citation '(?m)^version:\s*["'']?(?<version>[^"''\r\n]+)["'']?\s*$' 'version' 'CITATION.cff version metadata'
+if ($null -ne $citationVersion) {
+    Assert-Equal $citationVersion $ExpectedVersion 'CITATION.cff version metadata'
+}
+
+$changelog = Get-RequiredFileText 'CHANGELOG.md'
+$changelogMatch = [regex]::Match($changelog, '(?m)^##\s+(?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)\s+-\s+\d{4}-\d{2}-\d{2}\s*$')
+if ($changelogMatch.Success) {
+    Assert-Equal $changelogMatch.Groups['version'].Value $ExpectedVersion 'CHANGELOG latest released version heading'
+}
+else {
+    Add-Failure 'CHANGELOG latest released version heading was not found.'
+}
+
+if (-not [string]::IsNullOrWhiteSpace($TagName)) {
+    $tagMatch = [regex]::Match($TagName, '^v(?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)$')
+    if (-not $tagMatch.Success) {
+        Add-Failure "Tag '$TagName' is not a supported release tag. Use vMAJOR.MINOR.PATCH with an optional prerelease suffix."
+    }
+    else {
+        Assert-Equal $tagMatch.Groups['version'].Value $ExpectedVersion 'Git release tag version'
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($PackageDirectory)) {
+    $packageDirectoryPath = Resolve-RepositoryPath $PackageDirectory
+    if (-not (Test-Path -LiteralPath $packageDirectoryPath -PathType Container)) {
+        Add-Failure "Package directory was not found: $PackageDirectory"
+    }
+    else {
+        $packages = @(Get-ChildItem -LiteralPath $packageDirectoryPath -Filter '*.nupkg' -File)
+        $expectedPackageName = "CDCavell.NetCoreApplicationTemplate.$ExpectedVersion.nupkg"
+        $matchingPackages = @($packages | Where-Object { $_.Name -eq $expectedPackageName })
+        $driftedPackages = @($packages | Where-Object { $_.Name -ne $expectedPackageName })
+
+        if ($matchingPackages.Count -eq 0) {
+            Add-Failure "No generated package named '$expectedPackageName' was found in $PackageDirectory."
+        }
+
+        foreach ($package in $driftedPackages) {
+            Add-Failure "Generated package filename '$($package.Name)' does not match expected version '$ExpectedVersion'."
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host 'Version consistency validation failed.'
+    foreach ($failure in $failures) {
+        Write-Host "::error::$failure"
+        Write-Host "- $failure"
+    }
+
+    exit 1
+}
+
+Write-Host "Version consistency validation passed for version $ExpectedVersion."


### PR DESCRIPTION
## Summary

- Adds `scripts/Validate-VersionConsistency.ps1` for local and CI version drift detection.
- Adds a dedicated `Version Consistency` workflow that runs on PRs, pushes to `main`, release-style tags, and manual dispatch.
- Updates the template package publish workflow to run the shared validator before packing and again after package generation.
- Fixes the stale `PACKAGE-README.md` package install example from `0.5.0` to `0.5.4`.
- Updates the release checklist to reference the automated version consistency check and tag-triggered validation.

## Validation Coverage

The validator checks:

- `Directory.Build.props` `VersionPrefix`, `VersionSuffix`, `AssemblyVersion`, and `FileVersion`.
- `NetCoreApplicationTemplate.Template.csproj` package version metadata.
- README current-release block, release tag, package install example, and citation version.
- `PACKAGE-README.md` package install example.
- `CITATION.cff` version metadata.
- latest released `CHANGELOG.md` version heading.
- optional Git release tag agreement when `-TagName` is supplied.
- optional generated `.nupkg` filename agreement when `-PackageDirectory` is supplied.

## Notes

- I could not run the PowerShell validator locally from this environment because `pwsh` is not installed in the container. The new workflow and existing GitHub-hosted runners should validate the script on PR execution.

Closes #179