### PR TITLE
Standardize timestamp persistence behavior

### DIFF
--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -293,6 +293,20 @@ The external login unique key uses `NormalizedProviderName` plus `ProviderUserId
 
 SQLite and SQL Server can differ in default collation and case-sensitivity behavior. The template avoids relying on those defaults for provider-name lookup by storing a normalized provider-name value. Future applications that add slugs, usernames, tenant names, email login, or other lookup-sensitive fields should follow the same pattern: preserve the display value, store a normalized lookup value, and place uniqueness constraints on the normalized value.
 
+## Date and Time Persistence
+
+System and audit timestamps use UTC `DateTime` properties with a `Utc` suffix.
+
+The template treats these values as persistence timestamps, not display timestamps. They are generated in UTC, normalized to millisecond precision before save, and should be converted to a user's local time zone only at the display/API boundary when a consuming application needs that behavior.
+
+Provider notes:
+
+- SQL Server supports explicit precision for `DateTime`/`DateTimeOffset` values. UTC `DateTime` system fields are configured with millisecond precision.
+- SQLite stores these values as `TEXT`; provider precision behavior differs from SQL Server, so the application normalizes timestamp values before persistence to keep tests and comparisons stable.
+- Future application fields that need to preserve a caller-provided offset should use `DateTimeOffset` intentionally rather than overloading UTC `DateTime` fields.
+
+Do not store local time in system/audit `*Utc` columns.
+
 ## Raw SQL and Parameterization Safety
 
 The template does not currently require raw SQL command construction for its baseline data-access behavior.

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -56,6 +56,7 @@ public sealed partial class ApplicationDbContext(
 
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
         ConfigureDataEntityDefaults(modelBuilder);
+        ConfigureTimestampDefaults(modelBuilder);
 
         base.OnModelCreating(modelBuilder);
     }
@@ -86,6 +87,7 @@ public sealed partial class ApplicationDbContext(
     {
         ApplyPersistedStringCanonicalization();
         ApplyLookupStringNormalization();
+        ApplyTimestampNormalization();
         ApplyConcurrencyStamps();
 
         if (!_auditOptions)
@@ -117,6 +119,7 @@ public sealed partial class ApplicationDbContext(
     {
         ApplyPersistedStringCanonicalization();
         ApplyLookupStringNormalization();
+        ApplyTimestampNormalization();
         ApplyConcurrencyStamps();
 
         if (!_auditOptions)
@@ -214,6 +217,47 @@ public sealed partial class ApplicationDbContext(
         }
     }
 
+    private void ApplyTimestampNormalization()
+    {
+        ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry entry in ChangeTracker.Entries())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            foreach (PropertyEntry property in entry.Properties)
+            {
+                if (!IsUtcTimestampProperty(property.Metadata.Name))
+                {
+                    continue;
+                }
+
+                Type propertyType = Nullable.GetUnderlyingType(property.Metadata.ClrType)
+                    ?? property.Metadata.ClrType;
+
+                if (propertyType == typeof(DateTime) &&
+                    property.CurrentValue is DateTime dateTimeValue)
+                {
+                    property.CurrentValue = PersistenceTimestamp.NormalizeUtc(dateTimeValue);
+                    continue;
+                }
+
+                if (propertyType == typeof(DateTimeOffset) &&
+                    property.CurrentValue is DateTimeOffset dateTimeOffsetValue)
+                {
+                    property.CurrentValue = PersistenceTimestamp.NormalizeUtc(dateTimeOffsetValue);
+                }
+            }
+        }
+    }
+
+    private static bool IsUtcTimestampProperty(string propertyName)
+    {
+        return propertyName.EndsWith("Utc", StringComparison.Ordinal);
+    }
     private List<AuditEntry> OnBeforeSaveChanges()
     {
         ChangeTracker.DetectChanges();
@@ -229,7 +273,7 @@ public sealed partial class ApplicationDbContext(
             {
                 TableName = entry.Metadata.GetTableName() ?? string.Empty,
                 ModifiedBy = _currentActorAccessor.CurrentActor,
-                ModifiedOnUtc = DateTime.UtcNow,
+                ModifiedOnUtc = PersistenceTimestamp.UtcNow(),
                 State = entry.State.ToString()
             };
             auditEntries.Add(auditEntry);
@@ -372,6 +416,24 @@ public sealed partial class ApplicationDbContext(
                 .HasMaxLength(64)
                 .IsRequired()
                 .IsConcurrencyToken();
+        }
+    }
+
+    private static void ConfigureTimestampDefaults(ModelBuilder modelBuilder)
+    {
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (IMutableProperty property in entityType.GetProperties())
+            {
+                Type propertyType = Nullable.GetUnderlyingType(property.ClrType)
+                    ?? property.ClrType;
+
+                if ((propertyType == typeof(DateTime) || propertyType == typeof(DateTimeOffset)) &&
+                    IsUtcTimestampProperty(property.Name))
+                {
+                    property.SetPrecision(PersistenceTimestamp.Precision);
+                }
+            }
         }
     }
 

--- a/src/ProjectTemplate.Infrastructure/Data/Entities/AuditRecord.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Entities/AuditRecord.cs
@@ -9,7 +9,7 @@ public class AuditRecord : DataEntity
     /// <summary>
     /// The date and time when the change was made, in Coordinated Universal Time (UTC). It should be stored in UTC to avoid issues with time zones and daylight saving time. When displaying the date and time to users, it can be converted to their local time zone as needed.
     /// </summary>
-    public DateTime ModifiedOnUtc { get; set; } = DateTime.UtcNow;
+    public DateTime ModifiedOnUtc { get; set; } = PersistenceTimestamp.UtcNow();
     /// <summary>
     /// The name of the application or service that made the change. It can be used to group changes by application or service, and to identify which application or service is responsible for a change. It should be unique enough to identify the source of the change, but it does not have to be globally unique.
     /// </summary>

--- a/src/ProjectTemplate.Infrastructure/Data/Entities/ExternalLoginAccount.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Entities/ExternalLoginAccount.cs
@@ -43,7 +43,7 @@ public sealed class ExternalLoginAccount : DataEntity
     /// <summary>
     /// Creation timestamp in UTC when this external login account was linked to the local user. This can be useful for auditing and tracking purposes.
     /// </summary>
-    public DateTime CreatedOnUtc { get; set; } = DateTime.UtcNow;
+    public DateTime CreatedOnUtc { get; set; } = PersistenceTimestamp.UtcNow();
 
     /// <summary>
     /// Update timestamp in UTC when this external login account was last modified. This can be useful for auditing and tracking purposes, especially if the display name or email associated with the external account changes over time.

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530122223_StandardizeTimestampPersistence.Designer.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530122223_StandardizeTimestampPersistence.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectTemplate.Infrastructure.Data;
 
@@ -10,9 +11,11 @@ using ProjectTemplate.Infrastructure.Data;
 namespace ProjectTemplate.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530122223_StandardizeTimestampPersistence")]
+    partial class StandardizeTimestampPersistence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530122223_StandardizeTimestampPersistence.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Migrations/20260530122223_StandardizeTimestampPersistence.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectTemplate.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+public partial class StandardizeTimestampPersistence : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+
+    }
+}

--- a/src/ProjectTemplate.Infrastructure/Data/PersistenceTimestamp.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/PersistenceTimestamp.cs
@@ -1,0 +1,36 @@
+namespace ProjectTemplate.Infrastructure.Data;
+
+internal static class PersistenceTimestamp
+{
+    internal const int Precision = 3;
+
+    private const long _ticksPerMillisecond = TimeSpan.TicksPerMillisecond;
+
+    internal static DateTime UtcNow()
+    {
+        return NormalizeUtc(DateTime.UtcNow);
+    }
+
+    internal static DateTime NormalizeUtc(DateTime value)
+    {
+        DateTime utcValue = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+
+        long normalizedTicks = utcValue.Ticks - (utcValue.Ticks % _ticksPerMillisecond);
+
+        return new DateTime(normalizedTicks, DateTimeKind.Utc);
+    }
+
+    internal static DateTimeOffset NormalizeUtc(DateTimeOffset value)
+    {
+        DateTimeOffset utcValue = value.ToUniversalTime();
+        long normalizedTicks = utcValue.Ticks - (utcValue.Ticks % _ticksPerMillisecond);
+
+        return new DateTimeOffset(normalizedTicks, TimeSpan.Zero);
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextTimestampPersistenceTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextTimestampPersistenceTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationDbContextTimestampPersistenceTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_UtcTimestampProperties_NormalizesToMillisecondPrecision()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        DateTime createdOnUtc = new(2026, 5, 30, 12, 34, 56, 789, DateTimeKind.Utc);
+        createdOnUtc = createdOnUtc.AddTicks(1_234);
+
+        DateTime updatedOnUtc = new(2026, 5, 30, 13, 14, 15, 456, DateTimeKind.Utc);
+        updatedOnUtc = updatedOnUtc.AddTicks(5_678);
+
+        DateTime lastLoginOnUtc = new(2026, 5, 30, 14, 15, 16, 123, DateTimeKind.Utc);
+        lastLoginOnUtc = lastLoginOnUtc.AddTicks(9_999);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            ProviderUserId = "timestamp-user",
+            DisplayName = "Timestamp User",
+            Email = "timestamp@example.com",
+            CreatedOnUtc = createdOnUtc,
+            UpdatedOnUtc = updatedOnUtc,
+            LastLoginOnUtc = lastLoginOnUtc
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        ExternalLoginAccount persisted = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == account.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, persisted.CreatedOnUtc.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.NotNull(persisted.UpdatedOnUtc);
+        Assert.NotNull(persisted.LastLoginOnUtc);
+        Assert.Equal(0, persisted.UpdatedOnUtc.Value.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(0, persisted.LastLoginOnUtc.Value.Ticks % TimeSpan.TicksPerMillisecond);
+
+        Assert.Equal(TruncateToMillisecond(createdOnUtc).Ticks, persisted.CreatedOnUtc.Ticks);
+        Assert.Equal(TruncateToMillisecond(updatedOnUtc).Ticks, persisted.UpdatedOnUtc.Value.Ticks);
+        Assert.Equal(TruncateToMillisecond(lastLoginOnUtc).Ticks, persisted.LastLoginOnUtc.Value.Ticks);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_AuditingEnabled_AuditTimestampUsesMillisecondPrecision()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: true);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "Microsoft",
+            ProviderUserId = "audit-timestamp-user",
+            DisplayName = "Audit Timestamp User",
+            Email = "audit-timestamp@example.com",
+            CreatedOnUtc = DateTime.UtcNow.AddTicks(4_321)
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.ChangeTracker.Clear();
+
+        AuditRecord auditRecord = await context.AuditRecords
+            .SingleAsync(
+                item => item.Entity == "ExternalLoginAccounts",
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, auditRecord.ModifiedOnUtc.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal("UnitTest", auditRecord.ModifiedBy);
+        Assert.Equal(EntityState.Added.ToString(), auditRecord.State);
+    }
+
+    private static DateTime TruncateToMillisecond(DateTime value)
+    {
+        long normalizedTicks = value.Ticks - (value.Ticks % TimeSpan.TicksPerMillisecond);
+
+        return new DateTime(normalizedTicks, value.Kind);
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled = true)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "UnitTest";
+    }
+}


### PR DESCRIPTION
## Summary
- Defines UTC `DateTime` as the default convention for system/audit persistence timestamps.
- Normalizes `*Utc` timestamp values to millisecond precision before save.
- Configures EF Core timestamp precision for UTC timestamp properties.
- Adds timestamp persistence tests for external login and audit records.
- Documents persistence vs display-time conversion guidance for SQLite and SQL Server.

## Validation
- `dotnet test --configuration Release`
```powershell
PS > dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.19]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.78]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.23]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:15.11]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (17.1s)

Test summary: total: 149, failed: 0, succeeded: 149, skipped: 0, duration: 17.1s
Build succeeded in 18.3s
```

Closes #234