### PR TITLE
Improve CI coverage report generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
               dotnet test $project.FullName `
                 --configuration $env:CONFIGURATION `
                 --no-restore `
+                --no-build `
                 --verbosity normal `
                 --collect:"XPlat Code Coverage" `
                 --logger "trx" `
@@ -109,7 +110,8 @@ jobs:
             -reports:"./artifacts/test-results/**/coverage.cobertura.xml" `
             -targetdir:"./artifacts/coverage-report" `
             -reporttypes:"Html;MarkdownSummaryGithub;Cobertura" `
-            -assemblyfilters:"+Template.Web;-*.Tests"
+            -assemblyfilters:"+ProjectTemplate.*;-*.Tests" `
+            -filefilters:"-**/bin/**;-**/obj/**;-**/*.g.cs"
 
       - name: Publish test results artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -129,9 +131,7 @@ jobs:
         shell: pwsh
         run: |
           $threshold = [double]$env:COVERAGE_THRESHOLD
-          $coverageFile = Get-ChildItem -Path "./artifacts/coverage-report" -Recurse -Filter "*.xml" |
-            Where-Object { $_.Name -match "Cobertura|coverage" } |
-            Select-Object -First 1
+          $coverageFile = Get-Item "./artifacts/coverage-report/Cobertura.xml" -ErrorAction SilentlyContinue
 
           if (-not $coverageFile) {
               Write-Error "Coverage file was not generated."

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -42,11 +42,39 @@ jobs:
       - name: Build
         run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore /p:ContinuousIntegrationBuild=true
 
+      - name: Run tests with coverage
+        run: |
+          dotnet test ${{ env.SOLUTION_FILE }} `
+          --configuration ${{ env.CONFIGURATION }} `
+          --no-restore `
+          --no-build `
+          --verbosity normal `
+          --collect:"XPlat Code Coverage" `
+          --logger "trx" `
+          --results-directory "./artifacts/test-results" `
+          /p:ContinuousIntegrationBuild=true
+
       - name: Restore .NET tools
         run: dotnet tool restore
 
+      - name: Generate coverage report
+        shell: pwsh
+        run: |
+          dotnet reportgenerator `
+            -reports:"./artifacts/test-results/**/coverage.cobertura.xml" `
+            -targetdir:"./artifacts/coverage-report" `
+            -reporttypes:"Html;MarkdownSummaryGithub;Cobertura" `
+            -assemblyfilters:"+ProjectTemplate.*;-*.Tests" `
+            -filefilters:"-**/bin/**;-**/obj/**;-**/*.g.cs"
+
       - name: Build DocFX site
         run: dotnet tool run docfx -- docs/docfx.json
+
+      - name: Copy coverage report to DocFX output
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path "./docs/_site/coverage" -Force | Out-Null
+          Copy-Item -Path "./artifacts/coverage-report/*" -Destination "./docs/_site/coverage" -Recurse -Force
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -9,3 +9,6 @@
 
 - name: Repository
   href: https://github.com/cdcavell/NetCoreApplicationTemplate
+
+- name: Test Coverage
+  href: coverage/


### PR DESCRIPTION
## PR Summary

This PR improves CI coverage reporting by updating the ReportGenerator configuration to match the current project assembly names and exclude generated/build output files from the coverage report.

### Changes

* Updated coverage assembly filtering from the old `Template.Web` pattern to `ProjectTemplate.*`.
* Continued excluding test assemblies from coverage output.
* Added file filters to exclude:

  * `bin` output
  * `obj` output
  * generated `.g.cs` files
* Updated coverage threshold enforcement to read the expected `Cobertura.xml` report directly.
* Preserved coverage artifact publishing for CI review.

### Result

The CI workflow now generates a usable coverage report for the actual application assemblies and avoids noise from generated source files.
