### PR TITLE
Add persisted string canonicalization before save - issue #231

### DIFF
--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -255,6 +255,22 @@ When auditing is enabled, audit records are written to the application database.
 
 Consuming applications are responsible for deciding how audit records are retained, archived, masked, purged, or moved to long-term storage. Before enabling auditing in production, review whether audited values may contain sensitive or regulated data.
 
+## Persisted String Canonicalization
+
+The template canonicalizes string scalar values for added entities and modified string properties before EF Core persists changes.
+
+Canonicalization decodes bounded HTML/entity encoding and normalizes Unicode into a stable representation before save. This prevents common single-encoded or double-encoded values from being stored inconsistently while preserving raw special characters such as apostrophes, quotation marks, ampersands, and accented characters.
+
+This behavior is intended for persistence consistency and defense-in-depth. It is not a replacement for SQL injection protection.
+
+The primary SQL injection protections remain:
+
+- EF Core parameterized commands.
+- Avoiding manually concatenated SQL.
+- Validating application input according to domain rules.
+- Keeping output encoding context-specific.
+
+The template does not blanket HTML-encode values before database storage. Razor/UI output encoding and any API-specific encoding rules remain the responsibility of the output layer.
 
 ## Optimistic Concurrency
 

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -84,6 +84,7 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
+        ApplyPersistedStringCanonicalization();
         ApplyConcurrencyStamps();
 
         if (!_auditOptions)
@@ -113,6 +114,7 @@ public sealed partial class ApplicationDbContext(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
+        ApplyPersistedStringCanonicalization();
         ApplyConcurrencyStamps();
 
         if (!_auditOptions)
@@ -136,6 +138,46 @@ public sealed partial class ApplicationDbContext(
         return result;
     }
 
+    private void ApplyPersistedStringCanonicalization()
+    {
+        ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry entry in ChangeTracker.Entries())
+        {
+            if (entry.Entity is AuditRecord ||
+                entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            foreach (PropertyEntry property in entry.Properties)
+            {
+                if (property.Metadata.ClrType != typeof(string) ||
+                    property.Metadata.IsPrimaryKey() ||
+                    property.Metadata.IsConcurrencyToken)
+                {
+                    continue;
+                }
+
+                if (entry.State == EntityState.Modified && !property.IsModified)
+                {
+                    continue;
+                }
+
+                if (property.CurrentValue is not string currentValue)
+                {
+                    continue;
+                }
+
+                string canonicalValue = PersistenceStringCanonicalizer.Canonicalize(currentValue);
+
+                if (!string.Equals(canonicalValue, currentValue, StringComparison.Ordinal))
+                {
+                    property.CurrentValue = canonicalValue;
+                }
+            }
+        }
+    }
     private List<AuditEntry> OnBeforeSaveChanges()
     {
         ChangeTracker.DetectChanges();

--- a/src/ProjectTemplate.Infrastructure/Data/PersistenceStringCanonicalizer.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/PersistenceStringCanonicalizer.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using System.Text;
+
+namespace ProjectTemplate.Infrastructure.Data;
+
+internal static class PersistenceStringCanonicalizer
+{
+    private const int _maxDecodePasses = 4;
+
+    internal static string Canonicalize(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        string current = value.Normalize(NormalizationForm.FormC);
+
+        for (int pass = 0; pass < _maxDecodePasses; pass++)
+        {
+            string decoded = WebUtility.HtmlDecode(current);
+
+            if (string.Equals(decoded, current, StringComparison.Ordinal))
+            {
+                return current;
+            }
+
+            current = decoded.Normalize(NormalizationForm.FormC);
+        }
+
+        return current;
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextStringCanonicalizationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextStringCanonicalizationTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationDbContextStringCanonicalizationTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_SingleEncodedString_CanonicalizesBeforePersistence()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            ProviderUserId = "encoded-user",
+            DisplayName = "O&#39;Connor &quot;Admin&quot; &amp; Sons",
+            Email = "encoded@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == account.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal("O'Connor \"Admin\" & Sons", persisted.DisplayName);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DoubleEncodedString_CanonicalizesBeforePersistence()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "Microsoft",
+            ProviderUserId = "double-encoded-user",
+            DisplayName = "O&amp;#39;Connor &amp;quot;Admin&amp;quot; &amp;amp; Sons",
+            Email = "double-encoded@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == account.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal("O'Connor \"Admin\" & Sons", persisted.DisplayName);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_RawSpecialCharacters_RemainValid()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        const string displayName = "Élodie O'Connor \"QA\" & Sons";
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "Google",
+            ProviderUserId = "raw-special-user",
+            DisplayName = displayName,
+            Email = "raw-special@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == account.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal(displayName, persisted.DisplayName);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_SqlLikePayload_PersistsThroughParameterizedAccess()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        const string sqlLikeDisplayName = "Robert'); DROP TABLE ExternalLoginAccounts;--";
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            ProviderUserId = "sql-like-user",
+            DisplayName = sqlLikeDisplayName,
+            Email = "sql-like@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.ProviderUserId == "sql-like-user", TestContext.Current.CancellationToken);
+
+        int accountCount = await context.ExternalLoginAccounts
+            .CountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(sqlLikeDisplayName, persisted.DisplayName);
+        Assert.Equal(1, accountCount);
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled = true)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "UnitTest";
+    }
+}


### PR DESCRIPTION
## Summary

- Added bounded persisted string canonicalization before EF Core save operations.
- Normalized added entity string values and modified string properties before auditing, concurrency stamping, and persistence.
- Added test coverage for raw special characters, single encoding, double encoding, and SQL-like payload values.
- Documented the distinction between canonicalization, EF Core parameterization, and output encoding.

## Notes

This change improves persistence consistency and defense-in-depth. It does not replace parameterized database access or context-specific output encoding.

```poweshell
PS > dotnet build ./NetCoreApplicationTemplate.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
  ProjectTemplate.Infrastructure net10.0 succeeded (0.5s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.8s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (0.9s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll

Build succeeded in 3.4s
```
```poweshell
PS > dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:04.29]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:04.90]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:05.35]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:24.25]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (29.2s)

Test summary: total: 142, failed: 0, succeeded: 142, skipped: 0, duration: 29.2s
Build succeeded in 30.2s
```

Closes #231