### PR TITLE
Document v1.0 security header defaults - Issue #188

### DIFF
--- a/docs/articles/public-surface-v1.md
+++ b/docs/articles/public-surface-v1.md
@@ -109,6 +109,28 @@ Adding optional keys with safe defaults is normally a minor change.
 
 Correcting descriptions, examples, comments, or validation messages without behavior changes is normally a patch change.
 
+### Security Header Defaults
+
+The `ProjectTemplate:SecurityHeaders` section is part of the v1.0 public configuration surface.
+
+The following defaults are part of the v1.0 runtime contract when security headers are enabled:
+
+| Header | Default behavior |
+|:---|:---|
+| `X-Content-Type-Options` | Emits `nosniff`. |
+| `X-Frame-Options` | Emits `DENY`. |
+| `Referrer-Policy` | Emits `strict-origin-when-cross-origin`. |
+| `X-Permitted-Cross-Domain-Policies` | Emits `none`. |
+| `Cross-Origin-Opener-Policy` | Emits `same-origin` when `EnableCrossOriginHeaders` is `true`. |
+| `Cross-Origin-Resource-Policy` | Emits `same-origin` when `EnableCrossOriginHeaders` is `true`. |
+| `Permissions-Policy` | Emits the configured `PermissionsPolicy` value when `EnablePermissionsPolicy` is `true`. |
+| `Content-Security-Policy` | Emits the configured `ContentSecurityPolicy` value when `EnableContentSecurityPolicy` is `true`. |
+| `X-XSS-Protection` | Not emitted because it is obsolete. |
+
+Changing required default headers, changing documented default values, removing validation, or changing the meaning of documented security-header options is a breaking change after `v1.0.0` unless a compatibility path is provided.
+
+Adding new optional security headers or new configuration options with safe defaults is normally a minor change.
+
 ## Route and Endpoint Conventions
 
 The following endpoint conventions are part of the v1.0 public surface.
@@ -206,7 +228,7 @@ When classification is ambiguous, ask:
 
 > Would an application generated from the previous stable version break, require reconfiguration, require a deployment change, or require consumers to learn a new documented usage pattern?
 
-f yes, the change is probably SemVer-major unless the old behavior remains supported.
+If yes, the change is probably SemVer-major unless the old behavior remains supported.
 
 If the change only adds optional capability, it is probably SemVer-minor.
 
@@ -224,3 +246,4 @@ If the change affects only repository internals and not generated or documented 
 - [Health Checks](health-checks.md)
 - [Error Handling](error-handling.md)
 - [Container Release Publishing](container-publish.md)
+- [Security Headers](security-headers.md)

--- a/docs/articles/security-headers.md
+++ b/docs/articles/security-headers.md
@@ -15,22 +15,35 @@ The pipeline calls:
 ```csharp
 app.UseApplicationSecurityHeaders();
 ```
-## Default Headers
+## v1.0 Security Header Contract
 
-By default, the middleware applies the following headers when enabled:
+This contract applies when `ProjectTemplate:SecurityHeaders:Enabled` is `true` and the request path does not match `ExcludedPathPrefixes`.
 
-|Header|Default Value|Purpose|
-|:-----|:------------|:------|
-|`X-Content-Type-Options`|`nosniff`|Prevents MIME type sniffing by browsers, reducing the risk of drive-by downloads and content injection attacks.|
-|`X-Frame-Options`|`DENY`|Prevents the application from being framed by another site.|
-|`Referrer-Policy`|`strict-origin-when-cross-origin`|Limits how much referrer information is sent during navigation.|
-|`X-Permitted-Cross-Domain-Policies`|`none`|Blocks legacy cross-domain policy files.|
-|`Cross-Origin-Opener-Policy`|`same-origin`|Helps isolate the browsing context from cross-origin documents.|
-|`Cross-Origin-Resource-Policy`|`same-origin`|Restricts other origins from loading application resources.|
-|`Permissions-Policy`|Configurable|Disables or limits browser features such as camera, microphone, geolocation, payment, USB, and fullscreen.|
-|`Content-Security-Policy`|Configurable|Restricts where scripts, styles, images, forms, frames, and other resources may load from.|
+| Header | Default | Contract | Configuration |
+|:---|:---|:---|:---|
+| `X-Content-Type-Options` | `nosniff` | Required when security headers are enabled and the request path is not excluded | Not individually configurable |
+| `X-Frame-Options` | `DENY` | Required when security headers are enabled and the request path is not excluded | Not individually configurable |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Required when security headers are enabled and the request path is not excluded | Not individually configurable |
+| `X-Permitted-Cross-Domain-Policies` | `none` | Required when security headers are enabled and the request path is not excluded | Not individually configurable |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Configurable group | Controlled by `EnableCrossOriginHeaders` |
+| `Cross-Origin-Resource-Policy` | `same-origin` | Configurable group | Controlled by `EnableCrossOriginHeaders` |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)` | Configurable | Controlled by `EnablePermissionsPolicy` and `PermissionsPolicy` |
+| `Content-Security-Policy` | `default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline';` | Configurable | Controlled by `EnableContentSecurityPolicy` and `ContentSecurityPolicy` |
+| `X-XSS-Protection` | Not emitted | Intentionally omitted | Not supported |
 
 The middleware intentionally does not add `X-XSS-Protection` because that header is obsolete and can create inconsistent behavior in modern browsers.
+
+## Intentional Opt-Outs
+
+The following settings reduce or remove default browser hardening and should be used intentionally:
+
+| Setting | Effect | Recommended use |
+|:---|:---|:---|
+| `Enabled = false` | Disables all application security headers | Only when an upstream reverse proxy, gateway, or host platform applies equivalent headers |
+| `EnableContentSecurityPolicy = false` | Removes CSP | Temporary troubleshooting or applications that must define CSP elsewhere |
+| `EnablePermissionsPolicy = false` | Removes Permissions-Policy | Only when browser feature policy is managed elsewhere |
+| `EnableCrossOriginHeaders = false` | Removes COOP and CORP | Applications that intentionally integrate cross-origin windows or resources |
+| `ExcludedPathPrefixes` | Skips all security headers for matching paths | Infrastructure endpoints such as `/health` and `/metrics` |
 
 ## Configuration
 
@@ -66,7 +79,7 @@ Security headers can be configured from `appsettings.json`:
 
 ## Environment-Specific Behavior
 
-The default configuration is intentionally conservative. Applications created from this application can loosen or override headers in environment-specific settings files such as `appsettings.Development.json`.
+The default configuration is intentionally conservative. Applications created from this template can loosen or override headers in environment-specific settings files such as `appsettings.Development.json`.
 
 For example, a local development configuration may temporarily disable CSP while troubleshooting script or style loading:
 ```json

--- a/src/ProjectTemplate.Web/Options/ApplicationSecurityHeadersOptions.cs
+++ b/src/ProjectTemplate.Web/Options/ApplicationSecurityHeadersOptions.cs
@@ -45,7 +45,7 @@ public sealed class ApplicationSecurityHeadersOptions
 
     /// <summary>
     /// Gets or sets the Permissions-Policy header value applied to responses.
-    /// Set this to an empty string to omit the header.
+    /// Set EnablePermissionsPolicy to false to omit the header.
     /// </summary>
     public string PermissionsPolicy { get; set; } =
         "camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)";

--- a/tests/ProjectTemplate.Web.Tests/SecurityHeadersTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/SecurityHeadersTests.cs
@@ -159,6 +159,27 @@ public sealed class SecurityHeadersTests
     }
 
     /// <summary>
+    /// Verifies that no security headers are emitted when security headers are globally disabled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DisabledSecurityHeaders_DoNotEmitSecurityHeaders()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["ProjectTemplate:SecurityHeaders:Enabled"] = "false"
+        });
+
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync("/test/security-headers", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        AssertSecurityHeadersMissing(response);
+    }
+
+    /// <summary>
     /// Verifies that configured excluded path prefixes do not receive security headers.
     /// </summary>
     /// <param name="path">The excluded request path to verify.</param>


### PR DESCRIPTION
## Summary

Documents and tightens the v1.0 security header posture for the template.

## Changes

- Added explicit v1.0 security header contract guidance.
- Documented required, configurable, optional, and intentionally omitted headers.
- Added dangerous opt-out guidance for disabling all headers, CSP, Permissions-Policy, cross-origin headers, and excluded paths.
- Added security header defaults to the v1.0 public surface contract.
- Corrected the `PermissionsPolicy` option comment to match validation behavior.
- Added integration coverage for globally disabled security headers.

## Validation

- Confirmed default security headers remain covered by integration tests.
```powershell
Restore complete (2.7s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.2s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.4s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.3s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.10]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.43]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.70]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:08.00]   Finished:    ProjectTemplate.Web.Tests (ID = 'b73a943d775b2b9714d3794b049d8db32ae1a954b06893bc61c06a8ee9d0e5e9')
  ProjectTemplate.Web.Tests test net10.0 succeeded (9.4s)

Test summary: total: 123, failed: 0, succeeded: 123, skipped: 0, duration: 9.3s
Build succeeded in 16.4s
``` 
- Added coverage for `ProjectTemplate:SecurityHeaders:Enabled = false`.
- Confirmed typed options remain bound through `ProjectTemplate:SecurityHeaders`.

Closes #188