### PR TITLE
test: cover observability and forwarded header branches

### DIFF
--- a/tests/ProjectTemplate.Web.Tests/ForwardedHeadersExtensionsCoverageTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ForwardedHeadersExtensionsCoverageTests.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Web.Extensions;
+using ProjectTemplate.Web.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ForwardedHeadersExtensionsCoverageTests
+{
+    /// <summary>
+    /// Verifies that AddApplicationForwardedHeaders correctly configures ForwardedHeadersOptions based on the provided configuration when enabled. This test covers the mapping of all relevant properties from ApplicationForwardedHeadersOptions to ForwardedHeadersOptions, as well as validation of header names and known proxies/networks.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_EnabledConfiguration_ConfiguresForwardedHeadersOptions()
+    {
+        ServiceCollection services = new();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Enabled"] = "true",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:0"] = "XForwardedFor",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:1"] = "XForwardedProto",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:2"] = "XForwardedHost",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:ForwardLimit"] = "2",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:RequireHeaderSymmetry"] = "true",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:ClearKnownNetworksAndProxies"] = "true",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:KnownProxies:0"] = "10.20.30.40",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:KnownNetworks:0"] = "10.20.0.0/16",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:AllowedHosts:0"] = "example.test"
+        });
+
+        _ = services.AddApplicationForwardedHeaders(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        ForwardedHeadersOptions options = provider
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>()
+            .Value;
+
+        Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor));
+        Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedProto));
+        Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedHost));
+        Assert.Equal(2, options.ForwardLimit);
+        Assert.True(options.RequireHeaderSymmetry);
+        Assert.Contains(IPAddress.Parse("10.20.30.40"), options.KnownProxies);
+        _ = Assert.Single(options.KnownIPNetworks);
+        Assert.Contains("example.test", options.AllowedHosts);
+    }
+
+    /// <summary>
+    /// Verifies that when AddApplicationForwardedHeaders is called with Enabled set to false, the ForwardedHeadersOptions are configured to use no forwarded headers regardless of any other configuration values provided. This ensures that the middleware will not process any forwarded headers when disabled, even if header names or other settings are specified in the configuration.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_DisabledConfiguration_UsesNoForwardedHeaders()
+    {
+        ServiceCollection services = new();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Enabled"] = "false",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:0"] = "XForwardedFor",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:1"] = "XForwardedProto",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:ForwardLimit"] = "1"
+        });
+
+        _ = services.AddApplicationForwardedHeaders(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        ForwardedHeadersOptions options = provider
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>()
+            .Value;
+
+        Assert.Equal(ForwardedHeaders.None, options.ForwardedHeaders);
+    }
+
+    /// <summary>
+    /// Verifies that AddApplicationForwardedHeaders correctly parses header names with hyphens and underscores from the configuration and maps them to the appropriate ForwardedHeaders enum values. This test ensures that common variations in header naming conventions are supported and that the middleware will recognize headers like "X-Forwarded-For" and "X_Forwarded_Proto" regardless of formatting in the configuration.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_HeaderNamesWithHyphensAndUnderscores_AreParsed()
+    {
+        ServiceCollection services = new();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Enabled"] = "true",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:0"] = " x-forwarded-for ",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:1"] = "X_Forwarded_Proto",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:ForwardLimit"] = "1"
+        });
+
+        _ = services.AddApplicationForwardedHeaders(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        ForwardedHeadersOptions options = provider
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>()
+            .Value;
+
+        Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor));
+        Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedProto));
+    }
+
+    /// <summary>
+    /// Verifies that when AddApplicationForwardedHeaders is called with a ForwardLimit of zero, the options validation fails with an appropriate error message. This test ensures that the ForwardLimit property is correctly validated to be either null or greater than zero, preventing misconfiguration that could lead to unexpected behavior in the middleware when processing forwarded headers.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_ForwardLimitZero_FailsOptionsValidation()
+    {
+        Dictionary<string, string?> values = CreateValidValues();
+        values[$"{ApplicationForwardedHeadersOptions.SectionName}:ForwardLimit"] = "0";
+
+        AssertInvalidApplicationForwardedHeadersOptions(
+            values,
+            "ProjectTemplate:ForwardedHeaders:ForwardLimit must be null or greater than zero.");
+    }
+
+    /// <summary>
+    /// Verifies that when AddApplicationForwardedHeaders is called with an invalid header name in the configuration, the options validation fails with an appropriate error message. This test ensures that only valid header names that correspond to the ForwardedHeaders enum are accepted, preventing misconfiguration that could lead to runtime errors or unexpected behavior in the middleware when processing forwarded headers.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_InvalidHeader_FailsOptionsValidation()
+    {
+        Dictionary<string, string?> values = CreateValidValues();
+        values[$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:0"] = "InvalidForwardedHeader";
+
+        AssertInvalidApplicationForwardedHeadersOptions(
+            values,
+            "ProjectTemplate:ForwardedHeaders:Headers contains an invalid forwarded header value.");
+    }
+
+    /// <summary>
+    /// Verifies that when AddApplicationForwardedHeaders is called with an invalid known proxy IP address in the configuration, the options validation fails with an appropriate error message. This test ensures that the KnownProxies property is correctly validated to contain valid IP addresses, preventing misconfiguration that could lead to security issues or incorrect behavior in the middleware when determining trusted proxies.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_InvalidKnownProxy_FailsOptionsValidation()
+    {
+        Dictionary<string, string?> values = CreateValidValues();
+        values[$"{ApplicationForwardedHeadersOptions.SectionName}:KnownProxies:0"] = "not-an-ip-address";
+
+        AssertInvalidApplicationForwardedHeadersOptions(
+            values,
+            "ProjectTemplate:ForwardedHeaders:KnownProxies must contain valid IP addresses.");
+    }
+
+    /// <summary>
+    /// Verifies that when AddApplicationForwardedHeaders is called with an invalid known network CIDR range in the configuration, the options validation fails with an appropriate error message. This test ensures that the KnownNetworks property is correctly validated to contain valid CIDR notation for IP networks, preventing misconfiguration that could lead to security issues or incorrect behavior in the middleware when determining trusted networks.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_InvalidKnownNetwork_FailsOptionsValidation()
+    {
+        Dictionary<string, string?> values = CreateValidValues();
+        values[$"{ApplicationForwardedHeadersOptions.SectionName}:KnownNetworks:0"] = "10.20.0.0";
+
+        AssertInvalidApplicationForwardedHeadersOptions(
+            values,
+            "ProjectTemplate:ForwardedHeaders:KnownNetworks must contain valid CIDR ranges such as 10.0.0.0/24.");
+    }
+
+    /// <summary>
+    /// Verifies that when AddApplicationForwardedHeaders is called with XForwardedHost enabled in the Headers configuration but no allowed hosts specified in the AllowedHosts configuration, the options validation fails with an appropriate error message. This test ensures that the presence of XForwardedHost in the headers to process requires at least one allowed host to be configured, preventing misconfiguration that could lead to security issues or incorrect behavior in the middleware when processing forwarded host headers.
+    /// </summary>
+    [Fact]
+    public void AddApplicationForwardedHeaders_ForwardedHostWithoutAllowedHosts_FailsOptionsValidation()
+    {
+        Dictionary<string, string?> values = CreateValidValues();
+        values[$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:0"] = "XForwardedHost";
+        _ = values.Remove($"{ApplicationForwardedHeadersOptions.SectionName}:AllowedHosts:0");
+
+        AssertInvalidApplicationForwardedHeadersOptions(
+            values,
+            "ProjectTemplate:ForwardedHeaders:AllowedHosts must contain at least one host when XForwardedHost is enabled.");
+    }
+
+    private static void AssertInvalidApplicationForwardedHeadersOptions(
+        IReadOnlyDictionary<string, string?> values,
+        string expectedMessage)
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = CreateConfiguration(values);
+
+        _ = services.AddApplicationForwardedHeaders(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ApplicationForwardedHeadersOptions>>().Value);
+
+        Assert.Contains(expectedMessage, exception.Message, StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, string?> CreateValidValues()
+    {
+        return new Dictionary<string, string?>
+        {
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Enabled"] = "true",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:Headers:0"] = "XForwardedFor",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:ForwardLimit"] = "1",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:RequireHeaderSymmetry"] = "false",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:ClearKnownNetworksAndProxies"] = "true",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:KnownProxies:0"] = "10.20.30.40",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:KnownNetworks:0"] = "10.20.0.0/16",
+            [$"{ApplicationForwardedHeadersOptions.SectionName}:AllowedHosts:0"] = "example.test"
+        };
+    }
+
+    private static IConfiguration CreateConfiguration(IReadOnlyDictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/OpenTelemetryServiceExtensionsCoverageTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/OpenTelemetryServiceExtensionsCoverageTests.cs
@@ -1,0 +1,280 @@
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Exporter;
+using ProjectTemplate.Web.Extensions;
+using ProjectTemplate.Web.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class OpenTelemetryServiceExtensionsCoverageTests
+{
+    /// <summary>
+    /// Verifies that when OpenTelemetry is disabled, the service collection is returned without modification and no exceptions are thrown.
+    /// </summary>
+    [Fact]
+    public void AddApplicationOpenTelemetry_Disabled_ReturnsSameServiceCollection()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Enabled"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceName"] = "ProjectTemplate.Web.Tests"
+        });
+
+        IServiceCollection result = services.AddApplicationOpenTelemetry(
+            configuration,
+            new TestHostEnvironment());
+
+        Assert.Same(services, result);
+        Assert.NotEmpty(services);
+    }
+
+    /// <summary>
+    /// Verifies that when OpenTelemetry is enabled but both tracing and metrics are disabled, the service collection is returned without modification and no exceptions are thrown.
+    /// </summary>
+    [Fact]
+    public void AddApplicationOpenTelemetry_EnabledWithoutTracingOrMetrics_ReturnsSameServiceCollection()
+    {
+        ServiceCollection services = new();
+        _ = services.AddLogging();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Enabled"] = "true",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceName"] = "ProjectTemplate.Web.Tests",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceVersion"] = " 2.1.0 ",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableTracing"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableMetrics"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableAspNetCoreInstrumentation"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableHttpClientInstrumentation"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Otlp:Enabled"] = "false"
+        });
+
+        IServiceCollection result = services.AddApplicationOpenTelemetry(
+            configuration,
+            new TestHostEnvironment { EnvironmentName = Environments.Production });
+
+        Assert.Same(services, result);
+        Assert.NotEmpty(services);
+    }
+
+    /// <summary>
+    /// Verifies that when OpenTelemetry is enabled with both tracing and metrics enabled, and OTLP export is configured, the service collection is returned without modification and no exceptions are thrown.
+    /// </summary>
+    [Fact]
+    public void AddApplicationOpenTelemetry_TracingMetricsAndOtlpEnabled_ReturnsSameServiceCollection()
+    {
+        ServiceCollection services = new();
+        _ = services.AddLogging();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Enabled"] = "true",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceName"] = "ProjectTemplate.Web.Tests",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceVersion"] = "2.1.0",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableTracing"] = "true",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableMetrics"] = "true",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableAspNetCoreInstrumentation"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:EnableHttpClientInstrumentation"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Otlp:Enabled"] = "true",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Otlp:Endpoint"] = "http://localhost:4317",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Otlp:Protocol"] = "HttpProtobuf"
+        });
+
+        IServiceCollection result = services.AddApplicationOpenTelemetry(
+            configuration,
+            new TestHostEnvironment { EnvironmentName = "Testing" });
+
+        Assert.Same(services, result);
+        Assert.NotEmpty(services);
+    }
+
+    /// <summary>
+    /// Verifies that when OpenTelemetry is enabled but the service name is blank, an OptionsValidationException is thrown indicating that the service name must not be empty.
+    /// </summary>
+    [Fact]
+    public void AddApplicationOpenTelemetry_BlankServiceName_FailsOptionsValidation()
+    {
+        ServiceCollection services = new();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Enabled"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceName"] = " "
+        });
+
+        _ = services.AddApplicationOpenTelemetry(configuration, new TestHostEnvironment());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ApplicationOpenTelemetryOptions>>().Value);
+
+        Assert.Contains(
+            "ProjectTemplate:OpenTelemetry:ServiceName must not be empty.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that when OpenTelemetry is enabled and OTLP export is enabled but the endpoint is not a valid absolute URI, an OptionsValidationException is thrown indicating that the endpoint must be a valid absolute URI when OTLP export is enabled.
+    /// </summary>
+    [Fact]
+    public void AddApplicationOpenTelemetry_InvalidOtlpEndpoint_FailsOptionsValidation()
+    {
+        ServiceCollection services = new();
+
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Enabled"] = "false",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:ServiceName"] = "ProjectTemplate.Web.Tests",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Otlp:Enabled"] = "true",
+            [$"{ApplicationOpenTelemetryOptions.SectionName}:Otlp:Endpoint"] = "not-a-valid-uri"
+        });
+
+        _ = services.AddApplicationOpenTelemetry(configuration, new TestHostEnvironment());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ApplicationOpenTelemetryOptions>>().Value);
+
+        Assert.Contains(
+            "ProjectTemplate:OpenTelemetry:Otlp:Endpoint must be a valid absolute URI when OTLP export is enabled.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that when an explicit service version is provided with leading and trailing whitespace, the resolved service version is trimmed of whitespace.
+    /// </summary>
+    [Fact]
+    public void ResolveServiceVersion_ExplicitVersion_ReturnsTrimmedVersion()
+    {
+        ApplicationOpenTelemetryOptions options = new()
+        {
+            ServiceVersion = " 2.5.1 "
+        };
+
+        string result = InvokeResolveServiceVersion(options);
+
+        Assert.Equal("2.5.1", result);
+    }
+
+    /// <summary>
+    /// Verifies that when the service version is missing (null, empty, or whitespace), the resolved service version falls back to the assembly version of the OpenTelemetryServiceExtensions class.
+    /// </summary>
+    /// <param name="serviceVersion">
+    /// Null, empty, or whitespace string representing the service version to test. The test will be run for each of these cases to ensure that the fallback logic is correctly applied when the service version is not provided.
+    /// </param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ResolveServiceVersion_MissingVersion_ReturnsAssemblyFallback(string? serviceVersion)
+    {
+        ApplicationOpenTelemetryOptions options = new()
+        {
+            ServiceVersion = serviceVersion
+        };
+
+        string result = InvokeResolveServiceVersion(options);
+
+        Assert.Equal(GetExpectedAssemblyVersion(), result);
+    }
+
+    /// <summary>
+    /// Verifies that the ConfigureOtlpExporter method correctly configures the OtlpExporterOptions based on the provided ApplicationOtlpExporterOptions, including parsing the protocol string and setting the endpoint URI. The test covers various protocol string cases (e.g., "HttpProtobuf", "httpprotobuf", "Grpc", and an unknown value) to ensure that the correct OtlpExportProtocol enum value is set in the exporter options. Additionally, it verifies that the endpoint is correctly parsed into a Uri object.
+    /// </summary>
+    /// <param name="protocol">
+    /// The protocol string to test, which will be parsed by the ConfigureOtlpExporter method to determine the OtlpExportProtocol to use. The test includes valid protocol strings in different cases (e.g., "HttpProtobuf" and "httpprotobuf") as well as an unknown value to verify that the default protocol is used when an unrecognized string is provided.
+    /// </param>
+    /// <param name="expectedProtocol">
+    /// The expected OtlpExportProtocol enum value that should be set in the OtlpExporterOptions based on the provided protocol string. This parameter allows the test to verify that the ConfigureOtlpExporter method correctly maps the input protocol string to the corresponding OtlpExportProtocol value, ensuring that the exporter is configured with the intended protocol for OTLP export.
+    /// </param>
+    [Theory]
+    [InlineData("HttpProtobuf", OtlpExportProtocol.HttpProtobuf)]
+    [InlineData("httpprotobuf", OtlpExportProtocol.HttpProtobuf)]
+    [InlineData("Grpc", OtlpExportProtocol.Grpc)]
+    [InlineData("unknown", OtlpExportProtocol.Grpc)]
+    public void ConfigureOtlpExporter_ConfiguresEndpointAndProtocol(
+        string protocol,
+        OtlpExportProtocol expectedProtocol)
+    {
+        ApplicationOtlpExporterOptions options = new()
+        {
+            Enabled = true,
+            Endpoint = "http://localhost:4317",
+            Protocol = protocol
+        };
+
+        OtlpExporterOptions exporterOptions = InvokeConfigureOtlpExporter(options);
+
+        Assert.Equal(new Uri("http://localhost:4317"), exporterOptions.Endpoint);
+        Assert.Equal(expectedProtocol, exporterOptions.Protocol);
+    }
+
+    private static IConfiguration CreateConfiguration(IReadOnlyDictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    private static string InvokeResolveServiceVersion(ApplicationOpenTelemetryOptions options)
+    {
+        MethodInfo? method = typeof(OpenTelemetryServiceExtensions).GetMethod(
+            "ResolveServiceVersion",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.True(method is not null);
+
+        object? result = method.Invoke(null, [options]);
+
+        return Assert.IsType<string>(result);
+    }
+
+    private static OtlpExporterOptions InvokeConfigureOtlpExporter(
+        ApplicationOtlpExporterOptions options)
+    {
+        OtlpExporterOptions exporterOptions = new();
+
+        MethodInfo? method = typeof(OpenTelemetryServiceExtensions).GetMethod(
+            "ConfigureOtlpExporter",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.True(method is not null);
+
+        _ = method.Invoke(null, [exporterOptions, options]);
+
+        return exporterOptions;
+    }
+
+    private static string GetExpectedAssemblyVersion()
+    {
+        Assembly assembly = typeof(OpenTelemetryServiceExtensions).Assembly;
+
+        string? informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        return !string.IsNullOrWhiteSpace(informationalVersion)
+            ? informationalVersion
+            : assembly.GetName().Version?.ToString() ?? "unknown";
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+
+        public string ApplicationName { get; set; } = "ProjectTemplate.Web.Tests";
+
+        public string ContentRootPath { get; set; } = string.Empty;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Summary

* Added focused branch coverage for `OpenTelemetryServiceExtensions`
* Covered OpenTelemetry enabled/disabled registration paths
* Covered tracing, metrics, and OTLP exporter configuration branches
* Pinned OTLP endpoint/protocol behavior and service version fallback behavior
* Added focused branch coverage for `ForwardedHeadersExtensions`
* Covered enabled/disabled forwarded header configuration paths
* Covered forwarded header parsing with standard, hyphenated, and underscored header names
* Covered validation failures for invalid forward limits, invalid header names, invalid known proxies, invalid known networks, and missing allowed hosts when `XForwardedHost` is enabled

## Validation

* `dotnet test tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj`
```powershell
Restore complete (1.1s)
  ProjectTemplate.Infrastructure net10.0 succeeded (5.8s) → src\ProjectTemplate.Infrastructure\bin\Debug\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (4.8s) → src\ProjectTemplate.Web\bin\Debug\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (5.0s) → tests\ProjectTemplate.Web.Tests\bin\Debug\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.8)
[xUnit.net 00:00:01.18]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.91]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.40]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:15.19]   Finished:    ProjectTemplate.Web.Tests (ID = 'e65e496f176e17b1b67b1fa3e005b5965c00fbd610526048a104ec3e21e15fb2')
  ProjectTemplate.Web.Tests test net10.0 succeeded (17.2s)

Test summary: total: 255, failed: 0, succeeded: 255, skipped: 0, duration: 17.2s
Build succeeded in 36.4s
```
* Coverage report confirms improved branch coverage for OpenTelemetry and forwarded header configuration hotspots
