### PR TITLE
Fix dbProvider none template option and docs

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -56,6 +56,10 @@
         {
           "choice": "sqlserver",
           "description": "Generates the SQL Server provider configuration."
+        },
+        {
+          "choice": "none",
+          "description": "Generates the application with EF Core data access disabled."
         }
       ]
     },
@@ -92,6 +96,10 @@
           {
             "condition": "(dbProvider == \"sqlite\")",
             "value": "Sqlite"
+          },
+          {
+            "condition": "(dbProvider == \"none\")",
+            "value": "None"
           }
         ]
       },
@@ -111,8 +119,11 @@
           {
             "condition": "(dbProvider == \"sqlite\")",
             "value": "ApplicationDatabase"
-          }
-        ]
+          },
+          {
+            "condition": "(dbProvider == \"none\")",
+            "value": ""
+          }        ]
       },
       "replaces": "TemplateDataConnectionStringName"
     }

--- a/.template.content/README.md
+++ b/.template.content/README.md
@@ -34,7 +34,7 @@ The template supports these scaffold options:
 | Option | Default | Supported values | Description |
 |:---|:---|:---|:---|
 | `--authProvider` | `cookie` | `cookie`, `none` | Selects whether the generated application starts with the cookie-authentication-ready baseline or with application authentication disabled by default. |
-| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. |
+| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated data access mode. |
 | `--skipRestore` | `false` | `true`, `false` | Skips the post-create NuGet restore action when set to `true`. |
 
 The generated application still includes the core production-oriented guardrails regardless of these options, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
@@ -74,6 +74,8 @@ This is intended for applications that do not need local cookie authentication a
 Authentication and authorization tests that intentionally exercise protected endpoints may need to enable test authentication through in-memory test configuration.
 
 When `--dbProvider sqlserver` is used, the generated data access configuration selects `SqlServer` and `ApplicationSqlServer`. The generated `ConnectionStrings:ApplicationSqlServer` value is a local development example and should be replaced through environment-specific configuration before production use.
+
+When `--dbProvider none` is used, the generated data access configuration selects `None`. EF Core application data access services are not registered, and no data access connection string is required unless the consuming application adds its own persistence strategy.
 
 ## Restore
 
@@ -163,6 +165,8 @@ SQL Server scaffolds select `ConnectionStrings:ApplicationSqlServer`.
 The EF Core model includes baseline optimistic concurrency support for entities that inherit from the shared data entity base type. Concurrency conflicts are surfaced through EF Core rather than silently overwriting stale updates.
 
 The scaffold does not run EF Core migrations automatically during startup. Apply migrations intentionally as part of local setup or deployment.
+
+When data access is disabled with `--dbProvider none`, EF Core services are not registered and migration commands are not applicable unless the consuming application adds its own persistence layer.
 
 ### Health checks
 

--- a/README.md
+++ b/README.md
@@ -194,10 +194,26 @@ dotnet new netcoreapp-template `
   --dbProvider sqlserver
 ```
 
-Build and test the non-default generated output:
+Generate a scaffold with authentication and EF Core data access disabled:
+
+```powershell
+dotnet new netcoreapp-template `
+  --name ContosoNoAuthNoDataAccess `
+  --authProvider none `
+  --dbProvider none
+```
+
+Build and test either non-default generated output, for example:
 
 ```powershell
 cd ContosoNoAuthSqlServer
+dotnet restore
+dotnet build --configuration Release
+dotnet test --configuration Release
+```
+
+```powershell
+cd ContosoNoAuthNoDataAccess
 dotnet restore
 dotnet build --configuration Release
 dotnet test --configuration Release

--- a/docs/articles/public-surface-v1.md
+++ b/docs/articles/public-surface-v1.md
@@ -34,7 +34,7 @@ The following template symbols are part of the v1.0 public surface.
 |:---|:---|:---|:---|:---|
 | `skipRestore` | `bool` | `false` | `true`, `false` | Controls whether the post-create NuGet restore action runs. |
 | `authProvider` | `choice` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. `cookie` generates the default cookie-authentication-ready baseline. `none` generates the application with application authentication disabled by default. |
-| `dbProvider` | `choice` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. `sqlite` generates the default SQLite development configuration. `sqlserver` generates the SQL Server provider configuration. |
+| `dbProvider` | `choice` | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated data access mode. `sqlite` generates the default SQLite development configuration. `sqlserver` generates the SQL Server provider configuration. `none` generates the application with EF Core data access disabled. |
 
 Breaking changes include renaming a symbol, removing it, removing a documented supported value, inverting its meaning, changing its default in a behavior-changing way, or making generated output depend on it differently without a migration path.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -107,7 +107,7 @@ The template intentionally exposes a small set of stable options for common scaf
 | Option | Default | Supported values | Description |
 |:---|:---|:---|:---|
 | `--authProvider` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. Use `cookie` for the default cookie-authentication-ready baseline or `none` to generate the application with application authentication disabled by default. |
-| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. Use `sqlite` for the default local development configuration or `sqlserver` for the SQL Server provider configuration. |
+| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated data access mode. Use `sqlite` for the default local development configuration, `sqlserver` for the SQL Server provider configuration, or `none` to generate the application with EF Core data access disabled. |
 
 Example non-default scaffold:
 
@@ -125,6 +125,14 @@ All supported variants preserve the template's core infrastructure guardrails, i
 The `--authProvider none` option generates the application with `ProjectTemplate:Authentication:Enabled` and `ProjectTemplate:Authentication:Cookie:Enabled` set to `false`.
 
 The application still includes the authentication and authorization infrastructure so consumers can enable or replace authentication later. Test cases that intentionally exercise protected endpoints may enable test authentication through in-memory test configuration.
+
+### Data-access-disabled variant
+
+The `--dbProvider none` option generates the application with `ProjectTemplate:DataAccess:Provider` set to `None`.
+
+When data access is disabled, EF Core application data access services are not registered, including `ApplicationDbContext`, `IDbContextFactory<ApplicationDbContext>`, and EF-backed services that require `ApplicationDbContext`.
+
+This mode is appropriate for lightweight applications, workers, external modules, or services that use a separate persistence strategy.
 
 ## Restore, Build, and Test the Generated Project
 

--- a/docs/articles/v1-migration-guide.md
+++ b/docs/articles/v1-migration-guide.md
@@ -63,7 +63,7 @@ The template currently exposes the following consumer parameters:
 |:---|:---|:---|:---|:---|
 | `skipRestore` | `bool` | `false` | `true`, `false` | Skips the post-create NuGet restore action when set to `true`. |
 | `authProvider` | `choice` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. Use `cookie` for the default cookie-authentication-ready baseline or `none` to generate the application with application authentication disabled by default. |
-| `dbProvider` | `choice` | `sqlite` | `sqlite`, `sqlserver` | Selects the generated EF Core provider configuration. Use `sqlite` for the default local development configuration or `sqlserver` for the SQL Server provider configuration. |
+| `dbProvider` | `choice` | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated data access mode. Use `sqlite` for the default local development configuration, `sqlserver` for the SQL Server provider configuration, or `none` to generate the application with EF Core data access disabled. |
 
 Default scaffold:
 
@@ -88,6 +88,14 @@ Generate with SQL Server provider configuration:
 dotnet new netcoreapp-template `
   -n ContosoSqlServerPortal `
   --dbProvider sqlserver
+```
+
+Generate with EF Core data access disabled:
+
+```powershell
+dotnet new netcoreapp-template `
+  -n ContosoNoDataAccessPortal `
+  --dbProvider none
 ```
 
 Generate a non-default scaffold with authentication disabled and SQL Server configuration:
@@ -165,7 +173,7 @@ Review these areas carefully:
 [ ] Rate limiting defaults.
 [ ] Logging and telemetry configuration.
 [ ] Authentication and authorization configuration.
-[ ] EF Core provider and migration strategy.
+[ ] EF Core provider, disabled data access mode, and migration strategy reviewed.
 [ ] Tests and smoke-test expectations.
 [ ] README and generated consumer instructions.
 ```
@@ -185,7 +193,7 @@ Pay special attention to:
 - Static file behavior.
 - Routing, CORS, rate limiting, authentication, and authorization order.
 - Health check endpoints.
-- Data access provider selection.
+- Data access provider selection or disabled data access mode.
 - Explicit migration execution rather than automatic production startup migration.
 
 ## Breaking Change Review
@@ -229,8 +237,10 @@ At minimum, confirm:
 [ ] AllowedHosts matches public host names.
 [ ] Forwarded headers match the proxy/load balancer topology.
 [ ] Production secrets are not committed.
-[ ] Database provider and connection string names are correct.
-[ ] Migrations are applied intentionally.
+[ ] Data access provider or disabled data access mode reviewed.
+[ ] Database provider and connection string names are correct, when data access is enabled.
+[ ] Data access provider and migration strategy reviewed, when applicable.
+[ ] Migrations are applied intentionally, when data access is enabled.
 [ ] Health checks match infrastructure probe paths.
 [ ] Rate limits are appropriate for expected traffic.
 [ ] Logs do not expose sensitive values.
@@ -268,7 +278,7 @@ Use this checklist before treating a `v0.5.x` application as migrated to the `v1
 [ ] Security headers reviewed.
 [ ] Rate limits reviewed.
 [ ] Authentication and authorization settings reviewed.
-[ ] Data provider and migration strategy reviewed.
+[ ] Data access provider or disabled data access mode reviewed.
 [ ] Docker/container behavior reviewed, if applicable.
 [ ] Restore succeeds.
 [ ] Build succeeds in Release configuration.


### PR DESCRIPTION
## Summary

- Adds `none` as a supported `--dbProvider` template choice.
- Maps `--dbProvider none` to `ProjectTemplate:DataAccess:Provider = None`.
- Emits an empty data access connection string name for disabled data access mode.
- Preserves existing SQLite and SQL Server template behavior.

## Validation

- Verified the template accepts `--authProvider none --dbProvider none`.
- Verified generated output restores successfully.
- Verified existing SQLite and SQL Server provider options remain available.
```powershell
PS > dotnet new uninstall CDCavell.NetCoreApplicationTemplate
Success: CDCavell.NetCoreApplicationTemplate@0.5.6 was uninstalled.
PS > dotnet new install ./CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg
The following template packages will be installed:
   CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg

Success: CDCavell.NetCoreApplicationTemplate@0.5.6 installed the following templates:
Template Name                   Short Name           Language  Tags
------------------------------  -------------------  --------  -------------------------------------------------
.NET Core Application Template  netcoreapp-template  [C#]      Web/MVC/ASP.NET Core/Enterprise/Security/Template

PS > dotnet new netcoreapp-template -n ContosoSecurityPortal
The template ".NET Core Application Template" was created successfully.

Processing post-creation actions...
Restoring .\ContosoSecurityPortal\ContosoSecurityPortal.slnx:
Restore succeeded.
Restoring .\ContosoSecurityPortal\src\ContosoSecurityPortal.Web\ContosoSecurityPortal.Web.csproj:
Restore succeeded.
Restoring .\ContosoSecurityPortal\tests\ContosoSecurityPortal.Web.Tests\ContosoSecurityPortal.Web.Tests.csproj:
Restore succeeded.


PS > dotnet new netcoreapp-template --name ContosoNoAuthSqlServer --authProvider none --dbProvider sqlserver
The template ".NET Core Application Template" was created successfully.

Processing post-creation actions...
Restoring .\ContosoNoAuthSqlServer\ContosoNoAuthSqlServer.slnx:
Restore succeeded.
Restoring .\ContosoNoAuthSqlServer\src\ContosoNoAuthSqlServer.Web\ContosoNoAuthSqlServer.Web.csproj:
Restore succeeded.
Restoring .\ContosoNoAuthSqlServer\tests\ContosoNoAuthSqlServer.Web.Tests\ContosoNoAuthSqlServer.Web.Tests.csproj:
Restore succeeded.


PS > dotnet new netcoreapp-template --name ContosoNoAuthNoSqlServer --authProvider none --dbProvider none
The template ".NET Core Application Template" was created successfully.

Processing post-creation actions...
Restoring .\ContosoNoAuthNoSqlServer\ContosoNoAuthNoSqlServer.slnx:
Restore succeeded.
Restoring .\ContosoNoAuthNoSqlServer\src\ContosoNoAuthNoSqlServer.Web\ContosoNoAuthNoSqlServer.Web.csproj:
Restore succeeded.
Restoring .\ContosoNoAuthNoSqlServer\tests\ContosoNoAuthNoSqlServer.Web.Tests\ContosoNoAuthNoSqlServer.Web.Tests.csproj:
Restore succeeded.
```

Closes #224