### PR TITLE
Make data access optional with disabled EF Core mode

### DIFF
--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -37,9 +37,9 @@ Data access behavior is configured under `ProjectTemplate:DataAccess`:
 The configuration values are:
 |Setting|Purpose|
 |:------|:------|
-|`Provider`|Selects the EF Core database provider used by the application. The default local development provider is `Sqlite`.
-|`ConnectionStringName`|Identifies which named connection string should be resolved from `ConnectionStrings`.
-|`Auditing:Enabled`|Enables or disables EF Core audit record creation during `SaveChanges` and `SaveChangesAsync`.
+|`Provider`|Selects the data access mode. Supported values are `Sqlite`, `SqlServer`, `None`, and `Disabled`. The default local development provider is `Sqlite`.|
+|`ConnectionStringName`|Identifies which named connection string should be resolved from `ConnectionStrings` when data access is enabled. This value is not required when `Provider` is `None` or `Disabled`.|
+|`Auditing:Enabled`|Enables or disables EF Core audit record creation during `SaveChanges` and `SaveChangesAsync` when EF Core data access is enabled.|
 
 By default, the application uses:
 
@@ -58,6 +58,38 @@ ConnectionStrings:ApplicationDatabase
 EF Core migrations are stored in the infrastructure project because `ProjectTemplate.Infrastructure` owns the `ApplicationDbContext`, entities, and EF Core configuration.
 
 The web project is used as the startup project because it provides application configuration, dependency injection, provider setup, and connection-string resolution.
+
+## Disabled Data Access Mode
+
+Applications that do not need the template's EF Core data access layer can opt out explicitly:
+
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Provider": "None"
+  }
+}
+```
+
+`Disabled` is also accepted as an alias:
+
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Provider": "Disabled"
+  }
+}
+```
+
+When data access is disabled, the application does not register:
+
+- `ApplicationDbContext`
+- `IDbContextFactory<ApplicationDbContext>`
+- EF-backed application services that require `ApplicationDbContext`
+
+Disabled mode also does not require `ProjectTemplate:DataAccess:ConnectionStringName` to resolve to an existing connection string. This mode is appropriate for lightweight applications, workers, external modules, static front ends, or services that use a separate persistence strategy.
+
+Disabled mode should not be used by applications that need EF Core migrations, audit records, external login account persistence, or any service that depends on `ApplicationDbContext`.
 
 ## EF Core CLI Tool
 The dotnet ef command requires the EF Core command-line tool.
@@ -115,7 +147,7 @@ Generate a SQL script for review:
 dotnet ef migrations script `
   --project src/ProjectTemplate.Infrastructure `
   --startup-project src/ProjectTemplate.Web `
-  --context ApplicationDbContext
+  --context ApplicationDbContext `
   --output migration.sql
 ```
 ## Connection String Resolution
@@ -175,6 +207,8 @@ When `ConnectionStringName` is set to `ApplicationSqlServer`, the application re
 ConnectionStrings:ApplicationSqlServer
 ```
 
+When `Provider` is set to `None` or `Disabled`, connection string resolution is skipped.
+
 ## EF Core Auditing
 
 The template includes a baseline EF Core audit trail.
@@ -215,7 +249,7 @@ To disable audit record creation:
 }
 ```
 
-When the application starts, the data access startup log records the configured provider, connection string name, and EF Core auditing status.
+When the application starts, the data access startup log records the configured provider, connection string name, and EF Core auditing status. If data access is disabled, the startup log reports that EF Core services were not registered.
 
 When auditing is enabled, audit records are written to the application database. The template does not include automatic pruning, retention, archival, legal hold, masking, export, or purge behavior for audit records.
 
@@ -309,7 +343,7 @@ If migrations are not discovered, confirm that the command uses:
 --context ApplicationDbContext
 ```
 
-If data access provider configuration fails, confirm that `ProjectTemplate:DataAccess:Provider` is configured, that the selected provider package is referenced, and that `ProjectTemplate:DataAccess:ConnectionStringName` points to an existing named connection string under `ConnectionStrings`.
+If data access provider configuration fails, confirm that `ProjectTemplate:DataAccess:Provider` is configured. Use `Sqlite` or `SqlServer` when EF Core data access is required. Use `None` or `Disabled` only when the application intentionally does not need EF Core registrations.
 
 Future database providers, such as SQL Server, can be added by extending the data access registration configuration.
 SQLite remains the default development provider. SQL Server can be selected through configuration. Because EF Core migrations are provider-specific, production SQL Server deployments should generate and maintain SQL Server-compatible migrations before applying database updates.

--- a/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
@@ -27,11 +27,17 @@ public static class InfrastructureDataAccessServiceExtensions
             .Bind(configuration.GetSection(DataAccessOptions.SectionName))
             .Validate(options => !string.IsNullOrWhiteSpace(options.Provider),
                 "ProjectTemplate:DataAccess:Provider must not be empty.")
-            .Validate(options => !string.IsNullOrWhiteSpace(options.ConnectionStringName),
-                "ProjectTemplate:DataAccess:ConnectionStringName must not be empty.")
+            .Validate(options => DataAccessOptions.IsDisabledProvider(options.Provider)
+                || !string.IsNullOrWhiteSpace(options.ConnectionStringName),
+                "ProjectTemplate:DataAccess:ConnectionStringName must not be empty when data access is enabled.")
             .ValidateOnStart();
 
         DataAccessRegistration registration = ResolveDataAccessRegistration(configuration);
+
+        if (registration.IsDisabled)
+        {
+            return services;
+        }
 
         services.TryAddScoped<ICurrentActorAccessor, SystemCurrentActorAccessor>();
 
@@ -68,6 +74,11 @@ public static class InfrastructureDataAccessServiceExtensions
                 "Application data access provider was not configured.");
         }
 
+        if (DataAccessOptions.IsDisabledProvider(provider))
+        {
+            return DataAccessRegistration.Disabled(provider);
+        }
+
         if (string.IsNullOrWhiteSpace(connectionStringName))
         {
             throw new InvalidOperationException(
@@ -78,7 +89,7 @@ public static class InfrastructureDataAccessServiceExtensions
             ?? throw new InvalidOperationException(
                 $"Connection string '{connectionStringName}' was not configured.");
 
-        return new DataAccessRegistration(
+        return DataAccessRegistration.Enabled(
             provider,
             connectionString);
     }
@@ -88,23 +99,32 @@ public static class InfrastructureDataAccessServiceExtensions
         string provider,
         string connectionString)
     {
-        if (provider.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
+        if (provider.Equals(DataAccessOptions.SqliteProvider, StringComparison.OrdinalIgnoreCase))
         {
             options.UseSqlite(connectionString);
             return;
         }
 
-        if (provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
+        if (provider.Equals(DataAccessOptions.SqlServerProvider, StringComparison.OrdinalIgnoreCase))
         {
             options.UseSqlServer(connectionString);
             return;
         }
 
         throw new InvalidOperationException(
-            $"Unsupported data access provider '{provider}'. Supported providers: Sqlite, SqlServer.");
+            $"Unsupported data access provider '{provider}'. Supported providers: {DataAccessOptions.SqliteProvider}, {DataAccessOptions.SqlServerProvider}, {DataAccessOptions.DisabledProvider}.");
     }
 
     private readonly record struct DataAccessRegistration(
         string Provider,
-        string ConnectionString);
+        string ConnectionString,
+        bool IsDisabled)
+    {
+        public static DataAccessRegistration Enabled(
+            string provider,
+            string connectionString) => new(provider, connectionString, false);
+
+        public static DataAccessRegistration Disabled(
+            string provider) => new(provider, string.Empty, true);
+    }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
@@ -122,9 +122,15 @@ public static class InfrastructureDataAccessServiceExtensions
     {
         public static DataAccessRegistration Enabled(
             string provider,
-            string connectionString) => new(provider, connectionString, false);
+            string connectionString)
+        {
+            return new DataAccessRegistration(provider, connectionString, false);
+        }
 
         public static DataAccessRegistration Disabled(
-            string provider) => new(provider, string.Empty, true);
+            string provider)
+        {
+            return new DataAccessRegistration(provider, string.Empty, true);
+        }
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Options/DataAccessOptions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Options/DataAccessOptions.cs
@@ -5,9 +5,25 @@ public sealed class DataAccessOptions
 {
     public const string SectionName = "ProjectTemplate:DataAccess";
 
-    public string Provider { get; init; } = "Sqlite";
+    public const string SqliteProvider = "Sqlite";
+
+    public const string SqlServerProvider = "SqlServer";
+
+    public const string DisabledProvider = "None";
+
+    public const string DisabledProviderAlias = "Disabled";
+
+    public string Provider { get; init; } = SqliteProvider;
 
     public string ConnectionStringName { get; init; } = "ApplicationDatabase";
 
     public DataAuditingOptions Auditing { get; init; } = new();
+
+    public static bool IsDisabledProvider(string? provider)
+    {
+        string normalizedProvider = provider?.Trim() ?? string.Empty;
+
+        return normalizedProvider.Equals(DisabledProvider, StringComparison.OrdinalIgnoreCase)
+            || normalizedProvider.Equals(DisabledProviderAlias, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/ProjectTemplate.Web/Services/DataAccessStartupLogger.cs
+++ b/src/ProjectTemplate.Web/Services/DataAccessStartupLogger.cs
@@ -9,6 +9,15 @@ internal sealed partial class DataAccessStartupLogger(
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        if (DataAccessOptions.IsDisabledProvider(options.Value.Provider))
+        {
+            LogDataAccessDisabled(
+                logger,
+                options.Value.Provider);
+
+            return Task.CompletedTask;
+        }
+
         LogDataAccessConfiguration(
             logger,
             options.Value.Provider,
@@ -32,4 +41,12 @@ internal sealed partial class DataAccessStartupLogger(
         string provider,
         string connectionStringName,
         string auditingStatus);
+
+    [LoggerMessage(
+        EventId = 19101,
+        Level = LogLevel.Information,
+        Message = "Application data access disabled. Provider: {Provider}; EF Core services were not registered.")]
+    private static partial void LogDataAccessDisabled(
+        ILogger logger,
+        string provider);
 }

--- a/tests/ProjectTemplate.Web.Tests/DataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/DataAccessServiceExtensionsTests.cs
@@ -1,7 +1,9 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 using ProjectTemplate.Infrastructure.Data.Options;
 using ProjectTemplate.Web.Extensions;
 
@@ -80,6 +82,52 @@ public sealed class DataAccessServiceExtensionsTests
         using ApplicationDbContext context = serviceProvider.GetRequiredService<ApplicationDbContext>();
 
         Assert.Equal(expectedProviderName, context.Database.ProviderName);
+    }
+
+    /// <summary>
+    /// Verifies that data access can be intentionally disabled without requiring EF Core services.
+    /// </summary>
+    [Theory]
+    [InlineData("None")]
+    [InlineData("none")]
+    [InlineData("Disabled")]
+    [InlineData("disabled")]
+    public void AddApplicationDataAccess_DisabledProvider_SkipsEfCoreRegistrations(string provider)
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ProjectTemplate:DataAccess:Provider"] = provider
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        Assert.Null(serviceProvider.GetService<ApplicationDbContext>());
+        Assert.Null(serviceProvider.GetService<IDbContextFactory<ApplicationDbContext>>());
+        Assert.Null(serviceProvider.GetService<IExternalLoginAccountResolver>());
+    }
+
+    /// <summary>
+    /// Verifies that disabled data access does not require a configured connection string.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_DisabledProvider_DoesNotRequireConnectionStringName()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ProjectTemplate:DataAccess:Provider"] = "None",
+                ["ProjectTemplate:DataAccess:ConnectionStringName"] = string.Empty
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        DataAccessOptions options = serviceProvider
+            .GetRequiredService<IOptions<DataAccessOptions>>()
+            .Value;
+
+        Assert.Equal("None", options.Provider);
+        Assert.Null(serviceProvider.GetService<ApplicationDbContext>());
     }
 
     /// <summary>

--- a/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
@@ -2,8 +2,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectTemplate.Infrastructure.Data;
-using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 using ProjectTemplate.Infrastructure.Data.Extensions;
+using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 
 namespace ProjectTemplate.Web.Tests;
 

--- a/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 using ProjectTemplate.Infrastructure.Data.Extensions;
 
 namespace ProjectTemplate.Web.Tests;
@@ -43,5 +44,29 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
         Assert.Equal(SystemCurrentActorAccessor.ActorName, actorAccessor.CurrentActor);
         Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", context.Database.ProviderName);
         Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", factoryContext.Database.ProviderName);
+    }
+
+    [Fact]
+    public void AddApplicationInfrastructureDataAccess_DisabledProvider_SkipsDbContextFactoryAndEfBackedServices()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ProjectTemplate:DataAccess:Provider"] = "None"
+                })
+            .Build();
+
+        ServiceCollection services = new();
+
+        services.AddLogging();
+        services.AddApplicationInfrastructureDataAccess(configuration);
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        Assert.Null(serviceProvider.GetService<ICurrentActorAccessor>());
+        Assert.Null(serviceProvider.GetService<ApplicationDbContext>());
+        Assert.Null(serviceProvider.GetService<IDbContextFactory<ApplicationDbContext>>());
+        Assert.Null(serviceProvider.GetService<IExternalLoginAccountResolver>());
     }
 }


### PR DESCRIPTION
## Summary

- Adds explicit `None` / `Disabled` data access provider support.
- Skips EF Core registration when application data access is disabled.
- Avoids connection-string resolution when disabled mode is selected.
- Logs disabled startup mode separately from normal EF Core provider configuration.
- Documents disabled mode, supported provider values, and limitations.

## Implementation Notes

- Keeps `Sqlite` as the default provider.
- Preserves existing `SqlServer` behavior.
- Treats `None` and `Disabled` as intentional opt-out provider values.
- Does not register `ApplicationDbContext`, `IDbContextFactory<ApplicationDbContext>`, or `EfCoreExternalLoginAccountResolver` when data access is disabled.

## Tests

Added/updated tests for:

- Disabled provider mode with `None`, `none`, `Disabled`, and `disabled`.
- Disabled mode without a required connection string name.
- Infrastructure-level disabled mode skipping DbContext, factory, current actor accessor, and EF-backed resolver registrations.
- Existing SQLite and SQL Server provider behavior remains covered by existing tests.

Not run locally through this connector.

Closes #218