### PR TITLE
Align README and DocFX navigation for v1.0 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,26 +241,35 @@ Detailed documentation is maintained in the `docs` folder and published with Doc
 Documentation areas include:
 
 - [Getting Started](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/getting-started.html)
-- [v1.0 Migration Guide](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/v1-migration-guide.html)
-- [Production Deployment Checklist](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/production-deployment-checklist.html)
-- [Docker Development](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/docker.html)
-- [Project Structure](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/project-structure.html)
-- [Configuration](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/configuration.html)
-- [Deployment](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/deployment.html)
-- [Middleware Pipeline](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/middleware.html)
+- __v1.0 Readiness__
+  - [v1.0 Migration Guide](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/v1-migration-guide.html)
+  - [Public Surface v1.0](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/public-surface-v1.html)
+  - [Production Deployment Checklist](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/production-deployment-checklist.html)
+  - [Runtime Readiness](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/runtime-readiness.html)
+  - [Build Quality and Reproducibility](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/build-quality.html)
+  - [Container Release Publishing](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/container-publish.html)
+  - [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html)
+- __Application Basics__
+  - [Project Structure](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/project-structure.html)
+  - [Configuration](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/configuration.html)
+  - [Deployment Notes](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/deployment.html)
+  - [Docker Development](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/docker.html)
+- __Middleware Pipeline__
+  - [Middleware Pipeline](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/middleware.html)
+  - [Error Handling](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/error-handling.html)
+  - [Security Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/security-headers.html)
+  - [Forwarded Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/forwarded-headers.html)
+  - [Rate Limiting](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/rate-limiting.html)
+  - [Health Checks](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/health-checks.html)
 - [API Versioning](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/api-versioning.html)
-- [Logging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/logging.html)
-- [Error Handling](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/error-handling.html)
-- [Security Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/security-headers.html)
-- [Forwarded Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/forwarded-headers.html)
-- [Rate Limiting](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/rate-limiting.html)
-- [Health Checks](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/health-checks.html)
-- [Telemetry](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/telemetry.html)
-- [Authentication](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication.html)
-- [Authorization](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authorization.html)
+- __Observability__
+  - [Logging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/logging.html)
+  - [Telemetry](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/telemetry.html)
+- __Authentication and Authorization__
+  - [Authentication](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication.html)
+  - [Authorization](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authorization.html)
 - [Data Access](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/data-access.html)
 - [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html)
-- [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html)
 
 ## Repository Governance
 

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -2,4 +2,28 @@
 
 This section contains detailed documentation for the .NET Core Application Template.
 
-Start with [Getting Started](getting-started.md), [v1.0 Migration Guide](v1-migration-guide.md), or [Production Deployment Checklist](production-deployment-checklist.md), or use the navigation menu to browse configuration, deployment, middleware, logging, security, authentication, data access, GitHub workflow, and template packaging topics.
+Start with [Getting Started](getting-started.md), then use the navigation menu to browse the major documentation areas.
+
+## v1.0 readiness
+
+- [v1.0 Migration Guide](v1-migration-guide.md)
+- [Public Surface v1.0](public-surface-v1.md)
+- [Production Deployment Checklist](production-deployment-checklist.md)
+- [Runtime Readiness](runtime-readiness.md)
+- [Build Quality and Reproducibility](build-quality.md)
+- [Container Release Publishing](container-publish.md)
+- [Template Packaging](template-packaging.md)
+
+## Application documentation
+
+- [Project Structure](project-structure.md)
+- [Configuration](configuration.md)
+- [Deployment Notes](deployment.md)
+- [Docker Development](docker.md)
+- [Middleware Pipeline](middleware.md)
+- [Logging](logging.md)
+- [Security Headers](security-headers.md)
+- [Authentication](authentication.md)
+- [Authorization](authorization.md)
+- [Data Access](data-access.md)
+- [GitHub Workflow](github-workflow.md)

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -4,32 +4,35 @@
 - name: Getting Started
   href: getting-started.md
 
+- name: v1.0 Readiness
+  items:
+    - name: v1.0 Migration Guide
+      href: v1-migration-guide.md
+    - name: Public Surface v1.0
+      href: public-surface-v1.md
+    - name: Production Deployment Checklist
+      href: production-deployment-checklist.md
+    - name: Runtime Readiness
+      href: runtime-readiness.md
+    - name: Build Quality and Reproducibility
+      href: build-quality.md
+    - name: Container Release Publishing
+      href: container-publish.md
+    - name: Template Packaging
+      href: template-packaging.md
 
-- name: v1.0 Migration Guide
-  href: v1-migration-guide.md
+- name: Application Basics
+  items:
+    - name: Project Structure
+      href: project-structure.md
+    - name: Configuration
+      href: configuration.md
+    - name: Deployment Notes
+      href: deployment.md
+    - name: Docker Development
+      href: docker.md
 
-- name: Production Deployment Checklist
-  href: production-deployment-checklist.md
-
-- name: Docker Development
-  href: docker.md
-
-- name: Container Release Publishing
-  href: container-publish.md
-
-- name: Project Structure
-  href: project-structure.md
-
-- name: Configuration
-  href: configuration.md
-
-- name: Deployment
-  href: deployment.md
-
-- name: Runtime Readiness
-  href: runtime-readiness.md
-
-- name: Middleware
+- name: Middleware Pipeline
   items:
     - name: Middleware Pipeline
       href: middleware.md
@@ -64,17 +67,5 @@
 - name: Data Access
   href: data-access.md
 
-- name: Build Quality and Reproducibility
-  href: build-quality.md
-
-- name: Public Surface v1.0
-  href: public-surface-v1.md
-
-- name: v1.0 Migration Guide
-  href: v1-migration-guide.md
-
 - name: GitHub Workflow
   href: github-workflow.md
-
-- name: Template Packaging
-  href: template-packaging.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the documentation for the .NET Core Application Template.
 
-This documentation describes the reusable ASP.NET Core application baseline provided by the repository. It is intended for developers who want to understand the project structure, local development workflow, configuration model, middleware pipeline, security posture, authentication options, data access setup, and future template packaging direction.
+This documentation describes the reusable ASP.NET Core application baseline provided by the repository. It is intended for developers who want to understand the project structure, local development workflow, configuration model, middleware pipeline, security posture, authentication options, data access setup, template packaging, and v1.0 documentation surface.
 
 The template is designed as a production-oriented starting point for ASP.NET Core applications that need consistent defaults for:
 
@@ -18,22 +18,34 @@ The template is designed as a production-oriented starting point for ASP.NET Cor
 - Authentication and authorization modules
 - EF Core data access patterns
 - GitHub Actions validation
-- Future packaging as a reusable .NET template
+- Package-based `dotnet new` template scaffolding
 
 Use this documentation as the detailed reference. The root `README.md` provides the project summary and quick-start information.
 
 ## Documentation Areas
 
 - [Getting Started](articles/getting-started.md)
-- [Project Structure](articles/project-structure.md)
-- [Configuration](articles/configuration.md)
-- __Middleware__
+- __v1.0 Readiness__
+  - [v1.0 Migration Guide](articles/v1-migration-guide.md)
+  - [Public Surface v1.0](articles/public-surface-v1.md)
+  - [Production Deployment Checklist](articles/production-deployment-checklist.md)
+  - [Runtime Readiness](articles/runtime-readiness.md)
+  - [Build Quality and Reproducibility](articles/build-quality.md)
+  - [Container Release Publishing](articles/container-publish.md)
+  - [Template Packaging](articles/template-packaging.md)
+- __Application Basics__
+  - [Project Structure](articles/project-structure.md)
+  - [Configuration](articles/configuration.md)
+  - [Deployment Notes](articles/deployment.md)
+  - [Docker Development](articles/docker.md)
+- __Middleware Pipeline__
   - [Middleware Pipeline](articles/middleware.md)
   - [Error Handling](articles/error-handling.md)
   - [Security Headers](articles/security-headers.md)
   - [Forwarded Headers](articles/forwarded-headers.md)
   - [Rate Limiting](articles/rate-limiting.md)
   - [Health Checks](articles/health-checks.md)
+- [API Versioning](articles/api-versioning.md)
 - __Observability__
   - [Logging](articles/logging.md)
   - [Telemetry](articles/telemetry.md)
@@ -42,4 +54,3 @@ Use this documentation as the detailed reference. The root `README.md` provides 
   - [Authorization](articles/authorization.md)
 - [Data Access](articles/data-access.md)
 - [GitHub Workflow](articles/github-workflow.md)
-- [Template Packaging](articles/template-packaging.md)


### PR DESCRIPTION
## Summary

- Aligns the root README documentation section with the DocFX navigation surface.
- Groups v1.0 readiness documentation consistently across README, DocFX landing pages, and article TOC.
- Adds discoverability for Public Surface v1.0, Runtime Readiness, Build Quality and Reproducibility, and Container Release Publishing.
- Removes the duplicate v1.0 Migration Guide entry from the article TOC.
- Standardizes labels such as Middleware Pipeline and Deployment Notes.

## Validation

Reviewed the updated files for navigation parity:

- README.md
- docs/index.md
- docs/articles/index.md
- docs/articles/toc.yml

Not run locally through this connector.

Closes #215