### PR TITLE
Define persisted string lookup normalization rules

### DIFF
--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -272,6 +272,27 @@ The primary SQL injection protections remain:
 
 The template does not blanket HTML-encode values before database storage. Razor/UI output encoding and any API-specific encoding rules remain the responsibility of the output layer.
 
+## String Comparison and Lookup Normalization
+
+The template separates display values from lookup values.
+
+Persisted display strings preserve user-facing casing where practical, but lookup-sensitive values use explicit normalization rules so behavior is not accidentally determined by provider-specific collation behavior.
+
+Default rules:
+
+| Value | Rule |
+|---|---|
+| Provider name | Trim, Unicode Form C, preserve display casing |
+| Normalized provider name | Trim, Unicode Form C, uppercase invariant |
+| Provider user ID | Trim, Unicode Form C, case-sensitive |
+| Display name | Trim, Unicode Form C, preserve casing |
+| Email | Trim, Unicode Form C, preserve casing |
+| Normalized email | Trim, Unicode Form C, uppercase invariant |
+
+The external login unique key uses `NormalizedProviderName` plus `ProviderUserId`. This makes provider-name matching case-insensitive while preserving provider user IDs as exact, case-sensitive external identifiers.
+
+SQLite and SQL Server can differ in default collation and case-sensitivity behavior. The template avoids relying on those defaults for provider-name lookup by storing a normalized provider-name value. Future applications that add slugs, usernames, tenant names, email login, or other lookup-sensitive fields should follow the same pattern: preserve the display value, store a normalized lookup value, and place uniqueness constraints on the normalized value.
+
 ## Raw SQL and Parameterization Safety
 
 The template does not currently require raw SQL command construction for its baseline data-access behavior.

--- a/scripts/migration.sql
+++ b/scripts/migration.sql
@@ -49,3 +49,19 @@ VALUES ('20260528165924_AddDataEntityConcurrencyStamp', '10.0.8');
 
 COMMIT;
 
+BEGIN TRANSACTION;
+DROP INDEX "IX_ExternalLoginAccounts_ProviderName_ProviderUserId";
+
+ALTER TABLE "ExternalLoginAccounts" ADD "NormalizedEmail" TEXT NULL;
+
+ALTER TABLE "ExternalLoginAccounts" ADD "NormalizedProviderName" TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX "IX_ExternalLoginAccounts_NormalizedEmail" ON "ExternalLoginAccounts" ("NormalizedEmail");
+
+CREATE UNIQUE INDEX "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId" ON "ExternalLoginAccounts" ("NormalizedProviderName", "ProviderUserId");
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260530111053_AddExternalLoginAccountNormalizedLookupColumns', '10.0.8');
+
+COMMIT;
+

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -85,6 +85,7 @@ public sealed partial class ApplicationDbContext(
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
         ApplyPersistedStringCanonicalization();
+        ApplyLookupStringNormalization();
         ApplyConcurrencyStamps();
 
         if (!_auditOptions)
@@ -115,6 +116,7 @@ public sealed partial class ApplicationDbContext(
         CancellationToken cancellationToken = default)
     {
         ApplyPersistedStringCanonicalization();
+        ApplyLookupStringNormalization();
         ApplyConcurrencyStamps();
 
         if (!_auditOptions)
@@ -178,6 +180,40 @@ public sealed partial class ApplicationDbContext(
             }
         }
     }
+
+    private void ApplyLookupStringNormalization()
+    {
+        ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry<ExternalLoginAccount> entry in ChangeTracker.Entries<ExternalLoginAccount>())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            ExternalLoginAccount account = entry.Entity;
+
+            account.ProviderName =
+                PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(account.ProviderName);
+
+            account.NormalizedProviderName =
+                PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(account.ProviderName);
+
+            account.ProviderUserId =
+                PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(account.ProviderUserId);
+
+            account.DisplayName =
+                PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(account.DisplayName);
+
+            account.Email =
+                PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(account.Email);
+
+            account.NormalizedEmail =
+                PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(account.Email);
+        }
+    }
+
     private List<AuditEntry> OnBeforeSaveChanges()
     {
         ChangeTracker.DetectChanges();

--- a/src/ProjectTemplate.Infrastructure/Data/Configurations/ExternalLoginAccountConfiguration.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Configurations/ExternalLoginAccountConfiguration.cs
@@ -26,6 +26,10 @@ public sealed class ExternalLoginAccountConfiguration : IEntityTypeConfiguration
             .HasMaxLength(100)
             .IsRequired();
 
+        builder.Property(x => x.NormalizedProviderName)
+            .HasMaxLength(100)
+            .IsRequired();
+
         builder.Property(x => x.ProviderUserId)
             .HasMaxLength(256)
             .IsRequired();
@@ -36,14 +40,19 @@ public sealed class ExternalLoginAccountConfiguration : IEntityTypeConfiguration
         builder.Property(x => x.Email)
             .HasMaxLength(320);
 
+        builder.Property(x => x.NormalizedEmail)
+            .HasMaxLength(320);
+
         builder.Property(x => x.CreatedOnUtc)
             .IsRequired();
 
-        builder.HasIndex(x => new { x.ProviderName, x.ProviderUserId })
+        builder.HasIndex(x => new { x.NormalizedProviderName, x.ProviderUserId })
             .IsUnique();
 
         builder.HasIndex(x => x.LocalUserId);
 
         builder.HasIndex(x => x.Email);
+
+        builder.HasIndex(x => x.NormalizedEmail);
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Entities/ExternalLoginAccount.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Entities/ExternalLoginAccount.cs
@@ -16,6 +16,11 @@ public sealed class ExternalLoginAccount : DataEntity
     public string ProviderName { get; set; } = string.Empty;
 
     /// <summary>
+    /// Normalized provider name used for lookup and uniqueness comparisons.
+    /// </summary>
+    public string NormalizedProviderName { get; set; } = string.Empty;
+
+    /// <summary>
     /// Provider-specific unique identifier for the user (e.g., the "sub" claim from an OpenID Connect token).
     /// </summary>
     public string ProviderUserId { get; set; } = string.Empty;
@@ -29,6 +34,11 @@ public sealed class ExternalLoginAccount : DataEntity
     /// Email address associated with the external account, if available. This is not used for authentication but can be helpful for administrators to identify linked accounts and for potential communication purposes.
     /// </summary>
     public string? Email { get; set; }
+
+    /// <summary>
+    /// Normalized email address used for lookup comparisons when email-based lookup is needed.
+    /// </summary>
+    public string? NormalizedEmail { get; set; }
 
     /// <summary>
     /// Creation timestamp in UTC when this external login account was linked to the local user. This can be useful for auditing and tracking purposes.

--- a/src/ProjectTemplate.Infrastructure/Data/ExternalLogins/EfCoreExternalLoginAccountResolver.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ExternalLogins/EfCoreExternalLoginAccountResolver.cs
@@ -14,8 +14,8 @@ public sealed class EfCoreExternalLoginAccountResolver(ApplicationDbContext dbCo
     /// <summary>
     /// Finds an external login account by the provider name and provider user ID.
     /// </summary>
-    /// <param name="providerName">Provider name (e.g., "Google", "Facebook"). This value is case-insensitive and will be trimmed of whitespace.</param>
-    /// <param name="providerUserId">Provider user ID (the unique identifier for the user from the external provider). This value is case-insensitive and will be trimmed of whitespace.</param>
+    /// <param name="providerName">Provider name. This value is matched case-insensitively after trimming and Unicode normalization.</param>
+    /// <param name="providerUserId">Provider user ID. This value is trimmed and Unicode-normalized, but remains case-sensitive.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation if needed.</param>
     /// <returns>Returns the matching <see cref="ExternalLoginAccount" /> if found; otherwise, returns null.</returns>
     public async Task<ExternalLoginAccount?> FindByProviderUserIdAsync(
@@ -28,13 +28,16 @@ public sealed class EfCoreExternalLoginAccountResolver(ApplicationDbContext dbCo
             return null;
         }
 
-        string normalizedProviderName = providerName.Trim();
-        string normalizedProviderUserId = providerUserId.Trim();
+        string normalizedProviderName =
+            PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(providerName);
+
+        string normalizedProviderUserId =
+            PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(providerUserId);
 
         return await _dbContext.ExternalLoginAccounts
             .AsNoTracking()
             .FirstOrDefaultAsync(
-                x => x.ProviderName == normalizedProviderName
+                x => x.NormalizedProviderName == normalizedProviderName
                     && x.ProviderUserId == normalizedProviderUserId,
                 cancellationToken)
             .ConfigureAwait(false);

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530111053_AddExternalLoginAccountNormalizedLookupColumns.Designer.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530111053_AddExternalLoginAccountNormalizedLookupColumns.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectTemplate.Infrastructure.Data;
 
@@ -10,9 +11,11 @@ using ProjectTemplate.Infrastructure.Data;
 namespace ProjectTemplate.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530111053_AddExternalLoginAccountNormalizedLookupColumns")]
+    partial class AddExternalLoginAccountNormalizedLookupColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530111053_AddExternalLoginAccountNormalizedLookupColumns.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530111053_AddExternalLoginAccountNormalizedLookupColumns.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectTemplate.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalLoginAccountNormalizedLookupColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
+                table: "ExternalLoginAccounts");
+
+            migrationBuilder.AddColumn<string>(
+                name: "NormalizedEmail",
+                table: "ExternalLoginAccounts",
+                type: "TEXT",
+                maxLength: 320,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NormalizedProviderName",
+                table: "ExternalLoginAccounts",
+                type: "TEXT",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalLoginAccounts_NormalizedEmail",
+                table: "ExternalLoginAccounts",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId",
+                table: "ExternalLoginAccounts",
+                columns: new[] { "NormalizedProviderName", "ProviderUserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExternalLoginAccounts_NormalizedEmail",
+                table: "ExternalLoginAccounts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId",
+                table: "ExternalLoginAccounts");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedEmail",
+                table: "ExternalLoginAccounts");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedProviderName",
+                table: "ExternalLoginAccounts");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
+                table: "ExternalLoginAccounts",
+                columns: new[] { "ProviderName", "ProviderUserId" },
+                unique: true);
+        }
+    }
+}

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530111053_AddExternalLoginAccountNormalizedLookupColumns.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530111053_AddExternalLoginAccountNormalizedLookupColumns.cs
@@ -1,70 +1,69 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace ProjectTemplate.Infrastructure.Data.Migrations
+namespace ProjectTemplate.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddExternalLoginAccountNormalizedLookupColumns : Migration
 {
     /// <inheritdoc />
-    public partial class AddExternalLoginAccountNormalizedLookupColumns : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropIndex(
-                name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
-                table: "ExternalLoginAccounts");
+        migrationBuilder.DropIndex(
+            name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
+            table: "ExternalLoginAccounts");
 
-            migrationBuilder.AddColumn<string>(
-                name: "NormalizedEmail",
-                table: "ExternalLoginAccounts",
-                type: "TEXT",
-                maxLength: 320,
-                nullable: true);
+        migrationBuilder.AddColumn<string>(
+            name: "NormalizedEmail",
+            table: "ExternalLoginAccounts",
+            type: "TEXT",
+            maxLength: 320,
+            nullable: true);
 
-            migrationBuilder.AddColumn<string>(
-                name: "NormalizedProviderName",
-                table: "ExternalLoginAccounts",
-                type: "TEXT",
-                maxLength: 100,
-                nullable: false,
-                defaultValue: "");
+        migrationBuilder.AddColumn<string>(
+            name: "NormalizedProviderName",
+            table: "ExternalLoginAccounts",
+            type: "TEXT",
+            maxLength: 100,
+            nullable: false,
+            defaultValue: "");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_ExternalLoginAccounts_NormalizedEmail",
-                table: "ExternalLoginAccounts",
-                column: "NormalizedEmail");
+        migrationBuilder.CreateIndex(
+            name: "IX_ExternalLoginAccounts_NormalizedEmail",
+            table: "ExternalLoginAccounts",
+            column: "NormalizedEmail");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId",
-                table: "ExternalLoginAccounts",
-                columns: new[] { "NormalizedProviderName", "ProviderUserId" },
-                unique: true);
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId",
+            table: "ExternalLoginAccounts",
+            columns: ["NormalizedProviderName", "ProviderUserId"],
+            unique: true);
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropIndex(
-                name: "IX_ExternalLoginAccounts_NormalizedEmail",
-                table: "ExternalLoginAccounts");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_ExternalLoginAccounts_NormalizedEmail",
+            table: "ExternalLoginAccounts");
 
-            migrationBuilder.DropIndex(
-                name: "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId",
-                table: "ExternalLoginAccounts");
+        migrationBuilder.DropIndex(
+            name: "IX_ExternalLoginAccounts_NormalizedProviderName_ProviderUserId",
+            table: "ExternalLoginAccounts");
 
-            migrationBuilder.DropColumn(
-                name: "NormalizedEmail",
-                table: "ExternalLoginAccounts");
+        migrationBuilder.DropColumn(
+            name: "NormalizedEmail",
+            table: "ExternalLoginAccounts");
 
-            migrationBuilder.DropColumn(
-                name: "NormalizedProviderName",
-                table: "ExternalLoginAccounts");
+        migrationBuilder.DropColumn(
+            name: "NormalizedProviderName",
+            table: "ExternalLoginAccounts");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
-                table: "ExternalLoginAccounts",
-                columns: new[] { "ProviderName", "ProviderUserId" },
-                unique: true);
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_ExternalLoginAccounts_ProviderName_ProviderUserId",
+            table: "ExternalLoginAccounts",
+            columns: ["ProviderName", "ProviderUserId"],
+            unique: true);
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/PersistenceStringComparisonNormalizer.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/PersistenceStringComparisonNormalizer.cs
@@ -1,0 +1,30 @@
+using System.Text;
+
+namespace ProjectTemplate.Infrastructure.Data;
+
+internal static class PersistenceStringComparisonNormalizer
+{
+    internal static string NormalizeRequiredDisplayValue(string value)
+    {
+        return value.Trim().Normalize(NormalizationForm.FormC);
+    }
+
+    internal static string NormalizeRequiredLookupValue(string value)
+    {
+        return NormalizeRequiredDisplayValue(value).ToUpperInvariant();
+    }
+
+    internal static string? NormalizeOptionalDisplayValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Trim().Normalize(NormalizationForm.FormC);
+    }
+
+    internal static string? NormalizeOptionalLookupValue(string? value)
+    {
+        string? normalizedValue = NormalizeOptionalDisplayValue(value);
+
+        return normalizedValue?.ToUpperInvariant();
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountNormalizationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountNormalizationTests.cs
@@ -1,0 +1,178 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.ExternalLogins;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ExternalLoginAccountNormalizationTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_LookupSensitiveValues_TrimsAndStoresNormalizedColumns()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = " GitHub ",
+            ProviderUserId = " provider-user-123 ",
+            DisplayName = " Test User ",
+            Email = " User@Example.Com ",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == account.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal("GitHub", persisted.ProviderName);
+        Assert.Equal("GITHUB", persisted.NormalizedProviderName);
+        Assert.Equal("provider-user-123", persisted.ProviderUserId);
+        Assert.Equal("Test User", persisted.DisplayName);
+        Assert.Equal("User@Example.Com", persisted.Email);
+        Assert.Equal("USER@EXAMPLE.COM", persisted.NormalizedEmail);
+    }
+
+    [Fact]
+    public async Task FindByProviderUserIdAsync_ProviderNameCasingAndWhitespace_ReturnsLinkedAccount()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            ProviderUserId = "case-sensitive-user",
+            DisplayName = "Case Test",
+            Email = "case@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        ExternalLoginAccount? result = await resolver.FindByProviderUserIdAsync(
+            " github ",
+            "case-sensitive-user",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(account.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task FindByProviderUserIdAsync_DifferentProviderUserIdCasing_ReturnsNull()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            ProviderUserId = "CaseSensitiveUser",
+            DisplayName = "Case Sensitive User",
+            Email = "case-sensitive@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EfCoreExternalLoginAccountResolver resolver = new(context);
+
+        ExternalLoginAccount? result = await resolver.FindByProviderUserIdAsync(
+            "GitHub",
+            "casesensitiveuser",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DecomposedUnicode_NormalizesToFormC()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        string decomposedDisplayName = "Jose\u0301 User";
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            ProviderUserId = "unicode-user",
+            DisplayName = decomposedDisplayName,
+            Email = "unicode@example.com",
+            CreatedOnUtc = DateTime.UtcNow
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == account.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal("José User", persisted.DisplayName);
+        Assert.True(persisted.DisplayName!.IsNormalized(System.Text.NormalizationForm.FormC));
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled = true)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "UnitTest";
+    }
+}


### PR DESCRIPTION
## Summary

- Added normalized lookup columns for external login provider name and email values.
- Updated external login lookup to use normalized provider-name comparison while preserving case-sensitive provider user IDs.
- Added tests for whitespace trimming, provider-name casing, provider-user-id case sensitivity, and Unicode Form C normalization.
- Documented persisted string comparison rules and SQLite/SQL Server collation expectations.

## Notes

This keeps display values intact while making lookup-sensitive comparisons explicit and provider-safe.

```powershell
PS > dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.12]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.72]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.17]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:14.33]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (16.3s)

Test summary: total: 147, failed: 0, succeeded: 147, skipped: 0, duration: 16.3s
Build succeeded in 17.5s
```

Closes #233