### PR TITLE
Remove hardcoded OpenTelemetry service version

### DIFF
--- a/.template.content/src/ProjectTemplate.Web/appsettings.json
+++ b/.template.content/src/ProjectTemplate.Web/appsettings.json
@@ -116,7 +116,6 @@
     "OpenTelemetry": {
       "Enabled": true,
       "ServiceName": "ProjectTemplate.Web",
-      "ServiceVersion": "0.3.1",
       "EnableTracing": true,
       "EnableMetrics": true,
       "EnableAspNetCoreInstrumentation": true,

--- a/src/ProjectTemplate.Web/Extensions/OpenTelemetryServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/OpenTelemetryServiceExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
@@ -42,12 +43,14 @@ public static class OpenTelemetryServiceExtensions
             return services;
         }
 
+        string serviceVersion = ResolveServiceVersion(options);
+
         OpenTelemetryBuilder openTelemetryBuilder = services
             .AddOpenTelemetry()
             .ConfigureResource(resource => resource
                 .AddService(
                     serviceName: options.ServiceName,
-                    serviceVersion: options.ServiceVersion)
+                    serviceVersion: serviceVersion)
                 .AddAttributes(new Dictionary<string, object>
                 {
                     ["deployment.environment.name"] = environment.EnvironmentName
@@ -109,5 +112,21 @@ public static class OpenTelemetryServiceExtensions
             StringComparison.OrdinalIgnoreCase)
             ? OtlpExportProtocol.HttpProtobuf
             : OtlpExportProtocol.Grpc;
+    }
+
+    private static string ResolveServiceVersion(ApplicationOpenTelemetryOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.ServiceVersion))
+        {
+            return options.ServiceVersion.Trim();
+        }
+
+        Assembly assembly = typeof(Program).Assembly;
+
+        string? informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        return !string.IsNullOrWhiteSpace(informationalVersion) ? informationalVersion : assembly.GetName().Version?.ToString() ?? "unknown";
     }
 }

--- a/src/ProjectTemplate.Web/Options/ApplicationOpenTelemetryOptions.cs
+++ b/src/ProjectTemplate.Web/Options/ApplicationOpenTelemetryOptions.cs
@@ -23,7 +23,7 @@ public sealed class ApplicationOpenTelemetryOptions
     /// <summary>
     /// Gets or sets the logical OpenTelemetry service version.
     /// </summary>
-    public string ServiceVersion { get; set; } = "1.0.0";
+    public string? ServiceVersion { get; set; } = "1.0.0";
 
     /// <summary>
     /// Gets or sets a value indicating whether tracing is enabled.

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -116,7 +116,6 @@
     "OpenTelemetry": {
       "Enabled": true,
       "ServiceName": "ProjectTemplate.Web",
-      "ServiceVersion": "0.3.1",
       "EnableTracing": true,
       "EnableMetrics": true,
       "EnableAspNetCoreInstrumentation": true,

--- a/tests/ProjectTemplate.Web.Tests/OpenTelemetryTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/OpenTelemetryTests.cs
@@ -140,6 +140,72 @@ public sealed class OpenTelemetryTests
     }
 
     /// <summary>
+    /// Verifies that no appsettings.json files in the repository contain a stale OpenTelemetry service version value.
+    /// </summary>
+    [Fact]
+    public void Appsettings_DoNotContainStaleOpenTelemetryServiceVersion()
+    {
+        string solutionRoot = GetSolutionRoot();
+
+        List<string> appsettingsPaths = [];
+
+        string srcDirectory = Path.Combine(solutionRoot, "src");
+
+        if (Directory.Exists(srcDirectory))
+        {
+            appsettingsPaths.AddRange(
+                Directory.EnumerateFiles(srcDirectory, "appsettings.json", SearchOption.AllDirectories));
+        }
+
+        string templateContentAppsettings = Path.Combine(
+            solutionRoot,
+            ".template.content",
+            "src",
+            "ProjectTemplate.Web",
+            "appsettings.json");
+
+        if (File.Exists(templateContentAppsettings))
+        {
+            appsettingsPaths.Add(templateContentAppsettings);
+        }
+
+        Assert.NotEmpty(appsettingsPaths);
+
+        foreach (string appsettingsPath in appsettingsPaths.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            string appsettings = File.ReadAllText(appsettingsPath);
+
+            Assert.DoesNotContain(
+                "\"ServiceVersion\": \"0.3.1\"",
+                appsettings,
+                StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Gets the root directory of the solution.
+    /// </summary>
+    /// <returns>The solution root directory.</returns>
+    /// <exception cref="DirectoryNotFoundException"></exception>
+    private static string GetSolutionRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (Directory.EnumerateFiles(directory.FullName, "*.slnx").Any())
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate solution root from '{AppContext.BaseDirectory}'.");
+    }
+
+    /// <summary>
     /// Creates a test application factory with the supplied in-memory configuration overrides.
     /// </summary>
     /// <param name="configurationValues">The configuration key/value pairs used to override application settings for a test.</param>


### PR DESCRIPTION
## Summary

- Removes stale hardcoded `ServiceVersion: "0.3.1"` from OpenTelemetry appsettings.
- Prevents generated projects from inheriting stale telemetry version metadata.
- Resolves OpenTelemetry service version from assembly metadata when no explicit configuration value is provided.
- Preserves existing OpenTelemetry service name, tracing, metrics, and OTLP configuration behavior.

## Validation

- Ran `dotnet restore`.
- Ran `dotnet build --configuration Release`.
- Ran `dotnet test --configuration Release`.
- Verified shipped appsettings files no longer contain `ServiceVersion: "0.3.1"`.
```powershell
PS > dotnet new netcoreapp-template -n ContosoSecurityPortal
The template ".NET Core Application Template" was created successfully.

Processing post-creation actions...
Restoring .\ContosoSecurityPortal\ContosoSecurityPortal.slnx:
Restore succeeded.
Restoring .\ContosoSecurityPortal\src\ContosoSecurityPortal.Web\ContosoSecurityPortal.Web.csproj:
Restore succeeded.
Restoring .\ContosoSecurityPortal\tests\ContosoSecurityPortal.Web.Tests\ContosoSecurityPortal.Web.Tests.csproj:
Restore succeeded.


PS > dotnet new netcoreapp-template --name ContosoNoAuthSqlServer --authProvider none --dbProvider sqlserver
The template ".NET Core Application Template" was created successfully.

Processing post-creation actions...
Restoring .\ContosoNoAuthSqlServer\ContosoNoAuthSqlServer.slnx:
Restore succeeded.
Restoring .\ContosoNoAuthSqlServer\src\ContosoNoAuthSqlServer.Web\ContosoNoAuthSqlServer.Web.csproj:
Restore succeeded.
Restoring .\ContosoNoAuthSqlServer\tests\ContosoNoAuthSqlServer.Web.Tests\ContosoNoAuthSqlServer.Web.Tests.csproj:
Restore succeeded.


PS > dotnet new netcoreapp-template --name ContosoNoAuthNoSqlServer --authProvider none --dbProvider none
The template ".NET Core Application Template" was created successfully.

Processing post-creation actions...
Restoring .\ContosoNoAuthNoSqlServer\ContosoNoAuthNoSqlServer.slnx:
Restore succeeded.
Restoring .\ContosoNoAuthNoSqlServer\src\ContosoNoAuthNoSqlServer.Web\ContosoNoAuthNoSqlServer.Web.csproj:
Restore succeeded.
Restoring .\ContosoNoAuthNoSqlServer\tests\ContosoNoAuthNoSqlServer.Web.Tests\ContosoNoAuthNoSqlServer.Web.Tests.csproj:
Restore succeeded.
``` 

```powershell
PS .\ContosoNoAuthNoSqlServer> dotnet restore
Restore complete (2.9s)

Build succeeded in 3.1s
PS .\ContosoNoAuthNoSqlServer> dotnet build -c Release
Restore complete (2.4s)
  ContosoNoAuthNoSqlServer.Infrastructure net10.0 succeeded (1.0s) → src\ContosoNoAuthNoSqlServer.Infrastructure\bin\Release\net10.0\ContosoNoAuthNoSqlServer.Infrastructure.dll
  ContosoNoAuthNoSqlServer.Web net10.0 succeeded (0.4s) → src\ContosoNoAuthNoSqlServer.Web\bin\Release\net10.0\ContosoNoAuthNoSqlServer.Web.dll
  ContosoNoAuthNoSqlServer.Web.Tests net10.0 succeeded (0.7s) → tests\ContosoNoAuthNoSqlServer.Web.Tests\bin\Release\net10.0\ContosoNoAuthNoSqlServer.Web.Tests.dll

Build succeeded in 4.9s
PS .\ContosoNoAuthNoSqlServer> dotnet test -c Release
Restore complete (2.4s)
  ContosoNoAuthNoSqlServer.Infrastructure net10.0 succeeded (0.9s) → src\ContosoNoAuthNoSqlServer.Infrastructure\bin\Release\net10.0\ContosoNoAuthNoSqlServer.Infrastructure.dll
  ContosoNoAuthNoSqlServer.Web net10.0 succeeded (0.6s) → src\ContosoNoAuthNoSqlServer.Web\bin\Release\net10.0\ContosoNoAuthNoSqlServer.Web.dll
  ContosoNoAuthNoSqlServer.Web.Tests net10.0 succeeded (1.3s) → tests\ContosoNoAuthNoSqlServer.Web.Tests\bin\Release\net10.0\ContosoNoAuthNoSqlServer.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.35]   Discovering: ContosoNoAuthNoSqlServer.Web.Tests
[xUnit.net 00:00:00.71]   Discovered:  ContosoNoAuthNoSqlServer.Web.Tests
[xUnit.net 00:00:01.01]   Starting:    ContosoNoAuthNoSqlServer.Web.Tests
[xUnit.net 00:00:07.67]   Finished:    ContosoNoAuthNoSqlServer.Web.Tests (ID = '7ca4be546002dfd358e3966569a4d54a38248fc8fc0da0079603b9031158bfb4')
  ContosoNoAuthNoSqlServer.Web.Tests test net10.0 succeeded (8.7s)

Test summary: total: 138, failed: 0, succeeded: 138, skipped: 0, duration: 8.6s
Build succeeded in 14.4s
```