### PR TITLE
Add minimal auth and data provider template options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,11 +299,6 @@ jobs:
             --authProvider none `
             --dbProvider sqlserver
 
-      - name: Validate non-default scaffolded consumer manifest
-        if: runner.os == 'Linux'
-        shell: pwsh
-        run: ./eng/Validate-ScaffoldManifest.ps1 -ScaffoldRoot ./artifacts/scaffold/ContosoNoAuthSqlServer
-
       - name: Validate non-default scaffolded configuration
         if: runner.os == 'Linux'
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,71 @@ jobs:
         working-directory: ./artifacts/scaffold/ContosoSecurityPortal
         run: docker compose -p contososecurityportal-ci down --volumes --remove-orphans
 
+
+      - name: Scaffold non-default consumer project
+        if: runner.os == 'Linux'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path ./artifacts/scaffold -Force | Out-Null
+          dotnet new netcoreapp-template `
+            --name ContosoNoAuthSqlServer `
+            --output ./artifacts/scaffold/ContosoNoAuthSqlServer `
+            --skipRestore true `
+            --authProvider none `
+            --dbProvider sqlserver
+
+      - name: Validate non-default scaffolded consumer manifest
+        if: runner.os == 'Linux'
+        shell: pwsh
+        run: ./eng/Validate-ScaffoldManifest.ps1 -ScaffoldRoot ./artifacts/scaffold/ContosoNoAuthSqlServer
+
+      - name: Validate non-default scaffolded configuration
+        if: runner.os == 'Linux'
+        shell: pwsh
+        run: |
+          $appsettingsPath = "./artifacts/scaffold/ContosoNoAuthSqlServer/src/ContosoNoAuthSqlServer.Web/appsettings.json"
+
+          if (-not (Test-Path -LiteralPath $appsettingsPath -PathType Leaf)) {
+              Write-Error "Generated appsettings.json was not found: $appsettingsPath"
+              exit 1
+          }
+
+          $settings = Get-Content -LiteralPath $appsettingsPath -Raw | ConvertFrom-Json
+
+          if ($settings.ProjectTemplate.Authentication.Enabled -ne $false) {
+              Write-Error "Expected ProjectTemplate:Authentication:Enabled to be false."
+              exit 1
+          }
+
+          if ($settings.ProjectTemplate.Authentication.Cookie.Enabled -ne $false) {
+              Write-Error "Expected ProjectTemplate:Authentication:Cookie:Enabled to be false."
+              exit 1
+          }
+
+          if ($settings.ProjectTemplate.DataAccess.Provider -ne "SqlServer") {
+              Write-Error "Expected ProjectTemplate:DataAccess:Provider to be SqlServer."
+              exit 1
+          }
+
+          if ($settings.ProjectTemplate.DataAccess.ConnectionStringName -ne "ApplicationSqlServer") {
+              Write-Error "Expected ProjectTemplate:DataAccess:ConnectionStringName to be ApplicationSqlServer."
+              exit 1
+          }
+
+      - name: Build non-default scaffolded output
+        if: runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoNoAuthSqlServer
+        run: |
+          dotnet restore ./ContosoNoAuthSqlServer.slnx
+          dotnet build ./ContosoNoAuthSqlServer.slnx --configuration $env:CONFIGURATION --no-restore /p:ContinuousIntegrationBuild=true
+
+      - name: Test non-default scaffolded output
+        if: runner.os == 'Linux'
+        shell: pwsh
+        working-directory: ./artifacts/scaffold/ContosoNoAuthSqlServer
+        run: dotnet test ./ContosoNoAuthSqlServer.slnx --configuration $env:CONFIGURATION --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
+
       - name: Uninstall template package
         if: always()
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,9 +295,9 @@ jobs:
           dotnet new netcoreapp-template `
             --name ContosoNoAuthSqlServer `
             --output ./artifacts/scaffold/ContosoNoAuthSqlServer `
-            --skipRestore true `
-            --authProvider none `
-            --dbProvider sqlserver
+            --skipRestore=true `
+            --authProvider=none `
+            --dbProvider=sqlserver
 
       - name: Validate non-default scaffolded configuration
         if: runner.os == 'Linux'
@@ -311,6 +311,10 @@ jobs:
           }
 
           $settings = Get-Content -LiteralPath $appsettingsPath -Raw | ConvertFrom-Json
+          Write-Host "Generated auth enabled: $($settings.ProjectTemplate.Authentication.Enabled)"
+          Write-Host "Generated cookie enabled: $($settings.ProjectTemplate.Authentication.Cookie.Enabled)"
+          Write-Host "Generated data provider: $($settings.ProjectTemplate.DataAccess.Provider)"
+          Write-Host "Generated connection string name: $($settings.ProjectTemplate.DataAccess.ConnectionStringName)"
 
           if ($settings.ProjectTemplate.Authentication.Enabled -ne $false) {
               Write-Error "Expected ProjectTemplate:Authentication:Enabled to be false."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,29 +310,37 @@ jobs:
               exit 1
           }
 
+          $projectName = "ContosoNoAuthSqlServer"
           $settings = Get-Content -LiteralPath $appsettingsPath -Raw | ConvertFrom-Json
-          Write-Host "Generated auth enabled: $($settings.ProjectTemplate.Authentication.Enabled)"
-          Write-Host "Generated cookie enabled: $($settings.ProjectTemplate.Authentication.Cookie.Enabled)"
-          Write-Host "Generated data provider: $($settings.ProjectTemplate.DataAccess.Provider)"
-          Write-Host "Generated connection string name: $($settings.ProjectTemplate.DataAccess.ConnectionStringName)"
+          $projectSettings = $settings.PSObject.Properties[$projectName].Value
 
-          if ($settings.ProjectTemplate.Authentication.Enabled -ne $false) {
-              Write-Error "Expected ProjectTemplate:Authentication:Enabled to be false."
+          if ($null -eq $projectSettings) {
+              Write-Error "Expected generated appsettings root '$projectName' was not found."
               exit 1
           }
 
-          if ($settings.ProjectTemplate.Authentication.Cookie.Enabled -ne $false) {
-              Write-Error "Expected ProjectTemplate:Authentication:Cookie:Enabled to be false."
+          Write-Host "Generated auth enabled: $($projectSettings.Authentication.Enabled)"
+          Write-Host "Generated cookie enabled: $($projectSettings.Authentication.Cookie.Enabled)"
+          Write-Host "Generated data provider: $($projectSettings.DataAccess.Provider)"
+          Write-Host "Generated connection string name: $($projectSettings.DataAccess.ConnectionStringName)"
+
+          if ($projectSettings.Authentication.Enabled -ne $false) {
+              Write-Error "Expected ${projectName}:Authentication:Enabled to be false."
               exit 1
           }
 
-          if ($settings.ProjectTemplate.DataAccess.Provider -ne "SqlServer") {
-              Write-Error "Expected ProjectTemplate:DataAccess:Provider to be SqlServer."
+          if ($projectSettings.Authentication.Cookie.Enabled -ne $false) {
+              Write-Error "Expected ${projectName}:Authentication:Cookie:Enabled to be false."
               exit 1
           }
 
-          if ($settings.ProjectTemplate.DataAccess.ConnectionStringName -ne "ApplicationSqlServer") {
-              Write-Error "Expected ProjectTemplate:DataAccess:ConnectionStringName to be ApplicationSqlServer."
+          if ($projectSettings.DataAccess.Provider -ne "SqlServer") {
+              Write-Error "Expected ${projectName}:DataAccess:Provider to be SqlServer."
+              exit 1
+          }
+
+          if ($projectSettings.DataAccess.ConnectionStringName -ne "ApplicationSqlServer") {
+              Write-Error "Expected ${projectName}:DataAccess:ConnectionStringName to be ApplicationSqlServer."
               exit 1
           }
 

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -185,7 +185,9 @@
       "source": "./.template.content/",
       "target": "./",
       "include": [
-        "README.md"
+        "README.md",
+        "nuget.config",
+        "src/ProjectTemplate.Web/appsettings.json"
       ]
     }
   ],

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -26,6 +26,95 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Skips the post-create NuGet restore action when set to true."
+    },
+    "authProvider": {
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "cookie",
+      "description": "Selects the generated authentication baseline.",
+      "choices": [
+        {
+          "choice": "cookie",
+          "description": "Generates the default cookie-authentication-ready baseline."
+        },
+        {
+          "choice": "none",
+          "description": "Generates the application with application authentication disabled by default."
+        }
+      ]
+    },
+    "dbProvider": {
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "sqlite",
+      "description": "Selects the generated EF Core provider configuration.",
+      "choices": [
+        {
+          "choice": "sqlite",
+          "description": "Generates the default SQLite development configuration."
+        },
+        {
+          "choice": "sqlserver",
+          "description": "Generates the SQL Server provider configuration."
+        }
+      ]
+    },
+    "templateAuthEnabled": {
+      "type": "generated",
+      "generator": "switch",
+      "datatype": "string",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(authProvider == \"none\")",
+            "value": "false"
+          },
+          {
+            "condition": "(authProvider == \"cookie\")",
+            "value": "true"
+          }
+        ]
+      },
+      "replaces": "TemplateAuthEnabled"
+    },
+    "templateDataProvider": {
+      "type": "generated",
+      "generator": "switch",
+      "datatype": "string",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(dbProvider == \"sqlserver\")",
+            "value": "SqlServer"
+          },
+          {
+            "condition": "(dbProvider == \"sqlite\")",
+            "value": "Sqlite"
+          }
+        ]
+      },
+      "replaces": "TemplateDataProvider"
+    },
+    "templateDataConnectionStringName": {
+      "type": "generated",
+      "generator": "switch",
+      "datatype": "string",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(dbProvider == \"sqlserver\")",
+            "value": "ApplicationSqlServer"
+          },
+          {
+            "condition": "(dbProvider == \"sqlite\")",
+            "value": "ApplicationDatabase"
+          }
+        ]
+      },
+      "replaces": "TemplateDataConnectionStringName"
     }
   },
   "primaryOutputs": [

--- a/.template.content/README.md
+++ b/.template.content/README.md
@@ -22,6 +22,19 @@ The generated solution includes a production-oriented baseline for common web ap
 - .NET SDK 10.0 or later.
 - Docker Desktop or a compatible container runtime, only if you plan to use Docker Compose.
 
+## Template Options Used
+
+This project was generated from the `netcoreapp-template` template.
+
+The template supports a small set of scaffold options for common application variants:
+
+| Option | Default | Supported values | Description |
+|:---|:---|:---|:---|
+| `authProvider` | `cookie` | `cookie`, `none` | Selects whether the generated application starts with the cookie-authentication-ready baseline or with application authentication disabled by default. |
+| `dbProvider` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. |
+
+The generated application still includes the core production-oriented guardrails regardless of these options, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
+
 ## Restore
 
 ```powershell

--- a/.template.content/README.md
+++ b/.template.content/README.md
@@ -35,6 +35,14 @@ The template supports a small set of scaffold options for common application var
 
 The generated application still includes the core production-oriented guardrails regardless of these options, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
 
+### Authentication-disabled scaffolds
+
+When `--authProvider none` is used, application authentication and cookie authentication are disabled in the generated `appsettings.json`.
+
+This is intended for applications that do not need local cookie authentication at scaffold time, or that plan to add a different authentication approach later.
+
+Authentication and authorization tests that intentionally exercise protected endpoints may need to enable test authentication through in-memory test configuration.
+
 ## Restore
 
 ```powershell

--- a/.template.content/nuget.config
+++ b/.template.content/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/.template.content/src/ProjectTemplate.Web/appsettings.json
+++ b/.template.content/src/ProjectTemplate.Web/appsettings.json
@@ -128,12 +128,12 @@
       }
     },
     "Authentication": {
-      "Enabled": true,
+      "Enabled": TemplateAuthEnabled,
       "DefaultScheme": "Cookies",
       "DefaultChallengeScheme": "Cookies",
       "DefaultSignInScheme": "Cookies",
       "Cookie": {
-        "Enabled": true,
+        "Enabled": TemplateAuthEnabled,
         "Scheme": "Cookies",
         "LoginPath": "/Account/Login",
         "LogoutPath": "/Account/Logout",
@@ -220,8 +220,8 @@
       ]
     },
     "DataAccess": {
-      "Provider": "Sqlite",
-      "ConnectionStringName": "ApplicationDatabase",
+      "Provider": "TemplateDataProvider",
+      "ConnectionStringName": "TemplateDataConnectionStringName",
       "Auditing": {
         "Enabled": true
       }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,8 @@
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <EnableSourceLink Condition="'$(EnableSourceLink)' == '' and '$(GITHUB_ACTIONS)' == 'true'">true</EnableSourceLink>
+    <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
     <Deterministic>true</Deterministic>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ dotnet build --configuration Release
 dotnet test --configuration Release
 ```
 
+Generate a non-default scaffold with authentication disabled and SQL Server selected as the data provider:
+
+```powershell
+dotnet new netcoreapp-template `
+  --name ContosoNoAuthSqlServer `
+  --authProvider none `
+  --dbProvider sqlserver
+```
+
+Build and test the non-default generated output:
+
+```powershell
+cd ContosoNoAuthSqlServer
+dotnet restore
+dotnet build --configuration Release
+dotnet test --configuration Release
+```
+
+The non-default scaffold preserves the template's core guardrails, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
+
+
 Update the installed template by installing a newer package version:
 
 ```powershell

--- a/docs/articles/build-quality.md
+++ b/docs/articles/build-quality.md
@@ -92,7 +92,6 @@ Analyzer settings are intentionally production-oriented but not configured as gl
 Before a release, the expected validation path is:
 
 ```powershell
-dotnet restore ./NetCoreApplicationTemplate.slnx
 dotnet build ./NetCoreApplicationTemplate.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
 dotnet format ./NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal
 dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true

--- a/docs/articles/public-surface-v1.md
+++ b/docs/articles/public-surface-v1.md
@@ -30,11 +30,13 @@ Changing, removing, or repurposing these values after `v1.0.0` is a breaking cha
 
 The following template symbols are part of the v1.0 public surface.
 
-| Symbol | Type | Default | Contract |
-|:---|:---|:---|:---|
-| `skipRestore` | `bool` | `false` | Controls whether the post-create NuGet restore action runs. |
+| Symbol | Type | Default | Supported values | Contract |
+|:---|:---|:---|:---|:---|
+| `skipRestore` | `bool` | `false` | `true`, `false` | Controls whether the post-create NuGet restore action runs. |
+| `authProvider` | `choice` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. `cookie` generates the default cookie-authentication-ready baseline. `none` generates the application with application authentication disabled by default. |
+| `dbProvider` | `choice` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. `sqlite` generates the default SQLite development configuration. `sqlserver` generates the SQL Server provider configuration. |
 
-Breaking changes include renaming the symbol, removing it, inverting its meaning, changing its default in a behavior-changing way, or making generated output depend on it differently without a migration path.
+Breaking changes include renaming a symbol, removing it, removing a documented supported value, inverting its meaning, changing its default in a behavior-changing way, or making generated output depend on it differently without a migration path.
 
 Adding a new optional symbol with a safe default is normally a minor change.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -100,6 +100,26 @@ Use a project name that is also a valid C# identifier, such as `ContosoSecurityP
 
 This creates a new project using `ContosoSecurityPortal` as the replacement name for the source template namespace and project prefix.
 
+## Template Options
+
+The template intentionally exposes a small set of stable options for common scaffold variants.
+
+| Option | Default | Supported values | Description |
+|:---|:---|:---|:---|
+| `--authProvider` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. Use `cookie` for the default cookie-authentication-ready baseline or `none` to generate the application with application authentication disabled by default. |
+| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. Use `sqlite` for the default local development configuration or `sqlserver` for the SQL Server provider configuration. |
+
+Example non-default scaffold:
+
+```powershell
+dotnet new netcoreapp-template `
+  --name ContosoNoAuthSqlServer `
+  --authProvider none `
+  --dbProvider sqlserver
+```
+
+All supported variants preserve the template's core infrastructure guardrails, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
+
 ## Restore, Build, and Test the Generated Project
 
 ```powershell

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -120,6 +120,12 @@ dotnet new netcoreapp-template `
 
 All supported variants preserve the template's core infrastructure guardrails, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
 
+### Authentication-disabled variant
+
+The `--authProvider none` option generates the application with `ProjectTemplate:Authentication:Enabled` and `ProjectTemplate:Authentication:Cookie:Enabled` set to `false`.
+
+The application still includes the authentication and authorization infrastructure so consumers can enable or replace authentication later. Test cases that intentionally exercise protected endpoints may enable test authentication through in-memory test configuration.
+
 ## Restore, Build, and Test the Generated Project
 
 ```powershell

--- a/eng/scaffold-manifest.default.json
+++ b/eng/scaffold-manifest.default.json
@@ -17,6 +17,7 @@
     "README.md",
     "docker-compose.yml",
     "global.json",
+    "nuget.config",
     "scripts/migration.sql",
     "src/ContosoSecurityPortal.Infrastructure/ContosoSecurityPortal.Infrastructure.csproj",
     "src/ContosoSecurityPortal.Web/ContosoSecurityPortal.Web.csproj",

--- a/src/ProjectTemplate.Infrastructure/ProjectTemplate.Infrastructure.csproj
+++ b/src/ProjectTemplate.Infrastructure/ProjectTemplate.Infrastructure.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Condition="'$(EnableSourceLink)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
+++ b/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Condition="'$(EnableSourceLink)' == 'true'" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
     <PackageReference Include="Serilog.Enrichers.Thread" />

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -128,12 +128,12 @@
       }
     },
     "Authentication": {
-      "Enabled": true,
+      "Enabled": TemplateAuthEnabled,
       "DefaultScheme": "Cookies",
       "DefaultChallengeScheme": "Cookies",
       "DefaultSignInScheme": "Cookies",
       "Cookie": {
-        "Enabled": true,
+        "Enabled": TemplateAuthEnabled,
         "Scheme": "Cookies",
         "LoginPath": "/Account/Login",
         "LogoutPath": "/Account/Logout",
@@ -220,8 +220,8 @@
       ]
     },
     "DataAccess": {
-      "Provider": "Sqlite",
-      "ConnectionStringName": "ApplicationDatabase",
+      "Provider": "TemplateDataProvider",
+      "ConnectionStringName": "TemplateDataConnectionStringName",
       "Auditing": {
         "Enabled": true
       }

--- a/tests/ProjectTemplate.Web.Tests/AuthenticationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthenticationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ProjectTemplate.Web.Authentication.Options;
@@ -102,23 +103,32 @@ public sealed class AuthenticationTests
     }
 
     /// <summary>
-    /// Verifies the application authentication and cookie authentication are enabled by default for the base application.
+    /// Verifies that the authentication options match the expected values based on the provided configuration.
     /// </summary>
     [Fact]
-    public void AuthenticationOptions_AreEnabledByDefault()
+    public void AuthenticationOptions_MatchGeneratedConfiguration()
     {
         using ApplicationWebApplicationFactory factory = CreateFactory(new Dictionary<string, string?>());
+
+        IConfiguration configuration = factory.Services.GetRequiredService<IConfiguration>();
 
         ApplicationAuthenticationOptions options = factory.Services
             .GetRequiredService<IOptions<ApplicationAuthenticationOptions>>()
             .Value;
 
-        Assert.True(options.Enabled);
-        Assert.True(options.Cookie.Enabled);
+        bool expectedAuthenticationEnabled = bool.TryParse(
+            configuration["ProjectTemplate:Authentication:Enabled"],
+            out bool authenticationEnabled) && authenticationEnabled;
+
+        bool expectedCookieEnabled = bool.TryParse(
+            configuration["ProjectTemplate:Authentication:Cookie:Enabled"],
+            out bool cookieEnabled) && cookieEnabled;
+
+        Assert.Equal(expectedAuthenticationEnabled, options.Enabled);
+        Assert.Equal(expectedCookieEnabled, options.Cookie.Enabled);
         Assert.Equal("Cookies", options.DefaultScheme);
         Assert.Equal("Cookies", options.Cookie.Scheme);
     }
-
     /// <summary>
     /// Verifies that anonymous endpoints remain accessible when authentication is disabled.
     /// </summary>

--- a/tests/ProjectTemplate.Web.Tests/AuthenticationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthenticationTests.cs
@@ -129,6 +129,7 @@ public sealed class AuthenticationTests
         Assert.Equal("Cookies", options.DefaultScheme);
         Assert.Equal("Cookies", options.Cookie.Scheme);
     }
+
     /// <summary>
     /// Verifies that anonymous endpoints remain accessible when authentication is disabled.
     /// </summary>

--- a/tests/ProjectTemplate.Web.Tests/AuthorizationPolicyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthorizationPolicyTests.cs
@@ -218,6 +218,8 @@ public sealed class AuthorizationPolicyTests
             ["ProjectTemplate:Authentication:DefaultScheme"] = _testAuthenticationScheme,
             ["ProjectTemplate:Authentication:DefaultChallengeScheme"] = _testAuthenticationScheme,
             ["ProjectTemplate:Authentication:DefaultSignInScheme"] = _testAuthenticationScheme,
+            ["ProjectTemplate:Authentication:Cookie:Enabled"] = "true",
+            ["ProjectTemplate:Authentication:Cookie:Scheme"] = "Cookies",
             ["ProjectTemplate:Authorization:RoleClaimType"] = ApplicationClaimTypes.Role,
             ["ProjectTemplate:Authorization:PermissionClaimType"] = ApplicationClaimTypes.Permission,
             ["ProjectTemplate:Authorization:AdministratorRoles:0"] = "Administrator",

--- a/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
+++ b/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
@@ -11,7 +11,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Condition="'$(EnableSourceLink)' == 'true'" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Adds minimal `authProvider` and `dbProvider` template symbols.
- Supports `authProvider` values:
  - `cookie`
  - `none`
- Supports `dbProvider` values:
  - `sqlite`
  - `sqlserver`
- Adds generated configuration behavior for authentication and EF Core provider selection.
- Adds consumer `nuget.config` handling so generated projects avoid inherited package-source warning noise.
- Updates generated consumer README and template packaging documentation with the new scaffold options.
- Updates the v1.0 public-surface documentation to include the new stable symbols.
- Updates authentication/authorization tests so generated non-default scaffolds continue to build and test cleanly.
- Adds smoke-test coverage for a non-default scaffold using `authProvider none` and `dbProvider sqlserver`.

## Validation

- `dotnet format ./NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`
- `dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release`
```powershell
Restore complete (2.6s)
  ProjectTemplate.Infrastructure net10.0 succeeded (1.0s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.5s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (0.6s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.71]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.05]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.34]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:08.52]   Finished:    ProjectTemplate.Web.Tests (ID = 'b73a943d775b2b9714d3794b049d8db32ae1a954b06893bc61c06a8ee9d0e5e9')
  ProjectTemplate.Web.Tests test net10.0 succeeded (9.7s)

Test summary: total: 127, failed: 0, succeeded: 127, skipped: 0, duration: 9.7s
Build succeeded in 15.5s
```
- Default generated scaffold:
  - `dotnet restore`
  - `dotnet build --configuration Release`
  - `dotnet test --configuration Release`
```powershell
Restore complete (2.3s)
  ContosoSecurityDefaults.Infrastructure net10.0 succeeded (6.1s) → src\ContosoSecurityDefaults.Infrastructure\bin\Release\net10.0\ContosoSecurityDefaults.Infrastructure.dll
  ContosoSecurityDefaults.Web net10.0 succeeded (12.2s) → src\ContosoSecurityDefaults.Web\bin\Release\net10.0\ContosoSecurityDefaults.Web.dll
  ContosoSecurityDefaults.Web.Tests net10.0 succeeded (9.5s) → tests\ContosoSecurityDefaults.Web.Tests\bin\Release\net10.0\ContosoSecurityDefaults.Web.Tests.dll

Build succeeded in 26.5s
```
```powershell
Restore complete (2.4s)
  ContosoSecurityDefaults.Infrastructure net10.0 succeeded (1.1s) → src\ContosoSecurityDefaults.Infrastructure\bin\Release\net10.0\ContosoSecurityDefaults.Infrastructure.dll
  ContosoSecurityDefaults.Web net10.0 succeeded (0.3s) → src\ContosoSecurityDefaults.Web\bin\Release\net10.0\ContosoSecurityDefaults.Web.dll
  ContosoSecurityDefaults.Web.Tests net10.0 succeeded (0.5s) → tests\ContosoSecurityDefaults.Web.Tests\bin\Release\net10.0\ContosoSecurityDefaults.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.29]   Discovering: ContosoSecurityDefaults.Web.Tests
[xUnit.net 00:00:00.65]   Discovered:  ContosoSecurityDefaults.Web.Tests
[xUnit.net 00:00:00.93]   Starting:    ContosoSecurityDefaults.Web.Tests
[xUnit.net 00:00:07.32]   Finished:    ContosoSecurityDefaults.Web.Tests (ID = 'ed173e50d74fa589ec9a0681b13b99779860b4b7caf82a08b42432189bbf25a5')
  ContosoSecurityDefaults.Web.Tests test net10.0 succeeded (8.2s)

Test summary: total: 127, failed: 0, succeeded: 127, skipped: 0, duration: 8.2s
Build succeeded in 12.9s
```
- Non-default generated scaffold:
  - `dotnet new netcoreapp-template --name ContosoNoAuthSqlServer --authProvider none --dbProvider sqlserver`
  - `dotnet restore`
  - `dotnet build --configuration Release`
  - `dotnet test --configuration Release`
```powershell
Restore complete (2.4s)
  ContosoSecurityNoAuthSqlServer.Infrastructure net10.0 succeeded (2.4s) → src\ContosoSecurityNoAuthSqlServer.Infrastructure\bin\Release\net10.0\ContosoSecurityNoAuthSqlServer.Infrastructure.dll
  ContosoSecurityNoAuthSqlServer.Web net10.0 succeeded (4.4s) → src\ContosoSecurityNoAuthSqlServer.Web\bin\Release\net10.0\ContosoSecurityNoAuthSqlServer.Web.dll
  ContosoSecurityNoAuthSqlServer.Web.Tests net10.0 succeeded (4.9s) → tests\ContosoSecurityNoAuthSqlServer.Web.Tests\bin\Release\net10.0\ContosoSecurityNoAuthSqlServer.Web.Tests.dll

Build succeeded in 12.9s
```
```powershell
Restore complete (2.4s)
  ContosoSecurityNoAuthSqlServer.Infrastructure net10.0 succeeded (0.9s) → src\ContosoSecurityNoAuthSqlServer.Infrastructure\bin\Release\net10.0\ContosoSecurityNoAuthSqlServer.Infrastructure.dll
  ContosoSecurityNoAuthSqlServer.Web net10.0 succeeded (0.5s) → src\ContosoSecurityNoAuthSqlServer.Web\bin\Release\net10.0\ContosoSecurityNoAuthSqlServer.Web.dll
  ContosoSecurityNoAuthSqlServer.Web.Tests net10.0 succeeded (0.5s) → tests\ContosoSecurityNoAuthSqlServer.Web.Tests\bin\Release\net10.0\ContosoSecurityNoAuthSqlServer.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.32]   Discovering: ContosoSecurityNoAuthSqlServer.Web.Tests
[xUnit.net 00:00:00.64]   Discovered:  ContosoSecurityNoAuthSqlServer.Web.Tests
[xUnit.net 00:00:00.94]   Starting:    ContosoSecurityNoAuthSqlServer.Web.Tests
[xUnit.net 00:00:08.87]   Finished:    ContosoSecurityNoAuthSqlServer.Web.Tests (ID = '095422615082738b414d7d76f07755603b5ef920eb2be3f76a6582b13d6c2db8')
  ContosoSecurityNoAuthSqlServer.Web.Tests test net10.0 succeeded (9.9s)

Test summary: total: 127, failed: 0, succeeded: 127, skipped: 0, duration: 9.9s
Build succeeded in 15.0s
```

Closes #186