### PR TITLE
Review generated consumer README scaffold accuracy

### DIFF
--- a/.template.content/README.md
+++ b/.template.content/README.md
@@ -15,6 +15,7 @@ The generated solution includes a production-oriented baseline for common web ap
 - Authentication-ready and authorization-ready structure.
 - EF Core-ready data access structure.
 - Health checks.
+- Docker and Docker Compose support.
 - Baseline automated tests.
 
 ## Prerequisites
@@ -22,26 +23,57 @@ The generated solution includes a production-oriented baseline for common web ap
 - .NET SDK 10.0 or later.
 - Docker Desktop or a compatible container runtime, only if you plan to use Docker Compose.
 
+The generated project includes `global.json` so SDK selection is consistent across local development and CI validation.
+
 ## Template Options Used
 
 This project was generated from the `netcoreapp-template` template.
 
-The template supports a small set of scaffold options for common application variants:
+The template supports these scaffold options:
 
 | Option | Default | Supported values | Description |
 |:---|:---|:---|:---|
-| `authProvider` | `cookie` | `cookie`, `none` | Selects whether the generated application starts with the cookie-authentication-ready baseline or with application authentication disabled by default. |
-| `dbProvider` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. |
+| `--authProvider` | `cookie` | `cookie`, `none` | Selects whether the generated application starts with the cookie-authentication-ready baseline or with application authentication disabled by default. |
+| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. |
+| `--skipRestore` | `false` | `true`, `false` | Skips the post-create NuGet restore action when set to `true`. |
 
 The generated application still includes the core production-oriented guardrails regardless of these options, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
 
-### Authentication-disabled scaffolds
+### Default scaffold
+
+The default scaffold uses cookie-authentication-ready configuration and SQLite development data access:
+
+```powershell
+dotnet new netcoreapp-template --name ProjectTemplate
+```
+
+Equivalent explicit options:
+
+```powershell
+dotnet new netcoreapp-template `
+  --name ProjectTemplate `
+  --authProvider cookie `
+  --dbProvider sqlite
+```
+
+### Authentication-disabled SQL Server scaffold
+
+A common non-default scaffold disables application authentication by default and selects SQL Server configuration:
+
+```powershell
+dotnet new netcoreapp-template `
+  --name ProjectTemplate `
+  --authProvider none `
+  --dbProvider sqlserver
+```
 
 When `--authProvider none` is used, application authentication and cookie authentication are disabled in the generated `appsettings.json`.
 
 This is intended for applications that do not need local cookie authentication at scaffold time, or that plan to add a different authentication approach later.
 
 Authentication and authorization tests that intentionally exercise protected endpoints may need to enable test authentication through in-memory test configuration.
+
+When `--dbProvider sqlserver` is used, the generated data access configuration selects `SqlServer` and `ApplicationSqlServer`. The generated `ConnectionStrings:ApplicationSqlServer` value is a local development example and should be replaced through environment-specific configuration before production use.
 
 ## Restore
 
@@ -66,6 +98,8 @@ dotnet test --configuration Release
 ```powershell
 dotnet run --project src/ProjectTemplate.Web
 ```
+
+The local development profile may choose an available HTTPS or HTTP port depending on launch settings and environment. Docker Compose uses the fixed local port documented below.
 
 ## Run with Docker Compose
 
@@ -97,9 +131,40 @@ To customize local Compose values:
 Copy-Item .env.example .env
 ```
 
-Do not commit `.env` files that contain local secrets, production connection strings, or machine-specific values.
+Do not commit `.env` files that contain local or production environment-specific values.
 
-## Health Probe Semantics
+## Configuration Notes
+
+The generated `appsettings.json` includes baseline configuration for:
+
+- Forwarded headers.
+- Security headers.
+- Rate limiting.
+- Request logging.
+- OpenTelemetry.
+- Authentication and external provider placeholders.
+- Claims transformation.
+- Authorization.
+- Data access.
+- API versioning.
+
+### Authentication
+
+The default scaffold enables the application authentication baseline with cookie authentication enabled. External providers such as OpenID Connect, SAML2, Microsoft, Google, and GitHub are present as disabled placeholders.
+
+Enable external providers intentionally and store provider-specific values outside committed configuration.
+
+### Data access
+
+The default scaffold selects SQLite with `ConnectionStrings:ApplicationDatabase`.
+
+SQL Server scaffolds select `ConnectionStrings:ApplicationSqlServer`.
+
+The EF Core model includes baseline optimistic concurrency support for entities that inherit from the shared data entity base type. Concurrency conflicts are surfaced through EF Core rather than silently overwriting stale updates.
+
+The scaffold does not run EF Core migrations automatically during startup. Apply migrations intentionally as part of local setup or deployment.
+
+### Health checks
 
 Use `/health/live` for process liveness and `/health/ready` for dependency-aware deployment readiness.
 
@@ -107,9 +172,26 @@ The baseline readiness endpoint intentionally includes only checks explicitly ta
 
 ## Generated Content
 
-This scaffold intentionally includes source projects, baseline tests, Docker support, license files, and third-party asset notices.
+This scaffold intentionally includes:
 
-This scaffold intentionally excludes repository-maintainer files such as GitHub issue templates, release workflows, DocFX documentation source, ADRs, contribution policy, citation metadata, and release-management instructions.
+- Solution and project files.
+- Source projects under `src/`.
+- Baseline tests under `tests/`.
+- Docker support files.
+- Local configuration examples.
+- `LICENSE.txt`.
+- `ASSETS-LICENSES.md`.
+- This consumer-oriented `README.md`.
+
+This scaffold intentionally excludes repository-maintainer files such as GitHub issue templates, release workflows, DocFX documentation source, ADRs, contribution policy, security policy, package README, changelog, release-management instructions, and repository badges.
+
+## Upstream References
+
+The upstream template package and documentation can be used for deeper implementation guidance:
+
+- NuGet package: `CDCavell.NetCoreApplicationTemplate`
+- GitHub repository: `cdcavell/NetCoreApplicationTemplate`
+- Published documentation: `https://cdcavell.github.io/NetCoreApplicationTemplate/`
 
 ## License
 


### PR DESCRIPTION
## Summary

- Refreshes the generated consumer README for scaffold accuracy.
- Documents default and non-default scaffold examples.
- Adds the documented template options, including skip restore.
- Clarifies generated configuration behavior for authentication, data access, Docker Compose, health checks, and optimistic concurrency.
- Keeps the generated README consumer-focused and separate from maintainer README content.

## Validation

Reviewed against the template configuration, generated appsettings placeholders, and current CI scaffold smoke-test commands.

Not run locally through this connector.

Closes #217