### PR TITLE
docs: clarify readiness probe dependency checks

### DIFF
--- a/docs/articles/health-checks.md
+++ b/docs/articles/health-checks.md
@@ -22,7 +22,9 @@ app.MapApplicationHealthChecks();
 | `/health/ready` | Readiness endpoint intended for dependency-aware checks such as database, cache, or external service availability. |
 | `/health/live` | Liveness endpoint intended to verify that the application process can respond. |
 
-The baseline application does not yet register database or external dependency checks. Future modules, such as EF Core, SQL Server, authentication providers, or external integrations, can add tagged checks for readiness scenarios.
+The baseline application provides the readiness endpoint shape. It does not, by itself, prove database, cache, queue, or external service availability.
+
+Each generated application must register the dependency checks that define production readiness for that service. Future modules, such as EF Core, SQL Server, authentication providers, or external integrations, can add tagged checks for readiness scenarios.
 
 ## Liveness Semantics
 

--- a/docs/articles/production-deployment-checklist.md
+++ b/docs/articles/production-deployment-checklist.md
@@ -146,11 +146,15 @@ Related docs:
 ```text
 [ ] `/health` behavior is understood.
 [ ] `/health/live` is configured for liveness probes.
-[ ] `/health/ready` is configured for readiness probes.
+[ ] `/health/ready` is configured for readiness probes and includes the database, cache, queue, external service, or other dependency checks required before the service receives normal production traffic.
 [ ] Infrastructure probe paths and methods match application behavior.
 [ ] Health responses do not expose sensitive dependency details publicly.
 [ ] Load balancer or orchestrator health behavior is tested.
 ```
+
+Readiness scope:
+
+The template provides the readiness endpoint shape, but each generated application must register the dependency checks that define production readiness for that service. Do not treat the default readiness endpoint as proof that database, cache, queue, or external service dependencies are available unless those checks have been explicitly registered and included in readiness.
 
 Related docs:
 


### PR DESCRIPTION
## Summary

Clarifies that `/health/ready` must include the dependency checks required by the deployed service, rather than implying that the default readiness endpoint alone proves database or dependency readiness.

## Changes

- Updated the Production Deployment Checklist readiness item to require service-specific dependency checks.
- Added a readiness scope note explaining that the template provides the endpoint shape, while generated applications must register their own production readiness checks.
- Reinforced the Health Checks documentation so consumers do not mistake the baseline endpoint for database, cache, queue, or external-service readiness.

## Validation

- Documentation-only change.
- Existing liveness/readiness semantics preserved.

Closes #253 