### PR TITLE
docs: prepare release 0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 0.5.8 - 2026-05-30
+
+### Added
+
+* Added improved CI coverage report generation for the current `ProjectTemplate.*` assemblies.
+* Added coverage report filtering to exclude test assemblies, build output, generated `.g.cs` files, `bin`, and `obj` content.
+* Added generated ReportGenerator HTML coverage output to the published DocFX documentation site under `/coverage`.
+* Added direct hosted coverage report links from the root `README.md` and `PACKAGE-README.md`.
+* Added bounded persisted string canonicalization before EF Core save operations.
+* Added normalization for added entity string values and modified string properties before auditing, concurrency stamping, and persistence.
+* Added static raw SQL safety audit coverage to detect unsafe raw SQL APIs and manual command construction patterns.
+* Added normalized lookup columns for external login provider name and email values.
+* Added persisted string lookup tests for whitespace trimming, provider-name casing, provider-user-id case sensitivity, and Unicode Form C normalization.
+* Added UTC timestamp persistence conventions for system and audit timestamps.
+* Added millisecond precision normalization for `*Utc` timestamp values before save.
+* Added EF Core timestamp precision configuration for UTC timestamp properties.
+* Added timestamp persistence tests for external login and audit records.
+* Added model validation coverage for persisted decimal precision and scale configuration.
+* Added EF Core migration coverage for migration `Up` / `Down` operations, migration target model metadata, and the current `ApplicationDbContext` model snapshot.
+
+### Changed
+
+* Updated coverage threshold enforcement to read the expected `Cobertura.xml` report directly.
+* Updated documentation publishing to copy the generated coverage report into `docs/_site/coverage`.
+* Updated README coverage badge behavior so the visible badge links directly to the published test coverage report.
+* Updated external login lookup behavior to use normalized provider-name comparison while preserving case-sensitive provider user IDs.
+* Documented persisted string comparison rules and SQLite / SQL Server collation expectations.
+* Documented the distinction between persisted string canonicalization, EF Core parameterization, and context-specific output encoding.
+* Documented timestamp persistence versus display-time conversion guidance for SQLite and SQL Server.
+* Documented recommended decimal precision and scale patterns for future template consumers.
+* Clarified provider differences between SQL Server and SQLite decimal behavior.
+
+### Fixed
+
+* Fixed CI coverage assembly filtering that still referenced the older `Template.Web` naming pattern.
+* Fixed coverage report generation so it reports usable application assembly coverage instead of noisy or empty coverage output.
+* Fixed documentation workflow coverage publishing so the generated report is available through the public DocFX site.
+* Fixed PowerShell-based multi-line coverage commands so they run under `pwsh` during workflow execution.
+
+### Security
+
+* Strengthened persistence defense-in-depth by canonicalizing stored string values before EF Core persistence.
+* Strengthened raw SQL safety guardrails with static test coverage against unsafe raw SQL usage patterns.
+* Clarified that SQL injection protection remains based on EF Core parameterization and safe query construction, not string canonicalization alone.
+* Clarified that output encoding remains context-specific and is not replaced by persistence normalization.
+
+
 ## 0.5.7 - 2026-05-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.7"
-date-released: "2026-05-29"
+version: "0.5.8"
+date-released: "2026-05-30"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.7</VersionPrefix>
+    <VersionPrefix>0.5.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.7.0</AssemblyVersion>
-    <FileVersion>0.5.7.0</FileVersion>
+    <AssemblyVersion>0.5.8.0</AssemblyVersion>
+    <FileVersion>0.5.8.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.7</VersionPrefix>
+    <VersionPrefix>0.5.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -23,7 +23,7 @@ dotnet new install CDCavell.NetCoreApplicationTemplate
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.7.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.8.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.7](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.7)__
+Current release: __[Release 0.5.8](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.8)__
 
-Tag: `v0.5.7`
+Tag: `v0.5.8`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.7.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.8.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.7. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.8. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.7` |
+| Current package version | `0.5.8` |
 
 ## Consumer Scaffold Boundaries
 
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.7.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.8.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## PR Summary

This PR prepares the project for release `0.5.8`.

### Changes

* Added the `0.5.8` changelog entry.
* Documented the post-`0.5.7` coverage reporting improvements.
* Documented published DocFX coverage report updates.
* Documented persisted string canonicalization and lookup normalization changes.
* Documented raw SQL safety audit guardrails.
* Documented UTC timestamp persistence conventions.
* Documented decimal precision persistence guardrails.
* Documented expanded EF Core migration, model metadata, and model snapshot test coverage.

### Release Focus

Release `0.5.8` continues hardening the template ahead of `1.0.0` by improving persistence consistency, database safety guardrails, documentation discoverability, and test coverage visibility.

### Validation

* Confirmed recent Release test runs pass successfully.
* Confirmed coverage reporting now targets the current `ProjectTemplate.*` assemblies.
* Confirmed generated coverage output is linked from repository and package documentation.
