### PR TITLE
Prepare release 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 0.5.6 - 2026-05-28
+
+### Added
+
+* Added optimistic concurrency handling for EF Core entities that inherit from `DataEntity`.
+* Added a provider-safe `ConcurrencyStamp` concurrency token for SQLite-oriented local development and SQL Server-oriented production paths.
+* Added EF Core migration support for the shared data-entity concurrency stamp.
+* Added tests proving stale entity updates are detected for both synchronous and asynchronous save paths.
+* Added scaffold validation coverage for generated template output, including default application configuration and NuGet configuration.
+
+### Changed
+
+* Updated `ApplicationDbContext.SaveChanges` and `SaveChangesAsync` to refresh concurrency stamps during modified entity saves.
+* Updated concurrency conflict behavior to surface diagnosable `DbUpdateConcurrencyException` failures rather than allowing silent last-writer-wins overwrites.
+* Updated data-access, template-packaging, telemetry, release, and public-surface documentation for the 0.5.6 release.
+* Updated test platform package references to the latest 18.6.0 test SDK/platform packages.
+
+### Fixed
+
+* Improved generated-template completeness by ensuring expected scaffold content is included and verified.
+
 ## 0.5.5 - 2026-05-26
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.5"
-date-released: "2026-05-26"
+version: "0.5.6"
+date-released: "2026-05-28"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.5</VersionPrefix>
+    <VersionPrefix>0.5.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.5.0</AssemblyVersion>
-    <FileVersion>0.5.5.0</FileVersion>
+    <AssemblyVersion>0.5.6.0</AssemblyVersion>
+    <FileVersion>0.5.6.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.5</VersionPrefix>
+    <VersionPrefix>0.5.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -5,7 +5,7 @@ This package installs the `netcoreapp-template` project template for `dotnet new
 ## Install from a local package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.5.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.5](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.5)__
+Current release: __[Release 0.5.6](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.6)__
 
-Tag: `v0.5.5`
+Tag: `v0.5.6`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.5.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg
 ```
 
 Generate a consumer project:
@@ -392,7 +392,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.5. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.6. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.5` |
+| Current package version | `0.5.6` |
 
 ## Consumer Scaffold Boundaries
 
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.5.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

Prepares release `0.5.6`.

## Changes

* Added provider-safe optimistic concurrency handling for EF Core `DataEntity`-based entities.
* Added a shared `ConcurrencyStamp` concurrency token and migration.
* Updated `ApplicationDbContext.SaveChanges` and `SaveChangesAsync` so modified entities receive refreshed concurrency stamps.
* Preserved EF Core’s normal `DbUpdateConcurrencyException` behavior so stale updates fail clearly instead of silently overwriting data.
* Added tests covering stale update detection through both synchronous and asynchronous save paths.
* Improved scaffolded template output validation and included generated-template defaults.
* Updated test platform packages to `18.6.0`.
* Updated data-access, template-packaging, telemetry, release, and public-surface documentation.

## Validation

* Confirmed optimistic concurrency behavior is covered by tests.
* Confirmed generated scaffold content is represented in the template output.
* Confirmed release metadata and documentation are aligned for `0.5.6`.

Closes #199
