### PR TITLE
Complete OpenTelemetry correlation support - Issue #187

### DIFF
--- a/docs/articles/telemetry.md
+++ b/docs/articles/telemetry.md
@@ -62,6 +62,17 @@ When an incoming request includes a valid trace context, the ASP.NET Core and Op
 
 This gives operators a consistent path from an API error response to application logs and telemetry traces.
 
+## Log and Problem Details Correlation
+
+The template keeps request correlation, logs, Problem Details, and OpenTelemetry traces connected through a small shared identifier set:
+
+- `correlationId` comes from the configured request correlation header, defaulting to `X-Correlation-ID`.
+- `requestId` comes from ASP.NET Core `HttpContext.TraceIdentifier`.
+- `traceId` and `spanId` come from the current W3C `Activity` when available.
+- Serilog request logs include the same identifiers so operators can move from an error response to logs and then to an OpenTelemetry trace.
+
+OTLP export remains disabled by default. Applications can enable trace and metric export by configuring `ProjectTemplate:OpenTelemetry:Otlp`.
+
 ## Metrics Endpoint Behavior
 
 The template does not expose a direct Prometheus `/metrics` scraping endpoint by default.

--- a/src/ProjectTemplate.Web/ErrorHandling/ProblemDetailsExtensions.cs
+++ b/src/ProjectTemplate.Web/ErrorHandling/ProblemDetailsExtensions.cs
@@ -1,4 +1,8 @@
 using System.Diagnostics;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using ProjectTemplate.Web.Options;
 
 namespace ProjectTemplate.Web.ErrorHandling;
 
@@ -33,13 +37,37 @@ internal static class ProblemDetailsExtensions
 
         services.AddProblemDetails(options => options.CustomizeProblemDetails = context =>
             {
-                context.ProblemDetails.Instance ??= context.HttpContext.Request.Path;
+                string? originalExceptionPath = context.HttpContext.Features
+                    .Get<IExceptionHandlerPathFeature>()?
+                    .Path;
+
+                string? originalStatusCodePath = context.HttpContext.Features
+                    .Get<IStatusCodeReExecuteFeature>()?
+                    .OriginalPath;
+
+                context.ProblemDetails.Instance ??= !string.IsNullOrWhiteSpace(originalExceptionPath)
+                    ? originalExceptionPath
+                    : !string.IsNullOrWhiteSpace(originalStatusCodePath)
+                        ? originalStatusCodePath
+                        : context.HttpContext.Request.Path;
+
+                string correlationId = GetCorrelationId(context.HttpContext);
+
+                Activity? activity = Activity.Current;
 
                 context.ProblemDetails.Extensions["traceId"] =
-                    Activity.Current?.Id ?? context.HttpContext.TraceIdentifier;
+                    activity?.TraceId.ToString() ?? context.HttpContext.TraceIdentifier;
+
+                if (activity is not null)
+                {
+                    context.ProblemDetails.Extensions["spanId"] = activity.SpanId.ToString();
+                }
 
                 context.ProblemDetails.Extensions["requestId"] =
                     context.HttpContext.TraceIdentifier;
+
+                context.ProblemDetails.Extensions["correlationId"] =
+                    correlationId;
 
                 if (!webHostEnvironment.IsDevelopment() &&
                     context.ProblemDetails.Status >= StatusCodes.Status500InternalServerError)
@@ -85,5 +113,30 @@ internal static class ProblemDetailsExtensions
             branch => branch.UseStatusCodePagesWithReExecute("/Home/Error/{0}"));
 
         return app;
+    }
+
+    private static string GetCorrelationId(HttpContext httpContext)
+    {
+        ApplicationRequestLoggingOptions requestLoggingOptions = httpContext.RequestServices
+            .GetService<IOptions<ApplicationRequestLoggingOptions>>()?.Value
+            ?? new ApplicationRequestLoggingOptions();
+
+        if (httpContext.Request.Headers.TryGetValue(
+            requestLoggingOptions.CorrelationHeaderName,
+            out StringValues correlationHeaderValues))
+        {
+            string? headerValue = correlationHeaderValues.FirstOrDefault();
+
+            if (!string.IsNullOrWhiteSpace(headerValue))
+            {
+                string cleanValue = headerValue.Trim();
+
+                return cleanValue.Length <= 128
+                    ? cleanValue
+                    : cleanValue[..128];
+            }
+        }
+
+        return httpContext.TraceIdentifier;
     }
 }

--- a/src/ProjectTemplate.Web/Extensions/RequestLoggingExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/RequestLoggingExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using ProjectTemplate.Web.Options;
@@ -69,8 +70,16 @@ public static class RequestLoggingExtensions
                 return Task.CompletedTask;
             });
 
+            Activity? activity = Activity.Current;
+            string? traceId = activity?.TraceId.ToString();
+            string? spanId = activity?.SpanId.ToString();
+            string? traceParent = activity?.Id;
+
             using (LogContext.PushProperty("CorrelationId", correlationId))
             using (LogContext.PushProperty("RequestId", context.TraceIdentifier))
+            using (LogContext.PushProperty("TraceId", traceId))
+            using (LogContext.PushProperty("SpanId", spanId))
+            using (LogContext.PushProperty("TraceParent", traceParent))
             {
                 await next(context);
             }
@@ -108,12 +117,17 @@ public static class RequestLoggingExtensions
             // Request logging should default to operational metadata only.
             options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
             {
+                Activity? activity = Activity.Current;
+
                 diagnosticContext.Set("CorrelationId", GetCorrelationId(httpContext, requestLoggingOptions));
                 diagnosticContext.Set("RequestId", httpContext.TraceIdentifier);
                 diagnosticContext.Set("TraceIdentifier", httpContext.TraceIdentifier);
                 diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
                 diagnosticContext.Set("RequestScheme", httpContext.Request.Scheme);
                 diagnosticContext.Set("RequestPathBase", httpContext.Request.PathBase.Value);
+                diagnosticContext.Set("TraceId", activity?.TraceId.ToString());
+                diagnosticContext.Set("SpanId", activity?.SpanId.ToString());
+                diagnosticContext.Set("TraceParent", activity?.Id);
 
                 if (requestLoggingOptions.IncludeQueryString)
                 {

--- a/src/ProjectTemplate.Web/Program.cs
+++ b/src/ProjectTemplate.Web/Program.cs
@@ -1,16 +1,20 @@
+using System.Diagnostics;
 using System.Globalization;
 using ProjectTemplate.Web.Authentication.Extensions;
 using ProjectTemplate.Web.ErrorHandling;
 using ProjectTemplate.Web.Extensions;
 using Serilog;
 
+Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+Activity.ForceDefaultIdFormat = true;
+
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .WriteTo.Debug(
-        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}",
+        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}",
         formatProvider: CultureInfo.InvariantCulture)
     .WriteTo.Console(
-        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}",
+        outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}",
         formatProvider: CultureInfo.InvariantCulture)
     .CreateBootstrapLogger();
 

--- a/src/ProjectTemplate.Web/appsettings.Development.json
+++ b/src/ProjectTemplate.Web/appsettings.Development.json
@@ -12,14 +12,14 @@
         "Name": "Debug",
         "Args": {
           "minimumLevel": "Debug",
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
         }
       },
       {
         "Name": "Console",
         "Args": {
           "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
         }
       },
       {
@@ -33,7 +33,7 @@
           "rollOnFileSizeLimit": true,
           "shared": true,
           "flushToDiskInterval": "00:00:01",
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
         }
       }
     ]

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -35,7 +35,7 @@
         "Name": "Console",
         "Args": {
           "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
         }
       },
       {
@@ -48,7 +48,7 @@
           "rollOnFileSizeLimit": true,
           "shared": true,
           "flushToDiskInterval": "00:00:01",
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] [CorrelationId: {CorrelationId}] [TraceId: {TraceId}] [SpanId: {SpanId}] [RequestId: {RequestId}] [RequestPath: {RequestPath}] {Message:lj}{NewLine}{Exception}"
         }
       }
     ]

--- a/tests/ProjectTemplate.Web.Tests/AdvertisedBehaviorTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AdvertisedBehaviorTests.cs
@@ -20,8 +20,14 @@ public sealed class AdvertisedBehaviorTests
         using ApplicationWebApplicationFactory factory = CreateFactory();
         using HttpClient client = factory.CreateHttpsClient();
 
-        using HttpResponseMessage response = await client.GetAsync(
-            "/api/v1/advertised-behavior/missing",
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/api/v1/advertised-behavior/missing");
+
+        request.Headers.TryAddWithoutValidation("X-Correlation-ID", "test-correlation-187");
+
+        using HttpResponseMessage response = await client.SendAsync(
+            request,
             TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -35,6 +41,7 @@ public sealed class AdvertisedBehaviorTests
         Assert.Equal(404, root.GetProperty("status").GetInt32());
         Assert.Equal("Not Found", root.GetProperty("title").GetString());
         Assert.Equal("/api/v1/advertised-behavior/missing", root.GetProperty("instance").GetString());
+        Assert.Equal("test-correlation-187", root.GetProperty("correlationId").GetString());
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("traceId").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("requestId").GetString()));
     }


### PR DESCRIPTION
## Summary

Completes the OpenTelemetry observability baseline by tightening the correlation path across request logging, Problem Details, and W3C trace context.

## Changes

- Forces W3C `Activity` identifiers for consistent trace context behavior.
- Adds `TraceId`, `SpanId`, and `TraceParent` enrichment to request logging.
- Includes safe `correlationId`, `requestId`, `traceId`, and `spanId` values in Problem Details responses.
- Updates Serilog output templates so logs can be correlated with traces and error responses.
- Extends advertised behavior coverage for Problem Details correlation.
- Documents the log / trace / Problem Details correlation story.

## Validation

- [x] `dotnet test`
```powershell
Restore complete (2.5s)
  ProjectTemplate.Infrastructure net10.0 succeeded (15.2s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (13.5s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.6s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.34]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:00.70]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:00.99]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:06.91]   Finished:    ProjectTemplate.Web.Tests (ID = 'b73a943d775b2b9714d3794b049d8db32ae1a954b06893bc61c06a8ee9d0e5e9')
  ProjectTemplate.Web.Tests test net10.0 succeeded (7.9s)

Test summary: total: 127, failed: 0, succeeded: 127, skipped: 0, duration: 7.9s
Build succeeded in 43.6s
```


Closes #187
