### PR TITLE
Add branch-gap hardening tests

### DIFF
--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextBranchGapTests.cs
@@ -50,7 +50,8 @@ public sealed class ApplicationDbContextBranchGapTests
         Assert.Equal("Sync.User@Example.com", account.Email);
         Assert.Equal("SYNC.USER@EXAMPLE.COM", account.NormalizedEmail);
         Assert.Equal(NormalizeExpectedUtc(localCreatedOnUtc), account.CreatedOnUtc);
-        Assert.Equal(NormalizeExpectedUtc(unspecifiedUpdatedOnUtc), account.UpdatedOnUtc);
+        Assert.NotNull(account.UpdatedOnUtc);
+        Assert.Equal(NormalizeExpectedUtc(unspecifiedUpdatedOnUtc), account.UpdatedOnUtc.Value);
 
         int auditRecordCount = await context.AuditRecords
             .CountAsync(TestContext.Current.CancellationToken);
@@ -171,12 +172,14 @@ public sealed class ApplicationDbContextBranchGapTests
         await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
         _ = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
+        Assert.NotNull(account.UpdatedOnUtc);
+        Assert.NotNull(account.LastLoginOnUtc);
         Assert.Equal(NormalizeExpectedUtc(localCreatedOnUtc), account.CreatedOnUtc);
-        Assert.Equal(NormalizeExpectedUtc(unspecifiedUpdatedOnUtc), account.UpdatedOnUtc);
-        Assert.Equal(NormalizeExpectedUtc(localLastLoginOnUtc), account.LastLoginOnUtc);
+        Assert.Equal(NormalizeExpectedUtc(unspecifiedUpdatedOnUtc), account.UpdatedOnUtc.Value);
+        Assert.Equal(NormalizeExpectedUtc(localLastLoginOnUtc), account.LastLoginOnUtc.Value);
         Assert.Equal(DateTimeKind.Utc, account.CreatedOnUtc.Kind);
-        Assert.Equal(DateTimeKind.Utc, account.UpdatedOnUtc?.Kind);
-        Assert.Equal(DateTimeKind.Utc, account.LastLoginOnUtc?.Kind);
+        Assert.Equal(DateTimeKind.Utc, account.UpdatedOnUtc.Value.Kind);
+        Assert.Equal(DateTimeKind.Utc, account.LastLoginOnUtc.Value.Kind);
     }
 
     private static async Task<Guid> SeedExternalLoginAccountAsync(

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextBranchGapTests.cs
@@ -1,0 +1,259 @@
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationDbContextBranchGapTests
+{
+    [Fact]
+    public async Task SaveChanges_AuditingDisabled_PersistsCanonicalizedAccountWithoutAuditRecord()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        _ = context.Database.EnsureCreated();
+
+        DateTime localCreatedOnUtc = new(2026, 5, 31, 8, 9, 10, 456, DateTimeKind.Local);
+        localCreatedOnUtc = localCreatedOnUtc.AddTicks(1_234);
+
+        DateTime unspecifiedUpdatedOnUtc = new(2026, 5, 31, 9, 10, 11, 987, DateTimeKind.Unspecified);
+        unspecifiedUpdatedOnUtc = unspecifiedUpdatedOnUtc.AddTicks(5_678);
+
+        ExternalLoginAccount account = new()
+        {
+            ConcurrencyStamp = " ",
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = " Git&amp;Hub ",
+            ProviderUserId = " external-user&amp;#39;sync ",
+            DisplayName = " Sync &amp;amp; User ",
+            Email = " Sync.User&amp;#64;Example.com ",
+            CreatedOnUtc = localCreatedOnUtc,
+            UpdatedOnUtc = unspecifiedUpdatedOnUtc
+        };
+
+        context.ExternalLoginAccounts.Add(account);
+
+        int result = context.SaveChanges();
+
+        Assert.Equal(1, result);
+        Assert.False(string.IsNullOrWhiteSpace(account.ConcurrencyStamp));
+        Assert.Equal(32, account.ConcurrencyStamp.Length);
+        Assert.Equal("Git&Hub", account.ProviderName);
+        Assert.Equal("GIT&HUB", account.NormalizedProviderName);
+        Assert.Equal("external-user'sync", account.ProviderUserId);
+        Assert.Equal("Sync & User", account.DisplayName);
+        Assert.Equal("Sync.User@Example.com", account.Email);
+        Assert.Equal("SYNC.USER@EXAMPLE.COM", account.NormalizedEmail);
+        Assert.Equal(NormalizeExpectedUtc(localCreatedOnUtc), account.CreatedOnUtc);
+        Assert.Equal(NormalizeExpectedUtc(unspecifiedUpdatedOnUtc), account.UpdatedOnUtc);
+
+        int auditRecordCount = await context.AuditRecords
+            .CountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, auditRecordCount);
+    }
+
+    [Fact]
+    public async Task SaveChanges_ModifiedEmailWithAuditingEnabled_AuditsOnlyChangedEmailValues()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        Guid accountId = await SeedExternalLoginAccountAsync(
+            connection,
+            providerName: "GitHub",
+            providerUserId: "email-branch-user",
+            displayName: "Email Branch User",
+            email: "original@example.com");
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: true);
+
+        ExternalLoginAccount account = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == accountId, TestContext.Current.CancellationToken);
+
+        string originalStamp = account.ConcurrencyStamp;
+
+        account.Email = " New&amp;User@example.com ";
+
+        int result = context.SaveChanges();
+
+        Assert.True(result >= 1);
+        Assert.NotEqual(originalStamp, account.ConcurrencyStamp);
+        Assert.Equal("New&User@example.com", account.Email);
+        Assert.Equal("NEW&USER@EXAMPLE.COM", account.NormalizedEmail);
+
+        AuditRecord auditRecord = await context.AuditRecords
+            .SingleAsync(item => item.Entity == "ExternalLoginAccounts", TestContext.Current.CancellationToken);
+
+        Assert.Equal("BranchGapActor", auditRecord.ModifiedBy);
+        Assert.Equal(EntityState.Modified.ToString(), auditRecord.State);
+
+        using var originalValues = JsonDocument.Parse(auditRecord.OriginalValues);
+        using var currentValues = JsonDocument.Parse(auditRecord.CurrentValues);
+
+        Assert.Equal("original@example.com", originalValues.RootElement.GetProperty(nameof(ExternalLoginAccount.Email)).GetString());
+        Assert.Equal("New&User@example.com", currentValues.RootElement.GetProperty(nameof(ExternalLoginAccount.Email)).GetString());
+        Assert.Equal("ORIGINAL@EXAMPLE.COM", originalValues.RootElement.GetProperty(nameof(ExternalLoginAccount.NormalizedEmail)).GetString());
+        Assert.Equal("NEW&USER@EXAMPLE.COM", currentValues.RootElement.GetProperty(nameof(ExternalLoginAccount.NormalizedEmail)).GetString());
+        Assert.Equal(originalStamp, originalValues.RootElement.GetProperty(nameof(DataEntity.ConcurrencyStamp)).GetString());
+        Assert.Equal(account.ConcurrencyStamp, currentValues.RootElement.GetProperty(nameof(DataEntity.ConcurrencyStamp)).GetString());
+
+        Assert.False(currentValues.RootElement.TryGetProperty(nameof(ExternalLoginAccount.ProviderName), out _));
+        Assert.False(currentValues.RootElement.TryGetProperty(nameof(ExternalLoginAccount.ProviderUserId), out _));
+        Assert.False(currentValues.RootElement.TryGetProperty(nameof(ExternalLoginAccount.DisplayName), out _));
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_AuditingDisabled_ModifiedAccountUpdatesStampWithoutAuditRecord()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        Guid accountId = await SeedExternalLoginAccountAsync(
+            connection,
+            providerName: "Microsoft",
+            providerUserId: "async-disabled-user",
+            displayName: "Original Async User",
+            email: "async@example.com");
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+
+        ExternalLoginAccount account = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == accountId, TestContext.Current.CancellationToken);
+
+        string originalStamp = account.ConcurrencyStamp;
+        account.DisplayName = " Updated &amp; Async User ";
+
+        int result = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result);
+        Assert.Equal("Updated & Async User", account.DisplayName);
+        Assert.NotEqual(originalStamp, account.ConcurrencyStamp);
+
+        int auditRecordCount = await context.AuditRecords
+            .CountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, auditRecordCount);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_LocalAndUnspecifiedUtcTimestamps_NormalizesToUtcBeforePersisting()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        DateTime localCreatedOnUtc = new(2026, 5, 31, 6, 7, 8, 123, DateTimeKind.Local);
+        localCreatedOnUtc = localCreatedOnUtc.AddTicks(4_567);
+
+        DateTime unspecifiedUpdatedOnUtc = new(2026, 5, 31, 7, 8, 9, 234, DateTimeKind.Unspecified);
+        unspecifiedUpdatedOnUtc = unspecifiedUpdatedOnUtc.AddTicks(5_678);
+
+        DateTime localLastLoginOnUtc = new(2026, 5, 31, 8, 9, 10, 345, DateTimeKind.Local);
+        localLastLoginOnUtc = localLastLoginOnUtc.AddTicks(6_789);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "Google",
+            ProviderUserId = "timestamp-kind-user",
+            DisplayName = "Timestamp Kind User",
+            Email = "timestamp-kind@example.com",
+            CreatedOnUtc = localCreatedOnUtc,
+            UpdatedOnUtc = unspecifiedUpdatedOnUtc,
+            LastLoginOnUtc = localLastLoginOnUtc
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        _ = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(NormalizeExpectedUtc(localCreatedOnUtc), account.CreatedOnUtc);
+        Assert.Equal(NormalizeExpectedUtc(unspecifiedUpdatedOnUtc), account.UpdatedOnUtc);
+        Assert.Equal(NormalizeExpectedUtc(localLastLoginOnUtc), account.LastLoginOnUtc);
+        Assert.Equal(DateTimeKind.Utc, account.CreatedOnUtc.Kind);
+        Assert.Equal(DateTimeKind.Utc, account.UpdatedOnUtc?.Kind);
+        Assert.Equal(DateTimeKind.Utc, account.LastLoginOnUtc?.Kind);
+    }
+
+    private static async Task<Guid> SeedExternalLoginAccountAsync(
+        SqliteConnection connection,
+        string providerName,
+        string providerUserId,
+        string displayName,
+        string email)
+    {
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: false);
+        _ = await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = providerName,
+            ProviderUserId = providerUserId,
+            DisplayName = displayName,
+            Email = email,
+            CreatedOnUtc = new DateTime(2026, 5, 31, 8, 0, 0, DateTimeKind.Utc)
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        _ = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return account.Id;
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        bool auditingEnabled)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = auditingEnabled
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+    }
+
+    private static DateTime NormalizeExpectedUtc(DateTime value)
+    {
+        DateTime utcValue = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+
+        long normalizedTicks = utcValue.Ticks - (utcValue.Ticks % TimeSpan.TicksPerMillisecond);
+
+        return new DateTime(normalizedTicks, DateTimeKind.Utc);
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "BranchGapActor";
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
@@ -1,0 +1,195 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Web.Extensions;
+using ProjectTemplate.Web.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class RequestLoggingExtensionsBranchGapTests
+{
+    [Fact]
+    public void AddApplicationRequestLogging_BlankCorrelationHeaderName_FailsOptionsValidation()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationRequestLoggingOptions.SectionName}:CorrelationHeaderName"] = " "
+        });
+
+        _ = services.AddApplicationRequestLogging(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ApplicationRequestLoggingOptions>>().Value);
+
+        Assert.Contains(
+            "ProjectTemplate:RequestLogging:CorrelationHeaderName is required.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("health")]
+    [InlineData("   ")]
+    public void AddApplicationRequestLogging_InvalidExcludedPathPrefix_FailsOptionsValidation(string excludedPrefix)
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationRequestLoggingOptions.SectionName}:CorrelationHeaderName"] = "X-Correlation-ID",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:ExcludedPathPrefixes:0"] = excludedPrefix
+        });
+
+        _ = services.AddApplicationRequestLogging(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ApplicationRequestLoggingOptions>>().Value);
+
+        Assert.Contains(
+            "ProjectTemplate:RequestLogging:ExcludedPathPrefixes values must start with '/'.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddApplicationRequestLogging_ValidExcludedPathPrefixes_BindsOptions()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            [$"{ApplicationRequestLoggingOptions.SectionName}:Enabled"] = "true",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:CorrelationHeaderName"] = "X-Test-Correlation-ID",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:IncludeQueryString"] = "true",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:IncludeRemoteIpAddress"] = "false",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:IncludeUserName"] = "false",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:ExcludedPathPrefixes:0"] = "/healthz",
+            [$"{ApplicationRequestLoggingOptions.SectionName}:ExcludedPathPrefixes:1"] = "/metrics"
+        });
+
+        _ = services.AddApplicationRequestLogging(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        ApplicationRequestLoggingOptions options = provider
+            .GetRequiredService<IOptions<ApplicationRequestLoggingOptions>>()
+            .Value;
+
+        Assert.True(options.Enabled);
+        Assert.Equal("X-Test-Correlation-ID", options.CorrelationHeaderName);
+        Assert.True(options.IncludeQueryString);
+        Assert.False(options.IncludeRemoteIpAddress);
+        Assert.False(options.IncludeUserName);
+        Assert.Equal(["/healthz", "/metrics"], options.ExcludedPathPrefixes);
+    }
+
+    [Fact]
+    public void GetCorrelationId_HeaderWithWhitespace_ReturnsTrimmedHeaderValue()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.TraceIdentifier = "trace-fallback";
+        httpContext.Request.Headers["X-Correlation-ID"] = "  request-correlation-id  ";
+
+        string result = InvokeGetCorrelationId(httpContext, new ApplicationRequestLoggingOptions());
+
+        Assert.Equal("request-correlation-id", result);
+    }
+
+    [Fact]
+    public void GetCorrelationId_HeaderLongerThanMaximum_TruncatesToMaximumLength()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.TraceIdentifier = "trace-fallback";
+        httpContext.Request.Headers["X-Correlation-ID"] = new string('a', 140);
+
+        string result = InvokeGetCorrelationId(httpContext, new ApplicationRequestLoggingOptions());
+
+        Assert.Equal(128, result.Length);
+        Assert.Equal(new string('a', 128), result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetCorrelationId_MissingOrBlankHeader_ReturnsTraceIdentifier(string? headerValue)
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.TraceIdentifier = "trace-fallback";
+
+        if (headerValue is not null)
+        {
+            httpContext.Request.Headers["X-Correlation-ID"] = headerValue;
+        }
+
+        string result = InvokeGetCorrelationId(httpContext, new ApplicationRequestLoggingOptions());
+
+        Assert.Equal("trace-fallback", result);
+    }
+
+    [Theory]
+    [InlineData("/HEALTH/ready", true)]
+    [InlineData("/metrics/runtime", true)]
+    [InlineData("/api/status", false)]
+    [InlineData("", false)]
+    public void IsExcludedPath_ReturnsExpectedMatchForConfiguredPrefixes(
+        string requestPath,
+        bool expectedResult)
+    {
+        ApplicationRequestLoggingOptions options = new()
+        {
+            ExcludedPathPrefixes =
+            [
+                "/health",
+                "/metrics"
+            ]
+        };
+
+        bool result = InvokeIsExcludedPath(new PathString(requestPath), options);
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    private static IConfiguration CreateConfiguration(IReadOnlyDictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    private static string InvokeGetCorrelationId(
+        HttpContext httpContext,
+        ApplicationRequestLoggingOptions options)
+    {
+        MethodInfo? method = typeof(RequestLoggingExtensions).GetMethod(
+            "GetCorrelationId",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.True(method is not null);
+
+        object? result = method.Invoke(null, [httpContext, options]);
+
+        return Assert.IsType<string>(result);
+    }
+
+    private static bool InvokeIsExcludedPath(
+        PathString requestPath,
+        ApplicationRequestLoggingOptions options)
+    {
+        MethodInfo? method = typeof(RequestLoggingExtensions).GetMethod(
+            "IsExcludedPath",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.True(method is not null);
+
+        object? result = method.Invoke(null, [requestPath, options]);
+
+        return Assert.IsType<bool>(result);
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
@@ -58,8 +58,6 @@ public sealed class RequestLoggingExtensionsBranchGapTests
             StringComparison.Ordinal);
     }
 
-    private static readonly string[] _expected = ["/healthz", "/metrics"];
-
     [Fact]
     public void AddApplicationRequestLogging_ValidExcludedPathPrefixes_BindsOptions()
     {
@@ -88,7 +86,8 @@ public sealed class RequestLoggingExtensionsBranchGapTests
         Assert.True(options.IncludeQueryString);
         Assert.False(options.IncludeRemoteIpAddress);
         Assert.False(options.IncludeUserName);
-        Assert.Equal(_expected, options.ExcludedPathPrefixes);
+        Assert.Contains("/healthz", options.ExcludedPathPrefixes);
+        Assert.Contains("/metrics", options.ExcludedPathPrefixes);
     }
 
     [Fact]

--- a/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
@@ -86,7 +86,7 @@ public sealed class RequestLoggingExtensionsBranchGapTests
         Assert.True(options.IncludeQueryString);
         Assert.False(options.IncludeRemoteIpAddress);
         Assert.False(options.IncludeUserName);
-        Assert.Equal(["/healthz", "/metrics"], options.ExcludedPathPrefixes);
+        Assert.Equal(new[] { "/healthz", "/metrics" }, options.ExcludedPathPrefixes);
     }
 
     [Fact]

--- a/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RequestLoggingExtensionsBranchGapTests.cs
@@ -58,6 +58,8 @@ public sealed class RequestLoggingExtensionsBranchGapTests
             StringComparison.Ordinal);
     }
 
+    private static readonly string[] _expected = ["/healthz", "/metrics"];
+
     [Fact]
     public void AddApplicationRequestLogging_ValidExcludedPathPrefixes_BindsOptions()
     {
@@ -86,14 +88,16 @@ public sealed class RequestLoggingExtensionsBranchGapTests
         Assert.True(options.IncludeQueryString);
         Assert.False(options.IncludeRemoteIpAddress);
         Assert.False(options.IncludeUserName);
-        Assert.Equal(new[] { "/healthz", "/metrics" }, options.ExcludedPathPrefixes);
+        Assert.Equal(_expected, options.ExcludedPathPrefixes);
     }
 
     [Fact]
     public void GetCorrelationId_HeaderWithWhitespace_ReturnsTrimmedHeaderValue()
     {
-        DefaultHttpContext httpContext = new();
-        httpContext.TraceIdentifier = "trace-fallback";
+        DefaultHttpContext httpContext = new()
+        {
+            TraceIdentifier = "trace-fallback"
+        };
         httpContext.Request.Headers["X-Correlation-ID"] = "  request-correlation-id  ";
 
         string result = InvokeGetCorrelationId(httpContext, new ApplicationRequestLoggingOptions());
@@ -104,8 +108,10 @@ public sealed class RequestLoggingExtensionsBranchGapTests
     [Fact]
     public void GetCorrelationId_HeaderLongerThanMaximum_TruncatesToMaximumLength()
     {
-        DefaultHttpContext httpContext = new();
-        httpContext.TraceIdentifier = "trace-fallback";
+        DefaultHttpContext httpContext = new()
+        {
+            TraceIdentifier = "trace-fallback"
+        };
         httpContext.Request.Headers["X-Correlation-ID"] = new string('a', 140);
 
         string result = InvokeGetCorrelationId(httpContext, new ApplicationRequestLoggingOptions());
@@ -120,8 +126,10 @@ public sealed class RequestLoggingExtensionsBranchGapTests
     [InlineData("   ")]
     public void GetCorrelationId_MissingOrBlankHeader_ReturnsTraceIdentifier(string? headerValue)
     {
-        DefaultHttpContext httpContext = new();
-        httpContext.TraceIdentifier = "trace-fallback";
+        DefaultHttpContext httpContext = new()
+        {
+            TraceIdentifier = "trace-fallback"
+        };
 
         if (headerValue is not null)
         {


### PR DESCRIPTION
## Summary

Adds focused, repo-specific tests to close meaningful branch coverage gaps without refactoring production code.

## Changes

- Added `ApplicationDbContextBranchGapTests` covering additional save-pipeline branches:
  - sync `SaveChanges` with auditing disabled
  - sync modified-entity save with auditing enabled
  - async modified-entity save with auditing disabled
  - local/unspecified `*Utc` timestamp normalization paths
  - canonicalized persisted strings, lookup normalization, concurrency stamps, and audit suppression/creation behavior
- Added `RequestLoggingExtensionsBranchGapTests` covering request logging option/helper branches:
  - blank correlation header validation
  - invalid excluded path prefix validation
  - valid option binding for logging/enrichment flags
  - correlation ID trimming, truncation, and fallback behavior
  - excluded path prefix matching, including case-insensitive path matching

## Notes

- No production code refactor was included.
- Tests intentionally exercise behavior through public save paths where possible.
- Reflection is used only for request logging private static helpers that drive branch-heavy behavior and are otherwise captured indirectly by middleware configuration.

## Validation

Not run locally in this session. CI should run the full test suite and coverage report on the PR branch.