### PR TITLE
Add decimal precision persistence guardrails

### DIFF
--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -307,6 +307,38 @@ Provider notes:
 
 Do not store local time in system/audit `*Utc` columns.
 
+## Decimal Precision and Scale
+
+The baseline template currently does not define persisted `decimal` entity properties.
+
+Future applications that add persisted decimal values should configure precision and scale explicitly with EF Core instead of relying on provider defaults. This is especially important for values that represent money, percentages, rates, measurements, thresholds, scores, limits, or other business-sensitive quantities.
+
+Recommended default patterns:
+
+| Value type | Suggested precision | Notes |
+|---|---:|---|
+| Money-like values | `decimal(18, 2)` or `HasPrecision(18, 2)` | Common default for currency-style values. Domain-specific financial applications may require different precision, rounding, or minor-unit storage rules. |
+| Percentage values | `decimal(9, 4)` or `HasPrecision(9, 4)` | Useful when storing percentages such as `12.3456`. Decide whether the value is stored as `12.3456` or `0.123456` before choosing precision. |
+| Rates and ratios | `decimal(18, 6)` or `HasPrecision(18, 6)` | Useful for tax rates, interest rates, thresholds, and ratios where more fractional precision may matter. |
+| Measurements | `decimal(18, 4)` or domain-specific precision | Use precision appropriate to the measurement unit and required tolerance. |
+| Scores or weights | `decimal(9, 4)` or domain-specific precision | Useful for scoring, ranking, confidence, or weighting values when deterministic decimal behavior is preferred. |
+
+Example entity configuration:
+
+```csharp
+builder.Property(x => x.Amount)
+    .HasPrecision(18, 2);
+
+builder.Property(x => x.Rate)
+    .HasPrecision(18, 6);
+```
+
+SQLite and SQL Server handle decimal storage differently. SQL Server enforces decimal precision and scale through column types such as `decimal(18,2)`. SQLite has dynamic typing and does not enforce the same decimal semantics in the same way. For this reason, consuming applications should still validate decimal range, scale, and rounding rules in the application/domain layer when those rules matter.
+
+Do not use `double` or `float` for money-like values. Use `decimal` with explicit precision/scale, or use integer minor units such as cents when that better fits the domain.
+
+The template includes a model validation test that fails when persisted decimal properties are added without explicit precision and scale.
+
 ## Raw SQL and Parameterization Safety
 
 The template does not currently require raw SQL command construction for its baseline data-access behavior.

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextDecimalPrecisionTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextDecimalPrecisionTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationDbContextDecimalPrecisionTests
+{
+    [Fact]
+    public async Task Model_DecimalProperties_HaveExplicitPrecisionAndScale()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        string[] decimalPropertiesMissingPrecision = [.. context.Model
+            .GetEntityTypes()
+            .SelectMany(entityType => entityType.GetProperties())
+            .Where(property =>
+            {
+                Type propertyType = Nullable.GetUnderlyingType(property.ClrType)
+                    ?? property.ClrType;
+
+                return propertyType == typeof(decimal) &&
+                    (property.GetPrecision() is null || property.GetScale() is null);
+            })
+            .Select(property =>
+                $"{property.DeclaringType.DisplayName()}.{property.Name}")];
+
+        Assert.Empty(decimalPropertiesMissingPrecision);
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled = true)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "UnitTest";
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a model validation test that fails when persisted decimal properties lack explicit precision and scale.
- Documents recommended decimal precision/scale patterns for future template consumers.
- Clarifies provider differences between SQL Server and SQLite decimal behavior.
- Avoids adding fake decimal fields or unnecessary migrations because the current model has no persisted decimal properties.

## Validation
- `dotnet test --configuration Release`
```powershell
PS > dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.12]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.72]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.16]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:13.65]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (15.6s)

Test summary: total: 150, failed: 0, succeeded: 150, skipped: 0, duration: 15.5s
Build succeeded in 16.8s
```

Closes #235