### PR TITLE
test: add Problem Details exception handler contract coverage

### DIFF
--- a/src/ProjectTemplate.Web/Properties/AssemblyInfo.cs
+++ b/src/ProjectTemplate.Web/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ProjectTemplate.Web.Tests")]

--- a/tests/ProjectTemplate.Web.Tests/ProblemDetailsExceptionHandlerTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ProblemDetailsExceptionHandlerTests.cs
@@ -1,11 +1,11 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using ProjectTemplate.Web.ErrorHandling;
-using Microsoft.AspNetCore.Http.Features;
 
 namespace ProjectTemplate.Web.Tests;
 

--- a/tests/ProjectTemplate.Web.Tests/ProblemDetailsExceptionHandlerTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ProblemDetailsExceptionHandlerTests.cs
@@ -1,0 +1,312 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Web.ErrorHandling;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace ProjectTemplate.Web.Tests;
+
+/// <summary>
+/// Provides contract tests for centralized Problem Details exception handling.
+/// </summary>
+public sealed class ProblemDetailsExceptionHandlerTests
+{
+    public static TheoryData<ProblemDetailsExceptionCase, int, string> ExceptionMappings =>
+        new()
+        {
+            { ProblemDetailsExceptionCase.BadHttpRequest, StatusCodes.Status400BadRequest, "Bad Request" },
+            { ProblemDetailsExceptionCase.Argument, StatusCodes.Status400BadRequest, "Bad Request" },
+            { ProblemDetailsExceptionCase.UnauthorizedAccess, StatusCodes.Status403Forbidden, "Forbidden" },
+            { ProblemDetailsExceptionCase.Timeout, StatusCodes.Status503ServiceUnavailable, "Service Unavailable" },
+            { ProblemDetailsExceptionCase.Unknown, StatusCodes.Status500InternalServerError, "Internal Server Error" }
+        };
+
+    /// <summary>
+    /// Verifies that supported exception types are mapped to the expected status code and title.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExceptionMappings))]
+    public async Task TryHandleAsync_ExceptionMappings_WriteExpectedProblemDetails(
+    ProblemDetailsExceptionCase exceptionCase,
+    int expectedStatusCode,
+    string expectedTitle)
+    {
+        Exception exception = CreateException(exceptionCase);
+
+        CapturingProblemDetailsService problemDetailsService = new();
+        ProblemDetailsExceptionHandler handler = CreateHandler(
+            problemDetailsService,
+            Environments.Production);
+
+        DefaultHttpContext httpContext = CreateProblemDetailsHttpContext();
+
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            exception,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(handled);
+        Assert.NotNull(problemDetailsService.Context);
+        Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
+
+        ProblemDetails problemDetails = problemDetailsService.Context.ProblemDetails;
+
+        Assert.Equal(expectedStatusCode, problemDetails.Status);
+        Assert.Equal(expectedTitle, problemDetails.Title);
+        Assert.Equal($"https://httpstatuses.com/{expectedStatusCode}", problemDetails.Type);
+        Assert.Equal("/api/test/problem-details", problemDetails.Instance);
+        Assert.True(problemDetails.Extensions.ContainsKey("traceId"));
+        Assert.True(problemDetails.Extensions.ContainsKey("requestId"));
+    }
+
+    /// <summary>
+    /// Verifies that unknown production exceptions use a generic server-error detail.
+    /// </summary>
+    [Fact]
+    public async Task TryHandleAsync_UnknownProductionException_DoesNotExposeRawExceptionDetail()
+    {
+        const string SensitiveMessage = "Sensitive database password leak marker.";
+
+        CapturingProblemDetailsService problemDetailsService = new();
+        ProblemDetailsExceptionHandler handler = CreateHandler(
+            problemDetailsService,
+            Environments.Production);
+
+        DefaultHttpContext httpContext = CreateProblemDetailsHttpContext();
+
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            new InvalidOperationException(SensitiveMessage),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(handled);
+        Assert.NotNull(problemDetailsService.Context);
+
+        ProblemDetails problemDetails = problemDetailsService.Context.ProblemDetails;
+
+        Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
+        Assert.Equal(
+            "An unexpected error occurred. Contact support with the request ID.",
+            problemDetails.Detail);
+        Assert.DoesNotContain(SensitiveMessage, problemDetails.Detail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that production client-error responses do not expose raw exception messages.
+    /// </summary>
+    [Fact]
+    public async Task TryHandleAsync_ProductionClientException_DoesNotExposeRawExceptionDetail()
+    {
+        const string SensitiveMessage = "Sensitive validation internals leak marker.";
+
+        CapturingProblemDetailsService problemDetailsService = new();
+        ProblemDetailsExceptionHandler handler = CreateHandler(
+            problemDetailsService,
+            Environments.Production);
+
+        DefaultHttpContext httpContext = CreateProblemDetailsHttpContext();
+
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            new ArgumentException(SensitiveMessage),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(handled);
+        Assert.NotNull(problemDetailsService.Context);
+
+        ProblemDetails problemDetails = problemDetailsService.Context.ProblemDetails;
+
+        Assert.Equal(StatusCodes.Status400BadRequest, problemDetails.Status);
+        Assert.Equal("Bad Request", problemDetails.Title);
+        Assert.DoesNotContain(
+            SensitiveMessage,
+            problemDetails.Detail ?? string.Empty,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that development responses include the exception message for diagnostics.
+    /// </summary>
+    [Fact]
+    public async Task TryHandleAsync_DevelopmentEnvironment_IncludesExceptionMessage()
+    {
+        const string DevelopmentMessage = "Development diagnostic detail.";
+
+        CapturingProblemDetailsService problemDetailsService = new();
+        ProblemDetailsExceptionHandler handler = CreateHandler(
+            problemDetailsService,
+            Environments.Development);
+
+        DefaultHttpContext httpContext = CreateProblemDetailsHttpContext();
+
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            new ArgumentException(DevelopmentMessage),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(handled);
+        Assert.NotNull(problemDetailsService.Context);
+        Assert.Equal(DevelopmentMessage, problemDetailsService.Context.ProblemDetails.Detail);
+    }
+
+    /// <summary>
+    /// Verifies that non-Problem-Details requests are ignored by the handler.
+    /// </summary>
+    [Fact]
+    public async Task TryHandleAsync_NonProblemDetailsRequest_ReturnsFalse()
+    {
+        CapturingProblemDetailsService problemDetailsService = new();
+        ProblemDetailsExceptionHandler handler = CreateHandler(
+            problemDetailsService,
+            Environments.Production);
+
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Path = "/home/error";
+
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            new InvalidOperationException("Non API error."),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(handled);
+        Assert.Null(problemDetailsService.Context);
+    }
+
+    /// <summary>
+    /// Verifies that the handler does not attempt to write after the response has started.
+    /// </summary>
+    [Fact]
+    public async Task TryHandleAsync_ResponseAlreadyStarted_ReturnsFalse()
+    {
+        CapturingProblemDetailsService problemDetailsService = new();
+        ProblemDetailsExceptionHandler handler = CreateHandler(
+            problemDetailsService,
+            Environments.Production);
+
+        DefaultHttpContext httpContext = CreateStartedResponseProblemDetailsHttpContext();
+
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            new InvalidOperationException("Started response error."),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(handled);
+        Assert.Null(problemDetailsService.Context);
+    }
+
+    private static ProblemDetailsExceptionHandler CreateHandler(
+        CapturingProblemDetailsService problemDetailsService,
+        string environmentName)
+    {
+        return new ProblemDetailsExceptionHandler(
+            problemDetailsService,
+            new TestWebHostEnvironment(environmentName),
+            NullLogger<ProblemDetailsExceptionHandler>.Instance);
+    }
+
+    private static DefaultHttpContext CreateProblemDetailsHttpContext()
+    {
+        DefaultHttpContext httpContext = new();
+
+        httpContext.Request.Method = HttpMethods.Get;
+        httpContext.Request.Path = "/api/test/problem-details";
+        httpContext.TraceIdentifier = "test-request-id";
+
+        return httpContext;
+    }
+
+    private sealed class CapturingProblemDetailsService : IProblemDetailsService
+    {
+        public ProblemDetailsContext? Context { get; private set; }
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            Context = context;
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<bool> TryWriteAsync(ProblemDetailsContext context)
+        {
+            Context = context;
+
+            return ValueTask.FromResult(true);
+        }
+    }
+    private sealed class TestWebHostEnvironment(string environmentName) : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "ProjectTemplate.Web.Tests";
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public string EnvironmentName { get; set; } = environmentName;
+
+        public string WebRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private static Exception CreateException(ProblemDetailsExceptionCase exceptionCase)
+    {
+        return exceptionCase switch
+        {
+            ProblemDetailsExceptionCase.BadHttpRequest => new BadHttpRequestException(
+                "Bad HTTP request contract test detail.",
+                StatusCodes.Status400BadRequest),
+
+            ProblemDetailsExceptionCase.Argument => new ArgumentException(
+                "Invalid argument contract test detail."),
+
+            ProblemDetailsExceptionCase.UnauthorizedAccess => new UnauthorizedAccessException(
+                "Forbidden contract test detail."),
+
+            ProblemDetailsExceptionCase.Timeout => new TimeoutException(
+                "Timeout contract test detail."),
+
+            ProblemDetailsExceptionCase.Unknown => new InvalidOperationException(
+                "Internal failure contract test detail."),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(exceptionCase), exceptionCase, null)
+        };
+    }
+
+    public enum ProblemDetailsExceptionCase
+    {
+        BadHttpRequest,
+        Argument,
+        UnauthorizedAccess,
+        Timeout,
+        Unknown
+    }
+
+    private static DefaultHttpContext CreateStartedResponseProblemDetailsHttpContext()
+    {
+        FeatureCollection features = new();
+
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature
+        {
+            Method = HttpMethods.Get,
+            Path = "/api/test/problem-details"
+        });
+
+        features.Set<IHttpResponseFeature>(new StartedResponseFeature());
+
+        DefaultHttpContext httpContext = new(features)
+        {
+            TraceIdentifier = "test-request-id"
+        };
+
+        return httpContext;
+    }
+
+    private sealed class StartedResponseFeature : HttpResponseFeature
+    {
+        public override bool HasStarted => true;
+    }
+}


### PR DESCRIPTION
## Summary

- Added focused contract tests for `ProblemDetailsExceptionHandler`
- Pinned exception-to-status and title mappings for known exception types
- Verified unknown exceptions fall back to safe 500 Problem Details responses
- Added production sanitization coverage to prevent raw exception detail leakage
- Added development-environment coverage for diagnostic exception detail behavior
- Covered non-Problem-Details and response-already-started handler bypass paths

## Validation

- `dotnet test`
```powershell
PS > dotnet test NetCoreApplicationTemplate.slnx -c Release
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.4s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.5s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (0.8s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.51]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.17]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.64]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:14.02]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (16.0s)

Test summary: total: 169, failed: 0, succeeded: 169, skipped: 0, duration: 16.0s
Build succeeded in 19.7s
```
- `dotnet test --collect:"XPlat Code Coverage"`
```powershell
PS > dotnet test NetCoreApplicationTemplate.slnx -c Release --collect:"XPlat Code Coverage"
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.4s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.6s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (0.8s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.43]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.08]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.53]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:13.00]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (27.1s)

Test summary: total: 169, failed: 0, succeeded: 169, skipped: 0, duration: 27.1s
Build succeeded in 30.8s
```

Attachments: 
[coverage.cobertura.xml](https://github.com/user-attachments/files/28431252/coverage.cobertura.xml)
