### PR TITLE
Expand package README for NuGet consumer clarity

### DIFF
--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -1,21 +1,70 @@
-# .NET Core Application Template Package
+# .NET Core Application Template
 
-This package installs the `netcoreapp-template` project template for `dotnet new`.
+A reusable `dotnet new` template for creating a production-oriented ASP.NET Core application baseline with structured logging, security headers, forwarded headers, rate limiting, centralized error handling, authentication-ready architecture, and EF Core-ready structure.
 
-## Install from a local package
+This README is intended for NuGet package consumers. The full repository README and documentation site provide deeper implementation and maintainer guidance.
+
+## Template identity
+
+| Item | Value |
+|---|---|
+| Package ID | `CDCavell.NetCoreApplicationTemplate` |
+| Template short name | `netcoreapp-template` |
+| Default authentication provider | `cookie` |
+| Default data provider | `sqlite` |
+
+## Install
+
+Install the template package from NuGet:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg
+dotnet new install CDCavell.NetCoreApplicationTemplate
 ```
 
 ## Generate a project
 
+Create a default scaffold:
 ```powershell
 dotnet new netcoreapp-template -n ContosoSecurityPortal
 ```
 
-## Build and test generated output
+The default scaffold uses the cookie-authentication-ready baseline and SQLite development configuration.
 
+## Generate with authentication disabled
+```powershell
+dotnet new netcoreapp-template `
+  --name ContosoNoAuth `
+  --authProvider none
+```
+
+Use this option when the generated application should start with application authentication disabled by default.
+
+## Generate with SQL Server selected
+```powershell
+dotnet new netcoreapp-template `
+  --name ContosoSqlServer `
+  --dbProvider sqlserver
+```
+
+Use this option when the generated application should use the SQL Server provider configuration instead of the default SQLite development configuration.
+
+## Generate with authentication disabled and SQL Server selected
+```powershell
+dotnet new netcoreapp-template `
+  --name ContosoNoAuthSqlServer `
+  --authProvider none `
+  --dbProvider sqlserver
+```
+
+## Template options
+
+| Option           | Default  | Supported values              | Description                                                    |
+| ---------------- | -------- | ----------------------------- | -------------------------------------------------------------- |
+| `--authProvider` | `cookie` | `cookie`, `none`              | Selects the generated authentication baseline.                 |
+| `--dbProvider`   | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated EF Core provider configuration.          |
+| `--skipRestore`  | `false`  | `true`, `false`               | Skips the post-create NuGet restore action when set to `true`. |
+
+## Build and test generated output
 ```powershell
 cd ContosoSecurityPortal
 dotnet restore
@@ -25,16 +74,22 @@ dotnet test --configuration Release
 
 ## Update
 
-Install the newer package version with `dotnet new install`.
-
+Install the newer package version with the same package identity:
 ```powershell
-dotnet new install <path-or-package-id-for-new-version>
+dotnet new install CDCavell.NetCoreApplicationTemplate
 ```
 
 ## Uninstall
-
 ```powershell
 dotnet new uninstall CDCavell.NetCoreApplicationTemplate
 ```
 
-This package README is intended for template package distribution. Generated projects receive their own consumer README from the scaffold.
+## Additional resources
+- GitHub repository: https://github.com/cdcavell/NetCoreApplicationTemplate
+- Published documentation: https://cdcavell.github.io/NetCoreApplicationTemplate/
+- Template packaging documentation: https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html
+- Changelog: https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/CHANGELOG.md
+- License: https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/LICENSE.txt
+- Releases: https://github.com/cdcavell/NetCoreApplicationTemplate/releases
+
+Generated projects receive their own consumer-oriented README from the scaffold. This package README is intentionally limited to NuGet installation, scaffold options, validation commands, and consumer-facing reference links.

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -21,6 +21,11 @@ Install the template package from NuGet:
 dotnet new install CDCavell.NetCoreApplicationTemplate
 ```
 
+## For local package validation, install a packed package directly:
+```powershell
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.6.nupkg
+```
+
 ## Generate a project
 
 Create a default scaffold:


### PR DESCRIPTION
## Summary

- Expanded `PACKAGE-README.md` into a clearer NuGet consumer entry point.
- Replaced the local `.nupkg` install example with the stable package install flow.
- Documented the `netcoreapp-template` short name and supported scaffold options.
- Added examples for the default scaffold, `--authProvider none`, `--dbProvider sqlserver`, and the combined non-default variant.
- Added consumer-facing links to the repository, published docs, template packaging docs, changelog, license, and releases.

## Validation

- Documentation-only change.
- Verified examples align with the package ID, template short name, and current template options.
- Kept maintainer-only release-process detail out of the package README.

Closes #216

## Follow-up fix

- Restored a minimal versioned local `.nupkg` install example for package validation.
- Kept the stable NuGet package install command as the primary consumer path.
- This satisfies the version consistency check while preserving the intent of #216.