### PR TITLE
Add raw SQL safety audit guardrails - issue #232

### DIFF
--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -272,6 +272,24 @@ The primary SQL injection protections remain:
 
 The template does not blanket HTML-encode values before database storage. Razor/UI output encoding and any API-specific encoding rules remain the responsibility of the output layer.
 
+## Raw SQL and Parameterization Safety
+
+The template does not currently require raw SQL command construction for its baseline data-access behavior.
+
+When database access is needed, prefer EF Core LINQ queries and normal EF Core change tracking. These APIs generate parameterized database commands for application values and avoid manual SQL string construction.
+
+If raw SQL is required for a future feature, dynamic values must not be inserted into SQL command text through string concatenation, `string.Format`, or unsafe interpolation.
+
+Preferred approaches are:
+
+- Use `FromSqlInterpolated` for raw SQL queries with dynamic values.
+- Use `ExecuteSqlInterpolated` for raw SQL commands with dynamic values.
+- Use explicit provider parameters such as `DbParameter` when provider-specific command construction is required.
+- Keep raw SQL command text static except for reviewed schema identifiers that cannot be parameterized.
+- Do not rely on input encoding, persisted string canonicalization, or output encoding as the primary SQL injection defense.
+
+Persisted string canonicalization supports consistency and defense-in-depth. SQL injection protection remains based on parameterized database access, safe query construction, validation, and avoiding manually concatenated SQL.
+
 ## Optimistic Concurrency
 
 The template includes baseline optimistic concurrency detection for entities that inherit from `DataEntity`.

--- a/tests/ProjectTemplate.Web.Tests/RawSqlSafetyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RawSqlSafetyTests.cs
@@ -1,0 +1,72 @@
+namespace ProjectTemplate.Web.Tests;
+
+/// <summary>
+/// Provides static safety checks for raw SQL and manual command construction patterns.
+/// </summary>
+public sealed class RawSqlSafetyTests
+{
+    private static readonly string[] _unsafeRawSqlPatterns =
+    [
+        "FromSqlRaw",
+        "ExecuteSqlRaw",
+        "SqlQueryRaw",
+        "CommandText",
+        "CreateCommand",
+        "new SqlCommand"
+    ];
+
+    [Fact]
+    public void SourceFiles_DoNotUseUnsafeRawSqlOrManualCommandConstructionPatterns()
+    {
+        string solutionRoot = GetSolutionRoot();
+
+        string[] searchRoots =
+        [
+            Path.Combine(solutionRoot, "src"),
+            Path.Combine(solutionRoot, ".template.content", "src")
+        ];
+
+        List<string> violations = [];
+
+        foreach (string searchRoot in searchRoots.Where(Directory.Exists))
+        {
+            foreach (string filePath in Directory.EnumerateFiles(searchRoot, "*.cs", SearchOption.AllDirectories))
+            {
+                string source = File.ReadAllText(filePath);
+
+                foreach (string pattern in _unsafeRawSqlPatterns)
+                {
+                    if (source.Contains(pattern, StringComparison.Ordinal))
+                    {
+                        violations.Add($"{Path.GetRelativePath(solutionRoot, filePath)} contains '{pattern}'.");
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Unsafe raw SQL or manual command construction patterns were found. " +
+            "Prefer LINQ, FromSqlInterpolated, ExecuteSqlInterpolated, or explicit DbParameter usage for dynamic values." +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, violations));
+    }
+
+    private static string GetSolutionRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (Directory.EnumerateFiles(directory.FullName, "*.slnx").Any())
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate solution root from '{AppContext.BaseDirectory}'.");
+    }
+}


### PR DESCRIPTION
## Summary

- Added a static test that fails if unsafe raw SQL APIs or manual command construction patterns are introduced into source/template code.
- Documented preferred parameterized raw SQL patterns for future contributors.
- Clarified that SQL injection protection remains based on EF Core parameterization and safe query construction, separate from persisted string canonicalization and output encoding.

## Validation

- Ran `dotnet test --configuration Release`.
```powershell
PS > dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.13]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.73]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.18]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:13.98]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (16.2s)

Test summary: total: 143, failed: 0, succeeded: 143, skipped: 0, duration: 16.2s
Build succeeded in 17.4s
```

Closes #232