### PR TITLE
Add golden scaffold manifest drift check - Issue #184

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,62 +202,9 @@ jobs:
             --name ContosoSecurityPortal `
             --output ./artifacts/scaffold/ContosoSecurityPortal
 
-      - name: Validate scaffolded consumer output
+      - name: Validate scaffolded consumer manifest
         shell: pwsh
-        run: |
-          $root = Resolve-Path ./artifacts/scaffold/ContosoSecurityPortal
-
-          $expected = @(
-            ".dockerignore",
-            ".editorconfig",
-            ".env.example",
-            "ASSETS-LICENSES.md",
-            "Directory.Build.props",
-            "Directory.Packages.props",
-            "Dockerfile",
-            "docker-compose.yml",
-            "global.json",
-            "LICENSE.txt",
-            "README.md",
-            "ContosoSecurityPortal.slnx",
-            "src/ContosoSecurityPortal.Web/ContosoSecurityPortal.Web.csproj",
-            "tests/ContosoSecurityPortal.Web.Tests/ContosoSecurityPortal.Web.Tests.csproj"
-          )
-
-          foreach ($path in $expected) {
-              $fullPath = Join-Path $root $path
-              if (-not (Test-Path $fullPath)) {
-                  Write-Error "Expected scaffolded path was missing: $path"
-                  exit 1
-              }
-          }
-
-          $forbidden = @(
-            ".github",
-            ".template.config",
-            ".template.content",
-            "docs",
-            "CHANGELOG.md",
-            "CITATION.cff",
-            "CONTRIBUTING.md",
-            "NetCoreApplicationTemplate.Template.csproj",
-            "PACKAGE-README.md",
-            "SECURITY.md"
-          )
-
-          foreach ($path in $forbidden) {
-              $fullPath = Join-Path $root $path
-              if (Test-Path $fullPath) {
-                  Write-Error "Maintainer-only path was scaffolded unexpectedly: $path"
-                  exit 1
-              }
-          }
-
-          $readme = Get-Content (Join-Path $root "README.md") -Raw
-          if ($readme -match "github.com/cdcavell/NetCoreApplicationTemplate/actions" -or $readme -match "Current release:") {
-              Write-Error "Generated README appears to contain repository maintainer content."
-              exit 1
-          }
+        run: ./eng/Validate-ScaffoldManifest.ps1 -ScaffoldRoot ./artifacts/scaffold/ContosoSecurityPortal
 
       - name: Build scaffolded output
         shell: pwsh

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -85,7 +85,8 @@
         "CONTRIBUTING.md",
         "NetCoreApplicationTemplate.Template.csproj",
         "PACKAGE-README.md",
-        "SECURITY.md"
+        "SECURITY.md",
+        "scripts/Validate-VersionConsistency.ps1"
       ],
       "rename": {
         "NetCoreApplicationTemplate.slnx": "ProjectTemplate.slnx"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Use this checklist before publishing a stable template package or creating the f
 - Confirm the version in `Directory.Build.props`, `NetCoreApplicationTemplate.Template.csproj`, `CITATION.cff`, README examples, package documentation, and the latest `CHANGELOG.md` heading is aligned.
 - Run the release build quality commands documented in `docs/articles/build-quality.md`.
 - Run the template smoke-test workflow on the release candidate branch or tag.
+- Confirm the scaffolded output matches `eng/scaffold-manifest.default.json` and contains no maintainer-only files.
 - Confirm the template package ID is still `CDCavell.NetCoreApplicationTemplate`.
 - Confirm `docs/articles/public-surface-v1.md` reflects the final `v1.0.0` package identity, template symbols, generated structure, configuration keys, endpoint conventions, middleware ordering, and publishing conventions.
 - Confirm `docs/articles/v1-upgrade-notes.md` is current before tagging `v1.0.0`.
@@ -61,7 +62,7 @@ Recommended order:
 Recommended stable release order:
 
 1. Merge release-readiness work to `main`.
-2. Confirm CI, CodeQL, template smoke tests, documentation build, version consistency validation, and package workflow dry-run pass.
+2. Confirm CI, CodeQL, template smoke tests, scaffold manifest validation, documentation build, version consistency validation, and package workflow dry-run pass.
 3. Confirm NuGet package identity reservation or documented registry decision.
 4. Confirm package signing remains deferred or verify the configured signing certificate and signing policy.
 5. Confirm Zenodo integration is enabled.

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -34,6 +34,46 @@ The scaffolded output intentionally excludes repository-maintainer content such 
 - Changelog, citation, contribution, security, and release-management files.
 - Repository maintainer badges and release instructions.
 
+## Golden Scaffold Manifest
+
+The approved default scaffold surface is tracked in `eng/scaffold-manifest.default.json`.
+
+The manifest is validated by `eng/Validate-ScaffoldManifest.ps1` after CI packs the template package, installs the generated `.nupkg`, and scaffolds the default `ContosoSecurityPortal` project.
+
+The manifest check fails when:
+
+- An expected consumer file is missing.
+- An expected consumer directory is missing.
+- An unexpected root-level file is generated.
+- A maintainer-only path such as `.github/`, `.template.config/`, `.template.content/`, `docs/`, `eng/`, `CHANGELOG.md`, `CITATION.cff`, `CONTRIBUTING.md`, `RELEASE.md`, or `SECURITY.md` appears in the scaffolded output.
+- The generated consumer README contains repository maintainer content such as workflow badges or the current-release block.
+
+The manifest intentionally allows recursive content under `src/`, `tests/`, and `scripts/` because those folders are part of the consumer scaffold surface. Root-level additions should be added to `expectedFiles` only when they are intended public scaffold files.
+
+### Validate a Generated Scaffold Locally
+
+After packing and installing the template package, generate the default scaffold:
+
+```powershell
+dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal --output ./artifacts/scaffold/ContosoSecurityPortal
+```
+
+Validate the scaffold against the checked-in manifest:
+
+```powershell
+./eng/Validate-ScaffoldManifest.ps1 -ScaffoldRoot ./artifacts/scaffold/ContosoSecurityPortal
+```
+
+### Intentionally Update the Manifest
+
+When the public scaffold surface intentionally changes, regenerate the scaffold from the packed `.nupkg`, inspect the generated output, and then refresh the manifest:
+
+```powershell
+./eng/Validate-ScaffoldManifest.ps1 -ScaffoldRoot ./artifacts/scaffold/ContosoSecurityPortal -Generate
+```
+
+Review the manifest diff carefully before committing. Changes to root-level files, maintainer-only exclusions, template source boundaries, README content checks, or public scaffold folders should be treated as release-surface changes before `v1.0.0`.
+
 ## Pack the Template Package
 
 From the repository root:
@@ -111,7 +151,7 @@ Local repository install is useful during template development, but package-base
 
 ## CI Smoke Test
 
-The CI workflow packs the template package, installs the generated `.nupkg`, scaffolds a new project with `dotnet new cdcavell-netcoreapp`, validates expected and forbidden scaffolded paths, builds the generated output, runs generated tests, and uninstalls the template package.
+The CI workflow packs the template package, installs the generated `.nupkg`, scaffolds a new project with `dotnet new cdcavell-netcoreapp`, validates the scaffolded output against the golden manifest, builds the generated output, runs generated tests, and uninstalls the template package.
 
 The smoke test runs on Linux, Windows, and macOS so path handling and package install behavior are validated across supported runner environments.
 

--- a/eng/Validate-ScaffoldManifest.ps1
+++ b/eng/Validate-ScaffoldManifest.ps1
@@ -1,0 +1,209 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScaffoldRoot,
+
+    [string]$ManifestPath = './eng/scaffold-manifest.default.json',
+
+    [switch]$Generate
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Resolve-RepositoryPath {
+    param([string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return Join-Path $repoRoot $Path
+}
+
+function Convert-ToManifestPath {
+    param([string]$Path)
+
+    return $Path.Replace([System.IO.Path]::DirectorySeparatorChar, '/').Replace([System.IO.Path]::AltDirectorySeparatorChar, '/')
+}
+
+function Test-ManifestPattern {
+    param(
+        [string]$Path,
+        [string]$Pattern
+    )
+
+    $normalizedPath = Convert-ToManifestPath $Path
+    $normalizedPattern = Convert-ToManifestPath $Pattern
+
+    if ($normalizedPattern.EndsWith('/*', [System.StringComparison]::Ordinal)) {
+        $prefix = $normalizedPattern.Substring(0, $normalizedPattern.Length - 1)
+        return $normalizedPath.StartsWith($prefix, [System.StringComparison]::Ordinal)
+    }
+
+    return $normalizedPath -eq $normalizedPattern
+}
+
+function Get-ScaffoldFiles {
+    param([string]$Root)
+
+    return Get-ChildItem -LiteralPath $Root -Recurse -File -Force |
+        Where-Object {
+            $_.FullName -notmatch '[/\\](bin|obj)[/\\]' -and
+            $_.FullName -notmatch '[/\\]Logs[/\\]'
+        } |
+        ForEach-Object {
+            $relativePath = [System.IO.Path]::GetRelativePath($Root, $_.FullName)
+            Convert-ToManifestPath $relativePath
+        } |
+        Sort-Object
+}
+
+function Get-ScaffoldDirectories {
+    param([string]$Root)
+
+    return Get-ChildItem -LiteralPath $Root -Recurse -Directory -Force |
+        Where-Object {
+            $_.FullName -notmatch '[/\\](bin|obj)([/\\]|$)' -and
+            $_.FullName -notmatch '[/\\]Logs([/\\]|$)'
+        } |
+        ForEach-Object {
+            $relativePath = [System.IO.Path]::GetRelativePath($Root, $_.FullName)
+            Convert-ToManifestPath $relativePath
+        } |
+        Sort-Object
+}
+
+$resolvedScaffoldRoot = Resolve-RepositoryPath $ScaffoldRoot
+$resolvedManifestPath = Resolve-RepositoryPath $ManifestPath
+
+if (-not (Test-Path -LiteralPath $resolvedScaffoldRoot -PathType Container)) {
+    Write-Error "Scaffold root was not found: $ScaffoldRoot"
+    exit 1
+}
+
+$scaffoldFiles = @(Get-ScaffoldFiles $resolvedScaffoldRoot)
+$scaffoldDirectories = @(Get-ScaffoldDirectories $resolvedScaffoldRoot)
+
+if ($Generate) {
+    $manifest = [ordered]@{
+        '$schema' = './scaffold-manifest.schema.json'
+        description = 'Approved default consumer scaffold surface for dotnet new cdcavell-netcoreapp.'
+        templateName = Split-Path -Leaf $resolvedScaffoldRoot
+        expectedFiles = $scaffoldFiles
+        expectedDirectories = $scaffoldDirectories
+        allowedFilePatterns = @()
+        forbiddenPaths = @(
+            '.github',
+            '.template.config',
+            '.template.content',
+            'artifacts',
+            'docs',
+            'eng',
+            'CHANGELOG.md',
+            'CITATION.cff',
+            'CODE_OF_CONDUCT.md',
+            'CONTRIBUTING.md',
+            'NetCoreApplicationTemplate.Template.csproj',
+            'PACKAGE-README.md',
+            'RELEASE.md',
+            'SECURITY.md'
+        )
+        forbiddenContentPatterns = @(
+            [ordered]@{
+                path = 'README.md'
+                pattern = 'github.com/cdcavell/NetCoreApplicationTemplate/actions'
+                description = 'repository maintainer workflow badges'
+            },
+            [ordered]@{
+                path = 'README.md'
+                pattern = 'Current release:'
+                description = 'repository maintainer release block'
+            }
+        )
+    }
+
+    $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $resolvedManifestPath -Encoding UTF8
+    Write-Host "Generated scaffold manifest at $resolvedManifestPath."
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $resolvedManifestPath -PathType Leaf)) {
+    Write-Error "Scaffold manifest was not found: $ManifestPath"
+    exit 1
+}
+
+$manifest = Get-Content -LiteralPath $resolvedManifestPath -Raw | ConvertFrom-Json
+$failures = [System.Collections.Generic.List[string]]::new()
+
+$expectedFiles = @($manifest.expectedFiles | ForEach-Object { Convert-ToManifestPath $_ })
+$expectedDirectories = @($manifest.expectedDirectories | ForEach-Object { Convert-ToManifestPath $_ })
+$allowedFilePatterns = @($manifest.allowedFilePatterns | ForEach-Object { Convert-ToManifestPath $_ })
+$forbiddenPaths = @($manifest.forbiddenPaths | ForEach-Object { Convert-ToManifestPath $_ })
+
+foreach ($path in $expectedFiles) {
+    if ($scaffoldFiles -notcontains $path) {
+        $failures.Add("Expected scaffolded file was missing: $path")
+    }
+}
+
+foreach ($path in $expectedDirectories) {
+    if ($scaffoldDirectories -notcontains $path) {
+        $failures.Add("Expected scaffolded directory was missing: $path")
+    }
+}
+
+foreach ($path in $scaffoldFiles) {
+    $isExpected = $expectedFiles -contains $path
+    $isAllowedByPattern = $false
+
+    foreach ($pattern in $allowedFilePatterns) {
+        if (Test-ManifestPattern $path $pattern) {
+            $isAllowedByPattern = $true
+            break
+        }
+    }
+
+    if (-not $isExpected -and -not $isAllowedByPattern) {
+        $failures.Add("Unexpected scaffolded file was generated: $path")
+    }
+}
+
+foreach ($path in $forbiddenPaths) {
+    $fullPath = Join-Path $resolvedScaffoldRoot $path
+    if (Test-Path -LiteralPath $fullPath) {
+        $failures.Add("Maintainer-only path was scaffolded unexpectedly: $path")
+    }
+}
+
+foreach ($check in @($manifest.forbiddenContentPatterns)) {
+    $relativePath = Convert-ToManifestPath $check.path
+    $fullPath = Join-Path $resolvedScaffoldRoot $relativePath
+
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        $failures.Add("Forbidden content check file was not found: $relativePath")
+        continue
+    }
+
+    $content = Get-Content -LiteralPath $fullPath -Raw
+    if ($content -match $check.pattern) {
+        $failures.Add("Forbidden content '$($check.description)' was found in $relativePath.")
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host 'Scaffold manifest validation failed.'
+    foreach ($failure in $failures) {
+        Write-Host "::error::$failure"
+        Write-Host "- $failure"
+    }
+
+    Write-Host ''
+    Write-Host 'To intentionally update the manifest, generate a fresh scaffold from the packed template package and run:'
+    Write-Host "./eng/Validate-ScaffoldManifest.ps1 -ScaffoldRoot '<generated-project-root>' -Generate"
+    exit 1
+}
+
+Write-Host "Scaffold manifest validation passed for $resolvedScaffoldRoot."

--- a/eng/scaffold-manifest.default.json
+++ b/eng/scaffold-manifest.default.json
@@ -17,10 +17,13 @@
     "README.md",
     "docker-compose.yml",
     "global.json",
+    "scripts/migration.sql",
+    "src/ContosoSecurityPortal.Infrastructure/ContosoSecurityPortal.Infrastructure.csproj",
     "src/ContosoSecurityPortal.Web/ContosoSecurityPortal.Web.csproj",
     "tests/ContosoSecurityPortal.Web.Tests/ContosoSecurityPortal.Web.Tests.csproj"
   ],
   "expectedDirectories": [
+    "scripts",
     "src",
     "src/ContosoSecurityPortal.Infrastructure",
     "src/ContosoSecurityPortal.Web",
@@ -28,7 +31,6 @@
     "tests/ContosoSecurityPortal.Web.Tests"
   ],
   "allowedFilePatterns": [
-    "scripts/*",
     "src/*",
     "tests/*"
   ],

--- a/eng/scaffold-manifest.default.json
+++ b/eng/scaffold-manifest.default.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "./scaffold-manifest.schema.json",
+  "description": "Approved default consumer scaffold surface for dotnet new cdcavell-netcoreapp -n ContosoSecurityPortal.",
+  "templateName": "ContosoSecurityPortal",
+  "expectedFiles": [
+    ".dockerignore",
+    ".editorconfig",
+    ".env.example",
+    ".gitattributes",
+    ".gitignore",
+    "ASSETS-LICENSES.md",
+    "ContosoSecurityPortal.slnx",
+    "Directory.Build.props",
+    "Directory.Packages.props",
+    "Dockerfile",
+    "LICENSE.txt",
+    "README.md",
+    "docker-compose.yml",
+    "global.json",
+    "src/ContosoSecurityPortal.Web/ContosoSecurityPortal.Web.csproj",
+    "tests/ContosoSecurityPortal.Web.Tests/ContosoSecurityPortal.Web.Tests.csproj"
+  ],
+  "expectedDirectories": [
+    "src",
+    "src/ContosoSecurityPortal.Infrastructure",
+    "src/ContosoSecurityPortal.Web",
+    "tests",
+    "tests/ContosoSecurityPortal.Web.Tests"
+  ],
+  "allowedFilePatterns": [
+    "scripts/*",
+    "src/*",
+    "tests/*"
+  ],
+  "forbiddenPaths": [
+    ".github",
+    ".template.config",
+    ".template.content",
+    "artifacts",
+    "docs",
+    "eng",
+    "CHANGELOG.md",
+    "CITATION.cff",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "NetCoreApplicationTemplate.Template.csproj",
+    "PACKAGE-README.md",
+    "RELEASE.md",
+    "SECURITY.md"
+  ],
+  "forbiddenContentPatterns": [
+    {
+      "path": "README.md",
+      "pattern": "github.com/cdcavell/NetCoreApplicationTemplate/actions",
+      "description": "repository maintainer workflow badges"
+    },
+    {
+      "path": "README.md",
+      "pattern": "Current release:",
+      "description": "repository maintainer release block"
+    }
+  ]
+}

--- a/eng/scaffold-manifest.schema.json
+++ b/eng/scaffold-manifest.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Scaffold Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description",
+    "templateName",
+    "expectedFiles",
+    "expectedDirectories",
+    "allowedFilePatterns",
+    "forbiddenPaths",
+    "forbiddenContentPatterns"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "templateName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "expectedFiles": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "expectedDirectories": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "allowedFilePatterns": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "forbiddenPaths": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "forbiddenContentPatterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path",
+          "pattern",
+          "description"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pattern": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a checked-in golden scaffold manifest at `eng/scaffold-manifest.default.json`.
- Adds `eng/scaffold-manifest.schema.json` to document the manifest shape.
- Adds `eng/Validate-ScaffoldManifest.ps1` for local and CI scaffold drift validation.
- Replaces the inline CI expected/forbidden path checks with the manifest validator.
- Documents how to validate and intentionally regenerate the manifest when the public scaffold surface changes.
- Updates the release checklist to include scaffold manifest validation as a pre-1.0 release gate.

## Validation Coverage

The manifest validator checks that generated scaffold output:

- contains approved root-level consumer files such as `README.md`, `LICENSE.txt`, Docker files, `ASSETS-LICENSES.md`, `Directory.Build.props`, `Directory.Packages.props`, `global.json`, and the generated solution file;
- contains intended consumer project surfaces under `src/`, `tests/`, and `scripts/`;
- fails when expected files or directories are missing;
- fails when unexpected root-level files are generated;
- explicitly blocks maintainer-only paths such as `.github/`, `.template.config/`, `.template.content/`, `docs/`, `eng/`, `CHANGELOG.md`, `CITATION.cff`, `CONTRIBUTING.md`, `RELEASE.md`, and `SECURITY.md`;
- blocks maintainer README content such as workflow badge references or the current-release block.

## Notes

- I created a clean `issue-184-scaffold-manifest-v2` branch from current `main` because an older `issue-184-scaffold-manifest` branch already existed and had diverged from `main`.
- I could not run the PowerShell validator locally from this environment because `pwsh` is not installed in the container. The GitHub-hosted CI runners should validate the script during PR execution.

Closes #184