### PR TITLE
Document package signing policy and contributor publishing controls

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -156,6 +156,8 @@ External contributions must enter through pull requests, pass required CI checks
 
 The publish workflow keeps the manual approval gate in place so unsigned package publication remains intentional rather than automatic.
 
+Before each stable release, confirm that [`SECURITY.md`](SECURITY.md) still reflects the current package-signing posture and that any trigger condition requiring a signing-policy review has been evaluated.
+
 ## 4. Zenodo archival sequence
 
 Zenodo archives GitHub releases created after the GitHub integration is enabled. Enable integration before the DOI-bearing release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,6 +80,27 @@ Repository and environment secrets must be scoped to the narrowest workflow that
 
 Plaintext credentials are not allowed in workflow files, repository files, examples, documentation, screenshots, or committed logs.
 
+## Package Signing and External Contributor Controls
+
+NuGet package signing is currently deferred for pre-`v1.0.0` releases and remains a release-readiness decision point until a project-controlled signing certificate, timestamping approach, signing owner, certificate storage process, and verification policy are documented.
+
+Official package artifacts are produced only by the maintainer-controlled release workflow. External contributors do not publish NuGet packages directly and are not expected to sign generated `.nupkg` artifacts. If package signing is introduced later, release artifacts should be signed by a project-controlled certificate through the protected release workflow, not by individual contributors.
+
+External contributor trust is handled separately from package signing. External contributions should enter through pull requests, required CI checks, Code Owner review when owned paths change, branch protection, dependency review, CodeQL/security scanning, and maintainer approval before merge. Signed commits may be required later if the repository moves beyond the solo-maintainer profile.
+
+Revisit the package-signing decision when any of the following conditions occur:
+
+- Before publishing the stable `v1.0.0` NuGet package.
+- Before enabling fully automated package publication.
+- Before adding additional maintainers or package owners.
+- Before accepting external pull requests that affect workflows, package metadata, release automation, security policy, or template packaging.
+- When consumers, organizations, or registries require signed packages.
+- After a suspected credential, certificate, package, or release-workflow exposure.
+- After repeated supply-chain, dependency, or publishing-risk findings.
+- When package ownership moves to an organization or shared publishing model.
+
+If package signing is enabled, document the signing certificate owner, certificate storage location, timestamping authority, certificate rotation process, revocation response, NuGet.org certificate registration expectations, workflow integration, and package verification steps before publishing signed artifacts.
+
 ## Related Documents
 
 - [SUPPORT.md](SUPPORT.md)


### PR DESCRIPTION
## Summary

- Adds an explicit package-signing policy to `SECURITY.md`
- Clarifies that NuGet package signing is currently deferred for pre-v1.0 releases
- Separates package publication/signing mechanics from external contributor trust controls
- Documents trigger conditions for revisiting package signing
- Adds a release checklist reminder to confirm the signing policy before stable publication

## Validation

- Documentation-only change
- Reviewed `SECURITY.md` and `RELEASE.md` for consistency
- No runtime behavior, template output, package metadata, or workflow execution changed

Closes #181