### PR TITLE
docs: link coverage resources

### DIFF
--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -96,5 +96,6 @@ dotnet new uninstall CDCavell.NetCoreApplicationTemplate
 - Changelog: https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/CHANGELOG.md
 - License: https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/LICENSE.txt
 - Releases: https://github.com/cdcavell/NetCoreApplicationTemplate/releases
+- Coverage Report: https://cdcavell.github.io/NetCoreApplicationTemplate/coverage/index.html
 
 Generated projects receive their own consumer-oriented README from the scaffold. This package README is intentionally limited to NuGet installation, scaffold options, validation commands, and consumer-facing reference links.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Core Application Template 
 [![CI](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/ci.yml/badge.svg)](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/ci.yml)
-[![Coverage Gate](https://img.shields.io/badge/coverage%20gate-60%25-brightgreen)](#github-actions)
+[![Coverage Report](https://img.shields.io/badge/coverage%20gate-60%25-brightgreen)](https://cdcavell.github.io/NetCoreApplicationTemplate/coverage/index.html)
 [![Documentation](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/cdcavell/NetCoreApplicationTemplate/actions/workflows/publish-docs.yml)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://cdcavell.github.io/NetCoreApplicationTemplate/)
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple)](https://dotnet.microsoft.com/)

--- a/docs/articles/public-surface-v1.md
+++ b/docs/articles/public-surface-v1.md
@@ -249,3 +249,4 @@ If the change affects only repository internals and not generated or documented 
 - [Error Handling](error-handling.md)
 - [Container Release Publishing](container-publish.md)
 - [Security Headers](security-headers.md)
+- [Coverage Report](../coverage/index.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,3 +54,4 @@ Use this documentation as the detailed reference. The root `README.md` provides 
   - [Authorization](articles/authorization.md)
 - [Data Access](articles/data-access.md)
 - [GitHub Workflow](articles/github-workflow.md)
+- [Test Coverage](https://cdcavell.github.io/NetCoreApplicationTemplate/coverage/index.html)


### PR DESCRIPTION
## PR Summary

This PR updates project documentation links for the generated test coverage report.

### Changes

* Added the hosted coverage report link to the `PACKAGE-README.md` Additional Resources section.
* Updated the root `README.md` coverage badge link to point directly to the published Test Coverage report.
* Keeps the coverage gate badge visible while making its destination more useful for users reviewing project quality.

### Result

Users can now access the latest published coverage report directly from both the NuGet package documentation surface and the repository README.

Coverage report:

`https://cdcavell.github.io/NetCoreApplicationTemplate/coverage/index.html`
