### PR TITLE
Prepare release 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 0.5.5 - 2026-05-26
+
+### Added
+
+- Added explicit package signing policy guidance for release governance.
+- Added startup validation for application authorization configuration.
+- Added User Secrets support for the generated web project to support local development secret management.
+- Added configuration validation guidance for v1.0 readiness.
+
+### Changed
+
+- Clarified that NuGet package signing is currently deferred until a project-controlled certificate, timestamping approach, signing owner, and verification policy are documented.
+- Clarified that external contributors do not publish or sign release packages directly.
+- Updated configuration documentation to distinguish local development secrets from production secrets.
+- Cross-linked production deployment guidance with startup validation and secret-management expectations.
+
+### Security
+
+- Strengthened supply-chain and release-governance documentation around package publication, maintainer approval, protected release workflows, and future signing-policy trigger conditions.
+- Strengthened secure-by-default configuration behavior by failing startup when required authorization settings are invalid.
+
 ## 0.5.4 - 2026-05-25
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.4"
-date-released: "2026-05-25"
+version: "0.5.5"
+date-released: "2026-05-26"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.4</VersionPrefix>
+    <VersionPrefix>0.5.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.4.0</AssemblyVersion>
-    <FileVersion>0.5.4.0</FileVersion>
+    <AssemblyVersion>0.5.5.0</AssemblyVersion>
+    <FileVersion>0.5.5.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.4</VersionPrefix>
+    <VersionPrefix>0.5.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -5,7 +5,7 @@ This package installs the `netcoreapp-template` project template for `dotnet new
 ## Install from a local package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.4.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.5.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.4](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.4)__
+Current release: __[Release 0.5.5](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.5)__
 
-Tag: `v0.5.4`
+Tag: `v0.5.5`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.4.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.5.nupkg
 ```
 
 Generate a consumer project:
@@ -371,7 +371,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.4. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.5. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.4.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.5.nupkg
 ```
 
 ## Create a New Project from the Template

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.4` |
+| Current package version | `0.5.5` |
 
 ## Consumer Scaffold Boundaries
 


### PR DESCRIPTION
## Summary

- Updates project version metadata for release `0.5.5`
- Updates release/changelog documentation for the new patch release
- Captures the v1.0 readiness work completed since `0.5.4`
- Confirms release documentation remains aligned with the current template behavior

## Validation

- Ran `dotnet restore`
```powershell
Restore complete (3.0s)

Build succeeded in 3.9s
```
- Ran `dotnet build --configuration Release`
```powershell
Restore complete (1.4s)
  ProjectTemplate.Infrastructure net10.0 succeeded (6.6s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (6.1s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (5.5s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll

Build succeeded in 20.0s
```
- Ran `dotnet test --configuration Release`
```powershell
Restore complete (1.4s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.4s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (1.1s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.1s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.01]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.67]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.17]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:14.95]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (17.3s)

Test summary: total: 127, failed: 0, succeeded: 127, skipped: 0, duration: 17.2s
Build succeeded in 22.6s
```
- Confirmed release metadata and documentation reference `0.5.5`

## Notes

This is a pre-`1.0.0` patch release focused on release-readiness hardening, documentation alignment, and configuration/security polish.