### PR TITLE
docs: add NuGet downloads and Zenodo DOI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE.txt)
 [![GitHub Release](https://img.shields.io/github/v/release/cdcavell/NetCoreApplicationTemplate?display_name=tag)](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/latest)
 [![NuGet](https://img.shields.io/nuget/v/CDCavell.NetCoreApplicationTemplate?label=NuGet)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20373042.svg)](https://doi.org/10.5281/zenodo.20373042)
-<!--[![NuGet Downloads](https://img.shields.io/nuget/dt/CDCavell.NetCoreApplicationTemplate?label=downloads)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)-->
+[![NuGet Downloads](https://img.shields.io/nuget/dt/CDCavell.NetCoreApplicationTemplate?label=downloads)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)
+[![Zenodo DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20373042-blue)](https://doi.org/10.5281/zenodo.20373042)
 
 A reusable, production-oriented .NET application template designed to provide a secure, maintainable, and extensible baseline for building ASP.NET Core applications.
 


### PR DESCRIPTION
## Summary

- Enabled the NuGet total downloads badge in `README.md`.
- Replaced the Zenodo DOI badge with a static Shields.io DOI badge.
- Updated the README badge row to surface package adoption and citation information alongside CI, coverage, docs, release, NuGet, and license status.

## Notes

This improves the project landing page by showing both distribution activity through NuGet downloads and citation support through the Zenodo DOI.