### PR TITLE
Add optimistic concurrency handling for data entities

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />

--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -55,9 +55,6 @@ With the default configuration, the application resolves:
 ConnectionStrings:ApplicationDatabase
 ```
 
-
-
-
 EF Core migrations are stored in the infrastructure project because `ProjectTemplate.Infrastructure` owns the `ApplicationDbContext`, entities, and EF Core configuration.
 
 The web project is used as the startup project because it provides application configuration, dependency injection, provider setup, and connection-string resolution.
@@ -223,6 +220,19 @@ When the application starts, the data access startup log records the configured 
 When auditing is enabled, audit records are written to the application database. The template does not include automatic pruning, retention, archival, legal hold, masking, export, or purge behavior for audit records.
 
 Consuming applications are responsible for deciding how audit records are retained, archived, masked, purged, or moved to long-term storage. Before enabling auditing in production, review whether audited values may contain sensitive or regulated data.
+
+
+## Optimistic Concurrency
+
+The template includes baseline optimistic concurrency detection for entities that inherit from `DataEntity`.
+
+Each data entity includes a `ConcurrencyStamp` value. EF Core configures this value as a concurrency token. When an entity is updated or deleted, EF Core includes the original concurrency token value in the database update check. If another context or application instance has already changed the row, the update affects zero rows and EF Core throws `DbUpdateConcurrencyException`.
+
+The template uses an application-managed string concurrency stamp instead of a database-generated SQL Server `rowversion`. This keeps the default behavior provider-safe for SQLite local development while still supporting SQL Server-oriented production paths.
+
+`ApplicationDbContext.SaveChanges` and `SaveChangesAsync` refresh the concurrency stamp for modified entities before saving. Concurrency conflicts are logged and rethrown. The template does not automatically retry, merge, or overwrite conflicting changes.
+
+Consuming applications should decide how to handle conflicts based on domain needs. Common options include showing the user a reload-and-retry message, re-querying the current database values, or implementing an application-specific merge workflow.
 
 
 ## Automatic Startup Migrations

--- a/scripts/migration.sql
+++ b/scripts/migration.sql
@@ -39,3 +39,13 @@ VALUES ('20260521230436_InitialCreate', '10.0.8');
 
 COMMIT;
 
+BEGIN TRANSACTION;
+ALTER TABLE "ExternalLoginAccounts" ADD "ConcurrencyStamp" TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE "AuditRecords" ADD "ConcurrencyStamp" TEXT NOT NULL DEFAULT '';
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260528165924_AddDataEntityConcurrencyStamp', '10.0.8');
+
+COMMIT;
+

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ProjectTemplate.Infrastructure.Data.Entities;
@@ -39,12 +40,22 @@ public sealed partial class ApplicationDbContext(
         ILogger logger,
         string efCoreMessage);
 
+    [LoggerMessage(
+        EventId = 19001,
+        Level = LogLevel.Warning,
+        Message = "Optimistic concurrency conflict detected while saving {EntryCount} tracked entity entries.")]
+    private static partial void LogOptimisticConcurrencyConflict(
+        ILogger logger,
+        int entryCount,
+        Exception exception);
+
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
+        ConfigureDataEntityDefaults(modelBuilder);
 
         base.OnModelCreating(modelBuilder);
     }
@@ -73,13 +84,19 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
+        ApplyConcurrencyStamps();
+
         if (!_auditOptions)
         {
-            return base.SaveChanges(acceptAllChangesOnSuccess);
+            return SaveChangesWithConcurrencyHandling(
+                () => base.SaveChanges(acceptAllChangesOnSuccess));
         }
 
         List<AuditEntry> auditEntries = OnBeforeSaveChanges();
-        int result = base.SaveChanges(acceptAllChangesOnSuccess);
+
+        int result = SaveChangesWithConcurrencyHandling(
+            () => base.SaveChanges(acceptAllChangesOnSuccess));
+
         _ = OnAfterSaveChanges(auditEntries);
 
         return result;
@@ -96,18 +113,22 @@ public sealed partial class ApplicationDbContext(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
+        ApplyConcurrencyStamps();
+
         if (!_auditOptions)
         {
-            return await base.SaveChangesAsync(
-                acceptAllChangesOnSuccess,
-                cancellationToken);
+            return await SaveChangesWithConcurrencyHandlingAsync(
+                () => base.SaveChangesAsync(
+                    acceptAllChangesOnSuccess,
+                    cancellationToken)).ConfigureAwait(false);
         }
 
         List<AuditEntry> auditEntries = OnBeforeSaveChanges();
 
-        int result = await base.SaveChangesAsync(
-            acceptAllChangesOnSuccess,
-            cancellationToken).ConfigureAwait(false);
+        int result = await SaveChangesWithConcurrencyHandlingAsync(
+            () => base.SaveChangesAsync(
+                acceptAllChangesOnSuccess,
+                cancellationToken)).ConfigureAwait(false);
 
         _ = await OnAfterSaveChangesAsync(auditEntries, cancellationToken)
             .ConfigureAwait(false);
@@ -257,5 +278,71 @@ public sealed partial class ApplicationDbContext(
         return await base
             .SaveChangesAsync(cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private static void ConfigureDataEntityDefaults(ModelBuilder modelBuilder)
+    {
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (!typeof(DataEntity).IsAssignableFrom(entityType.ClrType))
+            {
+                continue;
+            }
+
+            modelBuilder.Entity(entityType.ClrType)
+                .Property<string>(nameof(DataEntity.ConcurrencyStamp))
+                .HasMaxLength(64)
+                .IsRequired()
+                .IsConcurrencyToken();
+        }
+    }
+
+    private void ApplyConcurrencyStamps()
+    {
+        ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry<DataEntity> entry in ChangeTracker.Entries<DataEntity>())
+        {
+            if (entry.State == EntityState.Added)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Entity.ConcurrencyStamp))
+                {
+                    entry.Entity.ConcurrencyStamp = DataEntity.NewConcurrencyStamp();
+                }
+
+                continue;
+            }
+
+            if (entry.State == EntityState.Modified)
+            {
+                entry.Entity.ConcurrencyStamp = DataEntity.NewConcurrencyStamp();
+            }
+        }
+    }
+
+    private int SaveChangesWithConcurrencyHandling(Func<int> saveChanges)
+    {
+        try
+        {
+            return saveChanges();
+        }
+        catch (DbUpdateConcurrencyException exception)
+        {
+            LogOptimisticConcurrencyConflict(_logger, exception.Entries.Count, exception);
+            throw;
+        }
+    }
+
+    private async Task<int> SaveChangesWithConcurrencyHandlingAsync(Func<Task<int>> saveChanges)
+    {
+        try
+        {
+            return await saveChanges().ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException exception)
+        {
+            LogOptimisticConcurrencyConflict(_logger, exception.Entries.Count, exception);
+            throw;
+        }
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Entities/DataEntity.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Entities/DataEntity.cs
@@ -9,4 +9,15 @@ public abstract class DataEntity
     /// Gets or sets the primary key.
     /// </summary>
     public Guid Id { get; set; } = Guid.NewGuid();
+
+
+    /// <summary>
+    /// Gets or sets the optimistic concurrency token used to detect conflicting updates.
+    /// </summary>
+    public string ConcurrencyStamp { get; set; } = NewConcurrencyStamp();
+
+    internal static string NewConcurrencyStamp()
+    {
+        return Guid.NewGuid().ToString("N");
+    }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260528165924_AddDataEntityConcurrencyStamp.Designer.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260528165924_AddDataEntityConcurrencyStamp.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectTemplate.Infrastructure.Data;
 
@@ -10,9 +11,11 @@ using ProjectTemplate.Infrastructure.Data;
 namespace ProjectTemplate.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528165924_AddDataEntityConcurrencyStamp")]
+    partial class AddDataEntityConcurrencyStamp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260528165924_AddDataEntityConcurrencyStamp.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260528165924_AddDataEntityConcurrencyStamp.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectTemplate.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddDataEntityConcurrencyStamp : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "ConcurrencyStamp",
+            table: "ExternalLoginAccounts",
+            type: "TEXT",
+            maxLength: 64,
+            nullable: false,
+            defaultValue: "");
+
+        migrationBuilder.AddColumn<string>(
+            name: "ConcurrencyStamp",
+            table: "AuditRecords",
+            type: "TEXT",
+            maxLength: 64,
+            nullable: false,
+            defaultValue: "");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ConcurrencyStamp",
+            table: "ExternalLoginAccounts");
+
+        migrationBuilder.DropColumn(
+            name: "ConcurrencyStamp",
+            table: "AuditRecords");
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextConcurrencyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextConcurrencyTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationDbContextConcurrencyTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_StaleEntityUpdate_ThrowsDbUpdateConcurrencyException()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        Guid accountId;
+
+        await using (ApplicationDbContext setupContext = CreateContext(connection, auditingEnabled: false))
+        {
+            await setupContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+            ExternalLoginAccount account = new()
+            {
+                LocalUserId = Guid.NewGuid(),
+                ProviderName = "GitHub",
+                ProviderUserId = "concurrency-user",
+                DisplayName = "Original User",
+                Email = "original@example.com",
+                CreatedOnUtc = DateTime.UtcNow
+            };
+
+            await setupContext.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+            await setupContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            accountId = account.Id;
+        }
+
+        await using ApplicationDbContext staleContext = CreateContext(connection, auditingEnabled: false);
+        await using ApplicationDbContext winningContext = CreateContext(connection, auditingEnabled: false);
+
+        ExternalLoginAccount staleAccount = await staleContext.ExternalLoginAccounts
+            .SingleAsync(account => account.Id == accountId, TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount winningAccount = await winningContext.ExternalLoginAccounts
+            .SingleAsync(account => account.Id == accountId, TestContext.Current.CancellationToken);
+
+        winningAccount.DisplayName = "Winning Update";
+        await winningContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        staleAccount.DisplayName = "Stale Update";
+
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+            async () => await staleContext.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void SaveChanges_StaleEntityUpdate_ThrowsDbUpdateConcurrencyException()
+    {
+        using SqliteConnection connection = new("Data Source=:memory:");
+        connection.Open();
+
+        Guid accountId;
+
+        using (ApplicationDbContext setupContext = CreateContext(connection, auditingEnabled: false))
+        {
+            setupContext.Database.EnsureCreated();
+
+            ExternalLoginAccount account = new()
+            {
+                LocalUserId = Guid.NewGuid(),
+                ProviderName = "Microsoft",
+                ProviderUserId = "sync-concurrency-user",
+                DisplayName = "Original User",
+                Email = "original@example.com",
+                CreatedOnUtc = DateTime.UtcNow
+            };
+
+            setupContext.ExternalLoginAccounts.Add(account);
+            setupContext.SaveChanges();
+
+            accountId = account.Id;
+        }
+
+        using ApplicationDbContext staleContext = CreateContext(connection, auditingEnabled: false);
+        using ApplicationDbContext winningContext = CreateContext(connection, auditingEnabled: false);
+
+        ExternalLoginAccount staleAccount = staleContext.ExternalLoginAccounts
+            .Single(account => account.Id == accountId);
+
+        ExternalLoginAccount winningAccount = winningContext.ExternalLoginAccounts
+            .Single(account => account.Id == accountId);
+
+        winningAccount.DisplayName = "Winning Sync Update";
+        winningContext.SaveChanges();
+
+        staleAccount.DisplayName = "Stale Sync Update";
+
+        Assert.Throws<DbUpdateConcurrencyException>(() => staleContext.SaveChanges());
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedEntity_UpdatesConcurrencyStamp()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "Google",
+            ProviderUserId = "stamp-user",
+            DisplayName = "Original User",
+            Email = "original@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        string originalStamp = account.ConcurrencyStamp;
+
+        account.DisplayName = "Updated User";
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(string.IsNullOrWhiteSpace(account.ConcurrencyStamp));
+        Assert.NotEqual(originalStamp, account.ConcurrencyStamp);
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled = true)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "UnitTest";
+    }
+}


### PR DESCRIPTION
## Summary

Adds baseline optimistic concurrency detection for EF Core data entities.

## Changes

- Added `ConcurrencyStamp` to the shared `DataEntity` base type.
- Configured the stamp as a required EF Core concurrency token for `DataEntity`-based entities.
- Updated `ApplicationDbContext.SaveChanges` and `SaveChangesAsync` to refresh stamps on modified entities.
- Added concurrency conflict logging while preserving `DbUpdateConcurrencyException` behavior.
- Added SQLite-backed tests proving stale sync and async updates fail.
- Documented the default provider-safe concurrency model.

## Notes

This intentionally detects conflicts only. It does not retry, merge, or resolve conflicts automatically. Generated applications can add domain-specific conflict-resolution behavior where needed.

Closes #199