### PR TITLE
Publish coverage report with DocFX documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
               dotnet test $project.FullName `
                 --configuration $env:CONFIGURATION `
                 --no-restore `
+                --no-build `
                 --verbosity normal `
                 --collect:"XPlat Code Coverage" `
                 --logger "trx" `
@@ -109,7 +110,8 @@ jobs:
             -reports:"./artifacts/test-results/**/coverage.cobertura.xml" `
             -targetdir:"./artifacts/coverage-report" `
             -reporttypes:"Html;MarkdownSummaryGithub;Cobertura" `
-            -assemblyfilters:"+Template.Web;-*.Tests"
+            -assemblyfilters:"+ProjectTemplate.*;-*.Tests" `
+            -filefilters:"-**/bin/**;-**/obj/**;-**/*.g.cs"
 
       - name: Publish test results artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -129,9 +131,7 @@ jobs:
         shell: pwsh
         run: |
           $threshold = [double]$env:COVERAGE_THRESHOLD
-          $coverageFile = Get-ChildItem -Path "./artifacts/coverage-report" -Recurse -Filter "*.xml" |
-            Where-Object { $_.Name -match "Cobertura|coverage" } |
-            Select-Object -First 1
+          $coverageFile = Get-Item "./artifacts/coverage-report/Cobertura.xml" -ErrorAction SilentlyContinue
 
           if (-not $coverageFile) {
               Write-Error "Coverage file was not generated."

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -46,8 +46,6 @@ jobs:
         run: |
           dotnet test ${{ env.SOLUTION_FILE }} `
           --configuration ${{ env.CONFIGURATION }} `
-          --no-restore `
-          --no-build `
           --verbosity normal `
           --collect:"XPlat Code Coverage" `
           --logger "trx" `

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -43,9 +43,12 @@ jobs:
         run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Run tests with coverage
+        shell: pwsh
         run: |
           dotnet test ${{ env.SOLUTION_FILE }} `
           --configuration ${{ env.CONFIGURATION }} `
+          --no-restore `
+          --no-build `
           --verbosity normal `
           --collect:"XPlat Code Coverage" `
           --logger "trx" `

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -42,11 +42,39 @@ jobs:
       - name: Build
         run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore /p:ContinuousIntegrationBuild=true
 
+      - name: Run tests with coverage
+        run: |
+          dotnet test ${{ env.SOLUTION_FILE }} `
+          --configuration ${{ env.CONFIGURATION }} `
+          --no-restore `
+          --no-build `
+          --verbosity normal `
+          --collect:"XPlat Code Coverage" `
+          --logger "trx" `
+          --results-directory "./artifacts/test-results" `
+          /p:ContinuousIntegrationBuild=true
+
       - name: Restore .NET tools
         run: dotnet tool restore
 
+      - name: Generate coverage report
+        shell: pwsh
+        run: |
+          dotnet reportgenerator `
+            -reports:"./artifacts/test-results/**/coverage.cobertura.xml" `
+            -targetdir:"./artifacts/coverage-report" `
+            -reporttypes:"Html;MarkdownSummaryGithub;Cobertura" `
+            -assemblyfilters:"+ProjectTemplate.*;-*.Tests" `
+            -filefilters:"-**/bin/**;-**/obj/**;-**/*.g.cs"
+
       - name: Build DocFX site
         run: dotnet tool run docfx -- docs/docfx.json
+
+      - name: Copy coverage report to DocFX output
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path "./docs/_site/coverage" -Force | Out-Null
+          Copy-Item -Path "./artifacts/coverage-report/*" -Destination "./docs/_site/coverage" -Recurse -Force
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -9,3 +9,6 @@
 
 - name: Repository
   href: https://github.com/cdcavell/NetCoreApplicationTemplate
+
+- name: Test Coverage
+  href: coverage/

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -7,8 +7,9 @@
 - name: API Reference
   href: api/
 
+- name: Test Coverage
+  href: coverage/
+
 - name: Repository
   href: https://github.com/cdcavell/NetCoreApplicationTemplate
 
-- name: Test Coverage
-  href: coverage/


### PR DESCRIPTION
## PR Summary

This PR updates the CI and documentation workflows to generate usable code coverage reports and publish the generated coverage output with the DocFX documentation site.

### Changes

* Updated coverage report generation to include the current `ProjectTemplate.*` assemblies.
* Excluded test assemblies from coverage output.
* Added file filters to exclude build output and generated source files:

  * `bin`
  * `obj`
  * `*.g.cs`
* Updated coverage threshold validation to read the expected `Cobertura.xml` report directly.
* Added coverage generation to the documentation publishing workflow.
* Copies the generated ReportGenerator HTML output into `docs/_site/coverage`.
* Publishes the coverage report with the GitHub Pages DocFX site.
* Ensures PowerShell-based multi-line commands run under `pwsh`.

### Result

The CI workflow now produces a cleaner and more accurate coverage report, while the documentation workflow publishes the latest generated coverage report alongside the DocFX site.

Expected coverage report location after deployment:

`https://cdcavell.github.io/NetCoreApplicationTemplate/coverage/index.html`

### Validation

* Confirmed local ReportGenerator output now detects the expected application assemblies.
* Confirmed coverage output reports line and branch coverage instead of showing zero assemblies.
* GitHub Actions should now run the coverage commands under the correct shell and avoid bash interpreting command arguments as separate commands.
