### PR TITLE
Add authorization startup validation and v1 secrets guidance

### DIFF
--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -139,7 +139,9 @@ dotnet user-secrets set "ConnectionStrings:ApplicationSqlServer" "Server=(locald
 dotnet user-secrets set "ProjectTemplate:Authentication:Providers:GitHub:ClientSecret" "local-development-secret" --project src/ProjectTemplate.Web
 ```
 
-For production, prefer the hosting platform secret manager, environment-protected variables, or an approved external secret store. Production secret values should be injected at deployment time rather than stored in committed JSON files.
+The generated web project includes a `UserSecretsId` so local development secrets can be managed through Visual Studio's **Manage User Secrets** command or the `dotnet user-secrets` CLI. User secrets are for local development only and should not be treated as encrypted production storage.
+
+Production deployments should supply sensitive values through protected environment variables, hosting-platform secret managers, or vault-backed configuration providers. Do not place production connection strings, authentication provider secrets, API keys, signing material, or organization-specific private endpoints in committed `appsettings*.json` files.
 
 ## Provider-Specific Configuration
 
@@ -185,9 +187,15 @@ The application uses strongly typed options classes for application-owned config
 
 Validated configuration areas include:
 
-- `ProjectTemplate:SecurityHeaders`
+- `ProjectTemplate:ApiVersioning`
+- `ProjectTemplate:Authentication`
+- `ProjectTemplate:Authorization`
+- `ProjectTemplate:DataAccess`
 - `ProjectTemplate:ForwardedHeaders`
+- `ProjectTemplate:OpenTelemetry`
 - `ProjectTemplate:RateLimiting`
+- `ProjectTemplate:RequestLogging`
+- `ProjectTemplate:SecurityHeaders`
 
 Invalid startup-sensitive values fail application startup rather than being silently corrected. This helps catch unsafe or malformed production configuration before the application begins serving requests.
 

--- a/docs/articles/production-deployment-checklist.md
+++ b/docs/articles/production-deployment-checklist.md
@@ -32,6 +32,7 @@ Related docs:
 [ ] TLS termination location is documented.
 [ ] Deployment slot, region, and environment names are documented.
 [ ] Platform-specific startup command or container entry point is verified.
+[ ] Startup configuration validation has been tested with the production configuration source.
 ```
 
 Related docs:
@@ -183,6 +184,7 @@ Related docs:
 [ ] Role and permission claim conventions are documented.
 [ ] Unauthorized and forbidden behavior is tested.
 [ ] Sign-in and sign-out flows are smoke tested.
+[ ] Required authorization claim types, administrator roles, and management permissions are configured.
 ```
 
 Related docs:
@@ -202,6 +204,7 @@ Related docs:
 [ ] Database backup/restore approach is understood before schema changes.
 [ ] Connection resiliency and timeout expectations are reviewed.
 [ ] Local development database settings are not used in production.
+[ ] Missing or invalid provider/connection string settings fail startup before deployment approval.
 ```
 
 Related docs:

--- a/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
@@ -35,7 +35,20 @@ public static class AuthorizationServiceExtensions
 
         services
             .AddOptions<ApplicationAuthorizationOptions>()
-            .Bind(configuration.GetSection(ApplicationAuthorizationOptions.SectionName));
+            .Bind(configuration.GetSection(ApplicationAuthorizationOptions.SectionName))
+            .Validate(
+                options => !string.IsNullOrWhiteSpace(options.RoleClaimType),
+                "ProjectTemplate:Authorization:RoleClaimType is required.")
+            .Validate(
+                options => !string.IsNullOrWhiteSpace(options.PermissionClaimType),
+                "ProjectTemplate:Authorization:PermissionClaimType is required.")
+            .Validate(
+                options => options.AdministratorRoles.Any(role => !string.IsNullOrWhiteSpace(role)),
+                "ProjectTemplate:Authorization:AdministratorRoles must contain at least one non-empty value.")
+            .Validate(
+                options => options.ManageApplicationPermissions.Any(permission => !string.IsNullOrWhiteSpace(permission)),
+                "ProjectTemplate:Authorization:ManageApplicationPermissions must contain at least one non-empty value.")
+            .ValidateOnStart();
 
         services.AddAuthorizationBuilder()
             .AddPolicy(

--- a/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
+++ b/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <PropertyGroup>
+    <UserSecretsId>projecttemplate-web-development</UserSecretsId>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Folder Include="Logs\" />
   </ItemGroup>

--- a/tests/ProjectTemplate.Web.Tests/AuthorizationPolicyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthorizationPolicyTests.cs
@@ -170,6 +170,33 @@ public sealed class AuthorizationPolicyTests
     }
 
     /// <summary>
+    /// Verifies that application startup fails with an appropriate error when the required RoleClaimType authorization option is not configured.
+    /// </summary>
+    [Fact]
+    public void ApplicationStartup_Fails_WhenAuthorizationRoleClaimTypeIsEmpty()
+    {
+        Dictionary<string, string?> configuration = new()
+        {
+            ["ProjectTemplate:Authorization:RoleClaimType"] = ""
+        };
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+        {
+            using ApplicationWebApplicationFactory factory = new(configuration);
+
+            // Accessing Services forces WebApplicationFactory to build/start the host,
+            // which triggers ValidateOnStart().
+            _ = factory.Services;
+        });
+
+        Assert.Contains(
+            exception.Failures,
+            failure => failure.Contains(
+                "ProjectTemplate:Authorization:RoleClaimType is required.",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
     /// Creates a test application factory with the supplied in-memory configuration overrides.
     /// </summary>
     /// <param name="configurationValues">The configuration key/value pairs used to override application settings for a test.</param>


### PR DESCRIPTION
## Summary

- Adds startup validation for application authorization options
- Enables User Secrets support for the generated web project
- Updates configuration documentation with the full validated-options inventory
- Clarifies development versus production secret-management guidance
- Cross-links startup validation and secrets expectations from the production deployment checklist

## Validation

- Documentation reviewed for consistency with existing configuration guidance
- Confirmed change is limited to startup validation, project metadata, and documentation
- Run `dotnet test --configuration Release`
```powershell
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.3s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.6s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (0.7s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.50]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.12]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.57]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:13.82]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (15.8s)

Test summary: total: 127, failed: 0, succeeded: 127, skipped: 0, duration: 15.8s
Build succeeded in 19.6s
```

Closes #189