### PR TITLE
test: cover HTTP current actor resolution branches

### DIFF
--- a/src/ProjectTemplate.Web/Accessors/HttpContextCurrentActorAccessor.cs
+++ b/src/ProjectTemplate.Web/Accessors/HttpContextCurrentActorAccessor.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using ProjectTemplate.Infrastructure.Data;
 
 namespace ProjectTemplate.Web.Accessors;
@@ -10,8 +11,13 @@ public sealed class HttpContextCurrentActorAccessor(
     IHttpContextAccessor httpContextAccessor)
     : ICurrentActorAccessor
 {
+    private const string _subjectClaimType = "sub";
+    private const string _unknownActor = "Unknown";
+
     /// <summary>
-    /// Accesses the current actor information from the HTTP context. It first attempts to retrieve the "sub" claim from the user's claims, and if that is not available, it falls back to using the remote IP address. If neither is available, it returns "Unknown".
+    /// Accesses the current actor information from the HTTP context. It first attempts to retrieve the authenticated
+    /// subject claim from the user's claims, then falls back to the authenticated name identifier claim, then the remote
+    /// IP address. If none are available, it returns "Unknown".
     /// </summary>
     public string CurrentActor
     {
@@ -19,16 +25,46 @@ public sealed class HttpContextCurrentActorAccessor(
         {
             HttpContext? httpContext = httpContextAccessor.HttpContext;
 
-            string? subject = httpContext?.User?.FindFirst("sub")?.Value;
+            string? authenticatedActor = GetAuthenticatedActor(httpContext?.User);
 
-            if (!string.IsNullOrWhiteSpace(subject))
+            if (!string.IsNullOrWhiteSpace(authenticatedActor))
             {
-                return $"Subject: {subject}";
+                return authenticatedActor;
             }
 
             string? remoteIpAddress = httpContext?.Connection.RemoteIpAddress?.ToString();
 
-            return !string.IsNullOrWhiteSpace(remoteIpAddress) ? $"Remote IP: {remoteIpAddress}" : "Unknown";
+            return !string.IsNullOrWhiteSpace(remoteIpAddress)
+                ? $"Remote IP: {remoteIpAddress}"
+                : _unknownActor;
         }
+    }
+
+    private static string? GetAuthenticatedActor(ClaimsPrincipal? user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        string? subject = GetClaimValue(user, _subjectClaimType);
+
+        if (!string.IsNullOrWhiteSpace(subject))
+        {
+            return $"Subject: {subject}";
+        }
+
+        string? nameIdentifier = GetClaimValue(user, ClaimTypes.NameIdentifier);
+
+        return !string.IsNullOrWhiteSpace(nameIdentifier)
+            ? $"Name Identifier: {nameIdentifier}"
+            : null;
+    }
+
+    private static string? GetClaimValue(ClaimsPrincipal user, string claimType)
+    {
+        string? value = user.FindFirst(claimType)?.Value?.Trim();
+
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 }

--- a/tests/ProjectTemplate.Web.Tests/HttpContextCurrentActorAccessorTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/HttpContextCurrentActorAccessorTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using ProjectTemplate.Web.Accessors;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class HttpContextCurrentActorAccessorTests
+{
+    [Fact]
+    public void CurrentActor_AuthenticatedUserWithSubjectClaim_ReturnsSubject()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext(
+            CreateAuthenticatedPrincipal(new Claim("sub", "user-123")));
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Subject: user-123", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_AuthenticatedUserWithWhitespaceSubjectClaim_TrimsSubject()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext(
+            CreateAuthenticatedPrincipal(new Claim("sub", "  user-123  ")));
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Subject: user-123", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_AuthenticatedUserMissingSubjectClaim_UsesNameIdentifierFallback()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext(
+            CreateAuthenticatedPrincipal(new Claim(ClaimTypes.NameIdentifier, "user-456")));
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Name Identifier: user-456", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_AuthenticatedUserWithWhitespaceSubjectClaim_UsesNameIdentifierFallback()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext(
+            CreateAuthenticatedPrincipal(
+                new Claim("sub", "   "),
+                new Claim(ClaimTypes.NameIdentifier, "user-456")));
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Name Identifier: user-456", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_AuthenticatedUserWithNoUsableClaims_UsesRemoteIpAddress()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext(
+            CreateAuthenticatedPrincipal(
+                new Claim("sub", "   "),
+                new Claim(ClaimTypes.NameIdentifier, "   ")),
+            IPAddress.Parse("203.0.113.10"));
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Remote IP: 203.0.113.10", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_AnonymousUserWithSubjectClaim_UsesRemoteIpAddress()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext(
+            CreateAnonymousPrincipal(new Claim("sub", "anonymous-claim")),
+            IPAddress.Parse("203.0.113.20"));
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Remote IP: 203.0.113.20", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_AnonymousRequestWithoutRemoteIpAddress_ReturnsUnknown()
+    {
+        DefaultHttpContext httpContext = CreateHttpContext();
+
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(httpContext);
+
+        Assert.Equal("Unknown", accessor.CurrentActor);
+    }
+
+    [Fact]
+    public void CurrentActor_MissingHttpContext_ReturnsUnknown()
+    {
+        HttpContextCurrentActorAccessor accessor = CreateAccessor(null);
+
+        Assert.Equal("Unknown", accessor.CurrentActor);
+    }
+
+    private static HttpContextCurrentActorAccessor CreateAccessor(HttpContext? httpContext)
+    {
+        return new HttpContextCurrentActorAccessor(
+            new HttpContextAccessor
+            {
+                HttpContext = httpContext
+            });
+    }
+
+    private static DefaultHttpContext CreateHttpContext(
+        ClaimsPrincipal? user = null,
+        IPAddress? remoteIpAddress = null)
+    {
+        DefaultHttpContext httpContext = new();
+
+        if (user is not null)
+        {
+            httpContext.User = user;
+        }
+
+        if (remoteIpAddress is not null)
+        {
+            httpContext.Connection.RemoteIpAddress = remoteIpAddress;
+        }
+
+        return httpContext;
+    }
+
+    private static ClaimsPrincipal CreateAuthenticatedPrincipal(params Claim[] claims)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+
+    private static ClaimsPrincipal CreateAnonymousPrincipal(params Claim[] claims)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(claims));
+    }
+}


### PR DESCRIPTION
## Summary

- Added branch coverage for `HttpContextCurrentActorAccessor`
- Pinned authenticated subject claim resolution
- Added fallback handling for authenticated `ClaimTypes.NameIdentifier`
- Verified whitespace claims do not produce invalid audit actor names
- Verified anonymous and missing `HttpContext` requests resolve safely
- Preserved remote IP and `Unknown` fallback behavior

## Testing

- `dotnet test tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj`
```powershell
Restore complete (1.0s)
  ProjectTemplate.Infrastructure net10.0 succeeded (1.7s) → src\ProjectTemplate.Infrastructure\bin\Debug\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (3.7s) → src\ProjectTemplate.Web\bin\Debug\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (3.7s) → tests\ProjectTemplate.Web.Tests\bin\Debug\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:04.02]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:04.66]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:05.13]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:24.49]   Finished:    ProjectTemplate.Web.Tests (ID = 'e65e496f176e17b1b67b1fa3e005b5965c00fbd610526048a104ec3e21e15fb2')
  ProjectTemplate.Web.Tests test net10.0 succeeded (28.7s)

Test summary: total: 177, failed: 0, succeeded: 177, skipped: 0, duration: 28.7s
Build succeeded in 40.7s
```

Closes #138