### PR TITLE
test: cover EF Core migration model metadata

### DIFF
--- a/tests/ProjectTemplate.Web.Tests/EfCoreMigrationCoverageTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/EfCoreMigrationCoverageTests.cs
@@ -1,0 +1,168 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Migrations;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class EfCoreMigrationCoverageTests
+{
+    private const string _migrationProvider = "Microsoft.EntityFrameworkCore.Sqlite";
+
+    private const string _auditRecordEntityName =
+        "ProjectTemplate.Infrastructure.Data.Entities.AuditRecord";
+
+    private const string _externalLoginAccountEntityName =
+        "ProjectTemplate.Infrastructure.Data.Entities.ExternalLoginAccount";
+
+    public static TheoryData<string, int, int> MigrationOperationCases => new()
+    {
+        { nameof(InitialCreate), 5, 2 },
+        { nameof(AddDataEntityConcurrencyStamp), 2, 2 },
+        { nameof(AddExternalLoginAccountNormalizedLookupColumns), 5, 5 },
+        { nameof(StandardizeTimestampPersistence), 0, 0 }
+    };
+
+    public static TheoryData<string, bool, bool, int?> MigrationModelCases => new()
+    {
+        { nameof(InitialCreate), false, false, null },
+        { nameof(AddDataEntityConcurrencyStamp), true, false, null },
+        { nameof(AddExternalLoginAccountNormalizedLookupColumns), true, true, null },
+        { nameof(StandardizeTimestampPersistence), true, true, 3 }
+    };
+
+    [Theory]
+    [MemberData(nameof(MigrationOperationCases))]
+    public void Migration_UpAndDown_DefinesExpectedOperations(
+        string migrationName,
+        int expectedUpOperations,
+        int expectedDownOperations)
+    {
+        Migration migration = CreateMigration(migrationName);
+
+        MigrationBuilder upBuilder = new(_migrationProvider);
+
+        InvokeMigrationMethod(migration, "Up", upBuilder);
+
+        Assert.Equal(expectedUpOperations, upBuilder.Operations.Count);
+
+        MigrationBuilder downBuilder = new(_migrationProvider);
+
+        InvokeMigrationMethod(migration, "Down", downBuilder);
+
+        Assert.Equal(expectedDownOperations, downBuilder.Operations.Count);
+    }
+
+    [Theory]
+    [MemberData(nameof(MigrationModelCases))]
+    public void Migration_TargetModel_PreservesExpectedPersistenceShape(
+        string migrationName,
+        bool expectsConcurrencyStamp,
+        bool expectsNormalizedLookupColumns,
+        int? expectedTimestampPrecision)
+    {
+        Migration migration = CreateMigration(migrationName);
+
+        IModel model = migration.TargetModel;
+
+        IEntityType? auditRecord = model.FindEntityType(_auditRecordEntityName);
+        IEntityType? externalLoginAccount = model.FindEntityType(_externalLoginAccountEntityName);
+
+        Assert.NotNull(auditRecord);
+        Assert.NotNull(externalLoginAccount);
+
+        Assert.Equal(
+            expectsConcurrencyStamp,
+            auditRecord!.FindProperty("ConcurrencyStamp") is not null);
+
+        Assert.Equal(
+            expectsConcurrencyStamp,
+            externalLoginAccount!.FindProperty("ConcurrencyStamp") is not null);
+
+        Assert.Equal(
+            expectsNormalizedLookupColumns,
+            externalLoginAccount.FindProperty("NormalizedEmail") is not null);
+
+        Assert.Equal(
+            expectsNormalizedLookupColumns,
+            externalLoginAccount.FindProperty("NormalizedProviderName") is not null);
+
+        IProperty? createdOnUtc = externalLoginAccount.FindProperty("CreatedOnUtc");
+        IProperty? modifiedOnUtc = auditRecord.FindProperty("ModifiedOnUtc");
+
+        Assert.NotNull(createdOnUtc);
+        Assert.NotNull(modifiedOnUtc);
+
+        Assert.Equal(expectedTimestampPrecision, createdOnUtc!.GetPrecision());
+        Assert.Equal(expectedTimestampPrecision, modifiedOnUtc!.GetPrecision());
+    }
+    [Fact]
+    public void ApplicationDbContextModelSnapshot_Model_PreservesCurrentPersistenceShape()
+    {
+        Type snapshotType = typeof(ApplicationDbContext).Assembly.GetType(
+            "ProjectTemplate.Infrastructure.Data.Migrations.ApplicationDbContextModelSnapshot",
+            throwOnError: true)!;
+
+        var snapshot = (ModelSnapshot)Activator.CreateInstance(
+            snapshotType,
+            nonPublic: true)!;
+
+        IModel model = snapshot.Model;
+
+        IEntityType? auditRecord = model.FindEntityType(_auditRecordEntityName);
+        IEntityType? externalLoginAccount = model.FindEntityType(_externalLoginAccountEntityName);
+
+        Assert.NotNull(auditRecord);
+        Assert.NotNull(externalLoginAccount);
+
+        Assert.NotNull(auditRecord!.FindProperty("ConcurrencyStamp"));
+        Assert.NotNull(externalLoginAccount!.FindProperty("ConcurrencyStamp"));
+        Assert.NotNull(externalLoginAccount.FindProperty("NormalizedEmail"));
+        Assert.NotNull(externalLoginAccount.FindProperty("NormalizedProviderName"));
+
+        Assert.Equal(3, auditRecord.FindProperty("ModifiedOnUtc")!.GetPrecision());
+        Assert.Equal(3, externalLoginAccount.FindProperty("CreatedOnUtc")!.GetPrecision());
+        Assert.Equal(3, externalLoginAccount.FindProperty("UpdatedOnUtc")!.GetPrecision());
+        Assert.Equal(3, externalLoginAccount.FindProperty("LastLoginOnUtc")!.GetPrecision());
+
+        IIndex? normalizedProviderIndex = externalLoginAccount
+            .GetIndexes()
+            .SingleOrDefault(index =>
+                index.Properties.Select(property => property.Name)
+                    .SequenceEqual(["NormalizedProviderName", "ProviderUserId"]));
+
+        Assert.NotNull(normalizedProviderIndex);
+        Assert.True(normalizedProviderIndex!.IsUnique);
+    }
+
+    private static void InvokeMigrationMethod(
+        Migration migration,
+        string methodName,
+        MigrationBuilder migrationBuilder)
+    {
+        MethodInfo? method = migration.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        _ = method.Invoke(migration, [migrationBuilder]);
+    }
+
+    private static Migration CreateMigration(string migrationName)
+    {
+        return migrationName switch
+        {
+            nameof(InitialCreate) => new InitialCreate(),
+            nameof(AddDataEntityConcurrencyStamp) => new AddDataEntityConcurrencyStamp(),
+            nameof(AddExternalLoginAccountNormalizedLookupColumns) => new AddExternalLoginAccountNormalizedLookupColumns(),
+            nameof(StandardizeTimestampPersistence) => new StandardizeTimestampPersistence(),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(migrationName),
+                migrationName,
+                "Unknown migration name.")
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Added coverage for EF Core migration Up/Down operation definitions.
- Added coverage for migration target model metadata.
- Added coverage for the current ApplicationDbContext model snapshot.
- Verified timestamp precision, concurrency stamp, and normalized external-login lookup metadata.

## Notes
- This targets the largest remaining coverage gap shown in the published coverage report.
- The test does not alter production behavior.

```powershell
PS > dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.14]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.77]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.23]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:14.19]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (16.1s)

Test summary: total: 159, failed: 0, succeeded: 159, skipped: 0, duration: 16.1s
Build succeeded in 17.4s
```