### PR TITLE
test: cover persistence normalization helpers

### DIFF
--- a/src/ProjectTemplate.Infrastructure/Properties/AssemblyInfo.cs
+++ b/src/ProjectTemplate.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ProjectTemplate.Web.Tests")]

--- a/tests/ProjectTemplate.Web.Tests/PersistenceStringComparisonNormalizerTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/PersistenceStringComparisonNormalizerTests.cs
@@ -1,0 +1,212 @@
+using System.Globalization;
+using System.Text;
+using ProjectTemplate.Infrastructure.Data;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class PersistenceStringComparisonNormalizerTests
+{
+    [Theory]
+    [InlineData(" Already Normalized ", "Already Normalized")]
+    [InlineData("\tTabbed Value\r\n", "Tabbed Value")]
+    [InlineData("Value", "Value")]
+    public void NormalizeRequiredDisplayValue_TrimsValue(string input, string expected)
+    {
+        string result = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeRequiredDisplayValue_NormalizesUnicodeToFormC()
+    {
+        string input = "Jose\u0301 User";
+
+        string result = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(input);
+
+        Assert.Equal("José User", result);
+        Assert.True(result.IsNormalized(NormalizationForm.FormC));
+    }
+
+    [Fact]
+    public void NormalizeRequiredDisplayValue_EncodedValue_IsNotDecoded()
+    {
+        string input = " O&amp;#39;Connor &amp;amp; Sons ";
+
+        string result = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(input);
+
+        Assert.Equal("O&amp;#39;Connor &amp;amp; Sons", result);
+        Assert.DoesNotContain("O'Connor", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NormalizeRequiredDisplayValue_IsIdempotent()
+    {
+        string input = " Jose\u0301 User ";
+
+        string once = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(input);
+        string twice = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(once);
+
+        Assert.Equal(once, twice);
+        Assert.Equal("José User", twice);
+    }
+
+    [Theory]
+    [InlineData("github", "GITHUB")]
+    [InlineData(" GitHub ", "GITHUB")]
+    [InlineData("user@example.com", "USER@EXAMPLE.COM")]
+    public void NormalizeRequiredLookupValue_TrimsNormalizesAndUppercasesInvariant(string input, string expected)
+    {
+        string result = PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeRequiredLookupValue_UsesInvariantCasing()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
+
+            string result = PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue("i");
+
+            Assert.Equal("I", result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
+    [Fact]
+    public void NormalizeRequiredLookupValue_IsIdempotent()
+    {
+        string input = " Jose\u0301@example.com ";
+
+        string once = PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(input);
+        string twice = PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(once);
+
+        Assert.Equal(once, twice);
+        Assert.Equal("JOSÉ@EXAMPLE.COM", twice);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t\r\n")]
+    public void NormalizeOptionalDisplayValue_NullEmptyOrWhitespace_ReturnsNull(string? input)
+    {
+        string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(input);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NormalizeOptionalDisplayValue_TrimsAndNormalizesUnicodeToFormC()
+    {
+        string input = " Jose\u0301 Optional ";
+
+        string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(input);
+
+        Assert.Equal("José Optional", result);
+        Assert.True(result!.IsNormalized(NormalizationForm.FormC));
+    }
+
+    [Fact]
+    public void NormalizeOptionalDisplayValue_EncodedValue_IsNotDecoded()
+    {
+        string input = " O&amp;#39;Connor &amp;amp; Sons ";
+
+        string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(input);
+
+        Assert.Equal("O&amp;#39;Connor &amp;amp; Sons", result);
+        Assert.DoesNotContain("O'Connor", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NormalizeOptionalDisplayValue_IsIdempotent()
+    {
+        string input = " Jose\u0301 Optional ";
+
+        string? once = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(input);
+        string? twice = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(once);
+
+        Assert.Equal(once, twice);
+        Assert.Equal("José Optional", twice);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t\r\n")]
+    public void NormalizeOptionalLookupValue_NullEmptyOrWhitespace_ReturnsNull(string? input)
+    {
+        string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(input);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("user@example.com", "USER@EXAMPLE.COM")]
+    [InlineData(" User@Example.Com ", "USER@EXAMPLE.COM")]
+    [InlineData("Jose\u0301@example.com", "JOSÉ@EXAMPLE.COM")]
+    public void NormalizeOptionalLookupValue_TrimsNormalizesAndUppercasesInvariant(string input, string expected)
+    {
+        string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeOptionalLookupValue_UsesInvariantCasing()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
+
+            string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue("i");
+
+            Assert.Equal("I", result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
+    [Fact]
+    public void NormalizeOptionalLookupValue_EncodedValue_IsNotDecoded()
+    {
+        string input = " O&amp;#39;Connor@example.com ";
+
+        string? result = PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(input);
+
+        Assert.Equal("O&AMP;#39;CONNOR@EXAMPLE.COM", result);
+        Assert.DoesNotContain("O'CONNOR", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NormalizeOptionalLookupValue_IsIdempotent()
+    {
+        string input = " Jose\u0301@example.com ";
+
+        string? once = PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(input);
+        string? twice = PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(once);
+
+        Assert.Equal(once, twice);
+        Assert.Equal("JOSÉ@EXAMPLE.COM", twice);
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/PersistenceTimestampTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/PersistenceTimestampTests.cs
@@ -1,0 +1,156 @@
+using ProjectTemplate.Infrastructure.Data;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class PersistenceTimestampTests
+{
+    [Fact]
+    public void NormalizeUtc_UtcDateTime_TrimsToMillisecondPrecision()
+    {
+        DateTime value = new(2026, 5, 31, 12, 34, 56, 789, DateTimeKind.Utc);
+        value = value.AddTicks(1_234);
+
+        DateTime result = PersistenceTimestamp.NormalizeUtc(value);
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        Assert.Equal(0, result.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(TruncateToMillisecond(value).Ticks, result.Ticks);
+    }
+
+    [Fact]
+    public void NormalizeUtc_AlreadyNormalizedUtcDateTime_ReturnsSameInstant()
+    {
+        DateTime value = new(2026, 5, 31, 12, 34, 56, 789, DateTimeKind.Utc);
+
+        DateTime result = PersistenceTimestamp.NormalizeUtc(value);
+
+        Assert.Equal(value, result);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+    [Fact]
+    public void NormalizeUtc_UnspecifiedDateTime_TreatsValueAsUtc()
+    {
+        DateTime value = new(2026, 5, 31, 12, 34, 56, 789, DateTimeKind.Unspecified);
+        value = value.AddTicks(9_999);
+
+        DateTime result = PersistenceTimestamp.NormalizeUtc(value);
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        Assert.Equal(0, result.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(TruncateToMillisecond(DateTime.SpecifyKind(value, DateTimeKind.Utc)).Ticks, result.Ticks);
+    }
+
+    [Fact]
+    public void NormalizeUtc_LocalDateTime_ConvertsToUtcAndTrimsPrecision()
+    {
+        DateTime value = new(2026, 5, 31, 12, 34, 56, 789, DateTimeKind.Local);
+        value = value.AddTicks(4_321);
+
+        DateTime result = PersistenceTimestamp.NormalizeUtc(value);
+
+        DateTime expected = TruncateToMillisecond(value.ToUniversalTime());
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        Assert.Equal(0, result.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(expected.Ticks, result.Ticks);
+    }
+
+    [Fact]
+    public void NormalizeUtc_DateTime_IsIdempotent()
+    {
+        DateTime value = new(2026, 5, 31, 12, 34, 56, 789, DateTimeKind.Utc);
+        value = value.AddTicks(7_654);
+
+        DateTime once = PersistenceTimestamp.NormalizeUtc(value);
+        DateTime twice = PersistenceTimestamp.NormalizeUtc(once);
+
+        Assert.Equal(once, twice);
+        Assert.Equal(DateTimeKind.Utc, twice.Kind);
+    }
+
+    [Fact]
+    public void NormalizeUtc_DateTimeOffset_ConvertsToUtcAndTrimsPrecision()
+    {
+        DateTimeOffset value = new(
+            2026,
+            5,
+            31,
+            12,
+            34,
+            56,
+            789,
+            TimeSpan.FromHours(-5));
+
+        value = value.AddTicks(8_765);
+
+        DateTimeOffset result = PersistenceTimestamp.NormalizeUtc(value);
+
+        DateTimeOffset expected = TruncateToMillisecond(value.ToUniversalTime());
+
+        Assert.Equal(TimeSpan.Zero, result.Offset);
+        Assert.Equal(0, result.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(expected.Ticks, result.Ticks);
+    }
+
+    [Fact]
+    public void NormalizeUtc_DateTimeOffset_IsIdempotent()
+    {
+        DateTimeOffset value = new(
+            2026,
+            5,
+            31,
+            12,
+            34,
+            56,
+            789,
+            TimeSpan.FromHours(2));
+
+        value = value.AddTicks(3_210);
+
+        DateTimeOffset once = PersistenceTimestamp.NormalizeUtc(value);
+        DateTimeOffset twice = PersistenceTimestamp.NormalizeUtc(once);
+
+        Assert.Equal(once, twice);
+        Assert.Equal(TimeSpan.Zero, twice.Offset);
+    }
+
+    [Fact]
+    public void NormalizeUtc_MinAndMaxUtcDateTimeValues_AreSupported()
+    {
+        var min = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+        var max = DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+
+        DateTime normalizedMin = PersistenceTimestamp.NormalizeUtc(min);
+        DateTime normalizedMax = PersistenceTimestamp.NormalizeUtc(max);
+
+        Assert.Equal(DateTimeKind.Utc, normalizedMin.Kind);
+        Assert.Equal(DateTimeKind.Utc, normalizedMax.Kind);
+        Assert.Equal(min, normalizedMin);
+        Assert.Equal(0, normalizedMax.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(TruncateToMillisecond(max).Ticks, normalizedMax.Ticks);
+    }
+
+    [Fact]
+    public void UtcNow_ReturnsUtcTimestampWithMillisecondPrecision()
+    {
+        DateTime result = PersistenceTimestamp.UtcNow();
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        Assert.Equal(0, result.Ticks % TimeSpan.TicksPerMillisecond);
+    }
+
+    private static DateTime TruncateToMillisecond(DateTime value)
+    {
+        long normalizedTicks = value.Ticks - (value.Ticks % TimeSpan.TicksPerMillisecond);
+
+        return new DateTime(normalizedTicks, value.Kind);
+    }
+
+    private static DateTimeOffset TruncateToMillisecond(DateTimeOffset value)
+    {
+        long normalizedTicks = value.Ticks - (value.Ticks % TimeSpan.TicksPerMillisecond);
+
+        return new DateTimeOffset(normalizedTicks, value.Offset);
+    }
+}


### PR DESCRIPTION
## Summary

- Added direct unit coverage for `PersistenceTimestamp`
- Added direct unit coverage for `PersistenceStringComparisonNormalizer`
- Pinned timestamp precision trimming, UTC/local/unspecified `DateTimeKind` handling, `DateTimeOffset` UTC conversion, idempotency, and boundary values
- Pinned null/empty/whitespace handling, Unicode Form C normalization, encoded-value behavior, invariant casing, and idempotency for string comparison normalization
- Added test assembly visibility for Infrastructure internals

## Validation

- `dotnet test tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj`
```powershell
Restore complete (1.0s)
  ProjectTemplate.Infrastructure net10.0 succeeded (5.7s) → src\ProjectTemplate.Infrastructure\bin\Debug\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (4.7s) → src\ProjectTemplate.Web\bin\Debug\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (5.0s) → tests\ProjectTemplate.Web.Tests\bin\Debug\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.14]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.85]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.33]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:14.33]   Finished:    ProjectTemplate.Web.Tests (ID = 'e65e496f176e17b1b67b1fa3e005b5965c00fbd610526048a104ec3e21e15fb2')
  ProjectTemplate.Web.Tests test net10.0 succeeded (16.3s)

Test summary: total: 223, failed: 0, succeeded: 223, skipped: 0, duration: 16.3s
Build succeeded in 34.4s
```
- Coverage report confirms improved line and branch coverage for persistence normalization helpers


Closes #251