### PR TITLE
Fix template package script warnings after scaffold manifest merge

### DIFF
--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -43,7 +43,7 @@
     <Content Include="LICENSE.txt" Pack="true" PackagePath="" />
     <Content Include="NetCoreApplicationTemplate.slnx" Pack="true" PackagePath="content/" />
     <Content Include="PACKAGE-README.md" Pack="true" PackagePath="" />
-    <Content Include="scripts/**/*" Pack="true" PackagePath="content/scripts/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include="scripts/migration.sql" Pack="true" PackagePath="content/scripts/" />
     <Content Include="src/**/*" Pack="true" PackagePath="content/src/%(RecursiveDir)%(Filename)%(Extension)" Exclude="src/**/bin/**;src/**/obj/**;src/**/Logs/**" />
     <Content Include="tests/**/*" Pack="true" PackagePath="content/tests/%(RecursiveDir)%(Filename)%(Extension)" Exclude="tests/**/bin/**;tests/**/obj/**;tests/**/Logs/**" />
     <Content Include="PACKAGE-ICON.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
## Summary

- Limits template package script content to the intended consumer script: `scripts/migration.sql`.
- Stops packing repository-maintainer PowerShell scripts under `content/scripts/`.
- Removes NuGet pack warnings about `Validate-VersionConsistency.ps1` being an unrecognized install script.

## Notes

This is a follow-up cleanup after #194. The scaffold manifest correctly caught the maintainer script as unintended consumer output; this change also prevents the maintainer script from being packed into the template package content.

Related to #184.