### PR TITLE
Add scaffolded Docker smoke test - Issue #180

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,73 @@ jobs:
         working-directory: ./artifacts/scaffold/ContosoSecurityPortal
         run: dotnet test ./ContosoSecurityPortal.slnx --configuration $env:CONFIGURATION --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
 
+      - name: Build scaffolded Docker image
+        if: runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: |
+          docker build `
+            --build-arg BUILD_CONFIGURATION=$env:CONFIGURATION `
+            --tag contososecurityportal-web:ci `
+            .
+
+      - name: Validate scaffolded Docker Compose configuration
+        if: runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: docker compose -p contososecurityportal-ci config
+
+      - name: Run scaffolded Docker Compose application
+        if: runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: docker compose -p contososecurityportal-ci up --build --detach
+
+      - name: Verify scaffolded Docker health endpoint
+        if: runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: |
+          $healthUrl = "http://localhost:8080/health/live"
+
+          for ($attempt = 1; $attempt -le 30; $attempt++) {
+              try {
+                  $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 2
+
+                  if ($response.StatusCode -eq 200) {
+                      Write-Host "Health endpoint responded successfully."
+                      exit 0
+                  }
+
+                  Write-Host "Health endpoint returned HTTP $($response.StatusCode)."
+              }
+              catch {
+                  Write-Host "Health probe attempt $attempt failed: $($_.Exception.Message)"
+              }
+
+              Start-Sleep -Seconds 2
+          }
+
+          docker compose -p contososecurityportal-ci ps
+          docker compose -p contososecurityportal-ci logs --no-color
+
+          Write-Error "Health endpoint did not respond successfully."
+          exit 1
+
+      - name: Capture scaffolded Docker logs
+        if: always() && runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: |
+          docker compose -p contososecurityportal-ci ps
+          docker compose -p contososecurityportal-ci logs --no-color
+
+      - name: Stop scaffolded Docker Compose application
+        if: always() && runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoSecurityPortal
+        run: docker compose -p contososecurityportal-ci down --volumes --remove-orphans
+
       - name: Uninstall template package
         if: always()
         shell: pwsh

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -155,6 +155,10 @@ The CI workflow packs the template package, installs the generated `.nupkg`, sca
 
 The smoke test runs on Linux, Windows, and macOS so path handling and package install behavior are validated across supported runner environments.
 
+On Linux runners, CI also validates the Docker consumer path from the generated scaffolded output. This Docker smoke test builds the generated Docker image, validates `docker compose config`, starts the generated Compose application, verifies `/health/live`, captures Compose logs for diagnostics, and tears down the Compose stack during cleanup.
+
+Docker runtime validation is intentionally limited to Linux runners. The goal is to prove that Docker files emitted by the template are usable by a generated consumer project, not to certify Docker host behavior across every operating system.
+
 ## Distribution Direction
 
 The intended stable distribution model is a published NuGet template package installable with `dotnet new install`.


### PR DESCRIPTION
## Summary

- Adds Linux-only Docker validation to the template smoke test path.
- Builds the Docker image from scaffolded consumer output generated from the packed `.nupkg`.
- Validates `docker compose config` against the scaffolded consumer project.
- Starts the generated Compose application and verifies `/health/live`.
- Captures Compose logs and tears down containers/volumes during cleanup.
- Documents the Docker validation scope in the template packaging documentation.

## Validation

- CI continues to pack, install, scaffold, manifest-check, build, and test generated consumer output.
- Docker image build now runs against `artifacts/scaffold/ContosoSecurityPortal`.
- Docker Compose configuration is validated from scaffolded output.
- Runtime health validation confirms the generated container responds at `/health/live`.

Closes #180
