### PR TITLE
test: cover enabled external authentication providers

### DIFF
--- a/tests/ProjectTemplate.Web.Tests/AuthenticationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthenticationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using ProjectTemplate.Web.Authentication.Extensions;
 using ProjectTemplate.Web.Authentication.Options;
 using ProjectTemplate.Web.Authentication.Providers.GitHub;
 using ProjectTemplate.Web.Authentication.Providers.Google;
@@ -16,6 +17,18 @@ namespace ProjectTemplate.Web.Tests;
 /// </summary>
 public sealed class AuthenticationTests
 {
+    /// <summary>
+    /// Test data for enabled external authentication provider configurations. Each entry includes the provider key, display name, and a set of configuration values required to enable the provider. This data is used to verify that the application correctly binds and validates external authentication provider settings from configuration. The test cases cover various providers such as OpenIdConnect, SAML2, Google, and GitHub, ensuring that each provider's specific configuration requirements are met when enabled.
+    /// </summary>
+    public static TheoryData<string, string, string> EnabledExternalProviderConfigurations =>
+        new()
+        {
+            { "OpenIdConnect", "OpenIdConnect", "OpenID Connect" },
+            { "Saml2", "Saml2", "SAML2" },
+            { "Google", "Google", "Google" },
+            { "GitHub", "GitHub", "GitHub" }
+        };
+
     /// <summary>
     /// Verifies that authentication options are bound from configuration into the options model.
     /// </summary>
@@ -174,6 +187,47 @@ public sealed class AuthenticationTests
         AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync("Cookies");
 
         Assert.NotNull(scheme);
+    }
+
+    /// <summary>
+    /// Verifies that an enabled external authentication provider registers the expected authentication scheme with the correct display name. This test uses parameterized data to validate multiple providers, ensuring that when a provider is enabled in the configuration, it correctly adds its authentication scheme to the application's authentication system. The test checks both the presence of the scheme and that its properties match the expected values defined in the configuration.
+    /// </summary>
+    /// <param name="providerName">
+    /// Name of the external authentication provider being tested (e.g., "OpenIdConnect", "Saml2", "Google", "GitHub"). This parameter is used to generate the appropriate configuration for the provider and to verify that the corresponding authentication scheme is registered correctly in the application's authentication system.
+    /// </param>
+    /// <param name="schemeName">
+    /// Name of the authentication scheme that should be registered for the enabled provider. This value is derived from the provider's configuration and is used to retrieve the scheme from the authentication scheme provider during the test. The test asserts that a scheme with this name exists and has the expected properties when the provider is enabled.
+    /// </param>
+    /// <param name="displayName">
+    /// Name of the display name that should be associated with the registered authentication scheme for the enabled provider. This value is defined in the provider's configuration and is used to verify that the scheme's display name matches the expected value when the provider is enabled. The test asserts that the display name of the registered scheme is correct, ensuring that the configuration is properly applied to the authentication system.
+    /// </param>
+    /// <returns></returns>
+    [Theory]
+    [MemberData(nameof(EnabledExternalProviderConfigurations))]
+    public async Task EnabledExternalAuthenticationProvider_RegistersConfiguredScheme(
+        string providerName,
+        string schemeName,
+        string displayName)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(CreateEnabledAuthenticationConfiguration(providerName))
+            .Build();
+
+        ServiceCollection services = new();
+
+        services.AddLogging();
+        services.AddApplicationAuthentication(configuration);
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        IAuthenticationSchemeProvider schemeProvider = serviceProvider
+            .GetRequiredService<IAuthenticationSchemeProvider>();
+
+        AuthenticationScheme? scheme = await schemeProvider.GetSchemeAsync(schemeName);
+
+        Assert.NotNull(scheme);
+        Assert.Equal(schemeName, scheme.Name);
+        Assert.Equal(displayName, scheme.DisplayName);
     }
 
     /// <summary>
@@ -652,5 +706,89 @@ public sealed class AuthenticationTests
     private static ApplicationWebApplicationFactory CreateFactory(IReadOnlyDictionary<string, string?> configurationValues)
     {
         return new ApplicationWebApplicationFactory(configurationValues);
+    }
+
+    private static Dictionary<string, string?> CreateEnabledAuthenticationConfiguration(string providerName)
+    {
+        Dictionary<string, string?> configuration = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ProjectTemplate:Authentication:Enabled"] = "true",
+            ["ProjectTemplate:Authentication:DefaultScheme"] = "Cookies",
+            ["ProjectTemplate:Authentication:DefaultChallengeScheme"] = "Cookies",
+            ["ProjectTemplate:Authentication:DefaultSignInScheme"] = "Cookies",
+            ["ProjectTemplate:Authentication:Cookie:Enabled"] = "true",
+            ["ProjectTemplate:Authentication:Cookie:Scheme"] = "Cookies",
+            ["ProjectTemplate:Authentication:Cookie:LoginPath"] = "/Account/Login",
+            ["ProjectTemplate:Authentication:Cookie:LogoutPath"] = "/Account/Logout",
+            ["ProjectTemplate:Authentication:Cookie:AccessDeniedPath"] = "/Account/AccessDenied",
+            ["ProjectTemplate:Authentication:Cookie:ExpireMinutes"] = "60"
+        };
+
+        foreach (KeyValuePair<string, string?> item in CreateProviderConfiguration(providerName))
+        {
+            configuration[item.Key] = item.Value;
+        }
+
+        return configuration;
+    }
+
+    private static Dictionary<string, string?> CreateProviderConfiguration(string providerName)
+    {
+        return providerName switch
+        {
+            "OpenIdConnect" => new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:Enabled"] = "true",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:Scheme"] = "OpenIdConnect",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:DisplayName"] = "OpenID Connect",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:Authority"] = "https://login.example.test",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:ClientId"] = "test-oidc-client-id",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:ClientSecret"] = "test-oidc-client-secret",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:CallbackPath"] = "/signin-oidc",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:ResponseType"] = "code",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:Scopes:0"] = "openid",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:Scopes:1"] = "profile",
+                ["ProjectTemplate:Authentication:Providers:OpenIdConnect:Scopes:2"] = "email"
+            },
+
+            "Saml2" => new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ProjectTemplate:Authentication:Providers:Saml2:Enabled"] = "true",
+                ["ProjectTemplate:Authentication:Providers:Saml2:Scheme"] = "Saml2",
+                ["ProjectTemplate:Authentication:Providers:Saml2:DisplayName"] = "SAML2",
+                ["ProjectTemplate:Authentication:Providers:Saml2:EntityId"] = "https://ProjectTemplate.example.test/saml2",
+                ["ProjectTemplate:Authentication:Providers:Saml2:MetadataUrl"] = "https://idp.example.test/metadata",
+                ["ProjectTemplate:Authentication:Providers:Saml2:ModulePath"] = "/Saml2/Acs",
+                ["ProjectTemplate:Authentication:Providers:Saml2:LoadMetadata"] = "false"
+            },
+
+            "Google" => new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ProjectTemplate:Authentication:Providers:Google:Enabled"] = "true",
+                ["ProjectTemplate:Authentication:Providers:Google:Scheme"] = "Google",
+                ["ProjectTemplate:Authentication:Providers:Google:DisplayName"] = "Google",
+                ["ProjectTemplate:Authentication:Providers:Google:ClientId"] = "test-google-client-id",
+                ["ProjectTemplate:Authentication:Providers:Google:ClientSecret"] = "test-google-client-secret",
+                ["ProjectTemplate:Authentication:Providers:Google:CallbackPath"] = "/signin-google",
+                ["ProjectTemplate:Authentication:Providers:Google:Scopes:0"] = "profile",
+                ["ProjectTemplate:Authentication:Providers:Google:Scopes:1"] = "email"
+            },
+
+            "GitHub" => new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ProjectTemplate:Authentication:Providers:GitHub:Enabled"] = "true",
+                ["ProjectTemplate:Authentication:Providers:GitHub:Scheme"] = "GitHub",
+                ["ProjectTemplate:Authentication:Providers:GitHub:DisplayName"] = "GitHub",
+                ["ProjectTemplate:Authentication:Providers:GitHub:ClientId"] = "test-github-client-id",
+                ["ProjectTemplate:Authentication:Providers:GitHub:ClientSecret"] = "test-github-client-secret",
+                ["ProjectTemplate:Authentication:Providers:GitHub:CallbackPath"] = "/signin-github",
+                ["ProjectTemplate:Authentication:Providers:GitHub:Scopes:0"] = "user:email"
+            },
+
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(providerName),
+                providerName,
+                "Unsupported authentication provider.")
+        };
     }
 }


### PR DESCRIPTION
## Summary

- Added application-level enabled-path registration coverage for OpenID Connect, SAML2, Google, and GitHub providers
- Verified each enabled provider registers its configured authentication scheme through `AddApplicationAuthentication`
- Preserved existing disabled-provider and startup-validation coverage
- Strengthened public provider-readiness claims with contract tests

## Testing

- `dotnet test tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj --configuration Release`
```powershell
Restore complete (1.0s)
  ProjectTemplate.Infrastructure net10.0 succeeded (1.2s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (2.8s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (2.5s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.09]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.73]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.19]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:14.97]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (16.9s)

Test summary: total: 181, failed: 0, succeeded: 181, skipped: 0, duration: 16.9s
Build succeeded in 25.7s
```
- `dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --collect:"XPlat Code Coverage" --results-directory "./artifacts/test-results"`
```powershell
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.4s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.6s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.0s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:00.42]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.06]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.53]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:13.61]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (18.0s)

Test summary: total: 181, failed: 0, succeeded: 181, skipped: 0, duration: 18.0s
Build succeeded in 21.8s
``
- `dotnet reportgenerator -reports:"./artifacts/test-results/**/coverage.cobertura.xml" -targetdir:"./artifacts/coverage-report" -reporttypes:"Html;MarkdownSummaryGithub;Cobertura" -assemblyfilters:"+ProjectTemplate.*;-*.Tests" -filefilters:"-**/bin/**;-**/obj/**;-**/*.g.cs"`
```powershell
2026-05-31T09:40:34: Arguments
2026-05-31T09:40:34:  -reports:./artifacts/test-results/**/coverage.cobertura.xml
2026-05-31T09:40:34:  -targetdir:./artifacts/coverage-report
2026-05-31T09:40:34:  -reporttypes:Html;MarkdownSummaryGithub;Cobertura
2026-05-31T09:40:34:  -assemblyfilters:+ProjectTemplate.*;-*.Tests
2026-05-31T09:40:34:  -filefilters:-**/bin/**;-**/obj/**;-**/*.g.cs
2026-05-31T09:40:36: Writing report file './artifacts/coverage-report\Cobertura.xml'
2026-05-31T09:40:36: Writing report file './artifacts/coverage-report\index.html'
2026-05-31T09:40:38: Writing report file './artifacts/coverage-report\SummaryGithub.md'
2026-05-31T09:40:38: Report generation took 3.4 seconds
```
- `pwsh ./eng/Assert-SecurityCriticalCoverage.ps1 -CoverageFile "./artifacts/coverage-report/Cobertura.xml" -ConfigFile "./eng/security-critical-coverage.json"`
```powershell
Security-critical coverage gate
--------------------------------
PASS: src/ProjectTemplate.Web/ErrorHandling/ProblemDetailsExceptionHandler.cs | line 98.48% >= 75.00% | branch 90.00% >= 60.00%
PASS: src/ProjectTemplate.Web/ErrorHandling/ProblemDetailsRequestClassifier.cs | line 81.82% >= 75.00% | branch 57.14% >= 50.00%
PASS: src/ProjectTemplate.Web/Accessors/HttpContextCurrentActorAccessor.cs | line 81.48% >= 80.00% | branch 60.00% >= 60.00%
PASS: src/ProjectTemplate.Web/Middleware/SecurityHeadersMiddleware.cs | line 100.00% >= 60.00% | branch 77.27% >= 40.00%
PASS: src/ProjectTemplate.Web/Extensions/SecurityHeadersExtensions.cs | line 100.00% >= 60.00% | branch 83.33% >= 40.00%
PASS: src/ProjectTemplate.Web/Extensions/ForwardedHeadersExtensions.cs | line 98.95% >= 60.00% | branch 84.38% >= 40.00%
PASS: src/ProjectTemplate.Web/Extensions/RateLimitingServiceExtensions.cs | line 96.35% >= 60.00% | branch 75.00% >= 40.00%
PASS: src/ProjectTemplate.Infrastructure/Data/PersistenceStringCanonicalizer.cs | line 88.89% >= 75.00% | branch 83.33% >= 50.00%
PASS: src/ProjectTemplate.Infrastructure/Data/PersistenceStringComparisonNormalizer.cs | line 100.00% >= 75.00% | branch 50.00% >= 50.00%
PASS: src/ProjectTemplate.Infrastructure/Data/PersistenceTimestamp.cs | line 61.54% >= 60.00% | branch 50.00% >= 50.00%
PASS: src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs | line 79.77% >= 60.00% | branch 64.62% >= 40.00%
Security-critical coverage gate passed.
```


Closes #249 