### PR TITLE
docs: prepare release 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 0.5.9 - 2026-05-31
+
+### Added
+
+* Added `AGENTS.md` repository instructions for GitHub Copilot coding agents and other AI-assisted contributors.
+* Added a security-critical coverage gate that evaluates ReportGenerator Cobertura output against file-level line and branch coverage thresholds.
+* Added `eng/security-critical-coverage.json` to define protected source files and minimum security-critical coverage expectations.
+* Added `eng/Assert-SecurityCriticalCoverage.ps1` to enforce security-critical coverage thresholds in CI.
+* Added focused contract coverage for `ProblemDetailsExceptionHandler`, including exception-to-status/title mappings and safe production response behavior.
+* Added Problem Details customization coverage for extension and request-classification behavior.
+* Added branch coverage for `HttpContextCurrentActorAccessor`, including authenticated subject claims, authenticated name identifier fallback, whitespace handling, remote IP fallback, and unknown actor behavior.
+* Added focused branch coverage for `ApplicationDbContext` save hooks, audit stamping, string normalization, timestamp normalization, direct audit-record saves, and concurrency-related persistence behavior.
+* Added additional `ApplicationDbContext` branch-gap tests for auditing-disabled and save-pipeline scenarios.
+* Added direct coverage for persistence normalization helpers, including timestamp precision trimming, UTC conversion, string comparison normalization, whitespace handling, and Unicode normalization behavior.
+* Added enabled-path authentication provider coverage for OpenID Connect, SAML2, Google, and GitHub registration.
+* Added provider option coverage for external authentication provider extensions, including null-argument validation, option binding, callback paths, scopes, and SAML2 provider configuration.
+* Added branch coverage for API versioning configuration validation.
+* Added branch coverage for OpenTelemetry registration, tracing, metrics, OTLP exporter configuration, and service-version behavior.
+* Added branch coverage for forwarded header configuration and request logging behavior.
+* Added README badge updates for NuGet total downloads, static Zenodo DOI display, and static MIT license presentation.
+* Added documentation examples for an opt-in fallback authorization policy and named authorization policy usage.
+
+### Changed
+
+* Updated CI to enforce both the global coverage threshold and the new security-critical per-file coverage gate.
+* Updated build-quality documentation to explain the security-critical coverage gate, protected-file configuration, and expectations for lowering protected thresholds.
+* Hardened HTTP current actor resolution so authenticated users resolve from the `sub` claim first, then `ClaimTypes.NameIdentifier`, before falling back to remote IP or `Unknown`.
+* Clarified that `/health/ready` provides the readiness endpoint shape but does not prove database, cache, queue, or external dependency readiness unless those checks are explicitly registered.
+* Updated the production deployment checklist to require service-specific readiness dependency checks before normal production traffic is allowed.
+* Clarified that fallback authorization is opt-in and should be reviewed carefully for public endpoints such as login, callback, health checks, static assets, and intentionally anonymous API endpoints.
+* Clarified the NuGet package signing policy: packages are not author-signed while the repository remains solo-maintained and are published only through the maintainer-controlled release workflow.
+* Clarified that published NuGet.org packages rely on NuGet.org repository signing rather than a separate project-managed author-signing certificate.
+
+### Security
+
+* Strengthened release-governance documentation around NuGet package publication, solo-maintainer ownership, protected release workflows, manual approval, and repository-signed NuGet.org package distribution.
+* Strengthened CI regression protection for security-sensitive source files by adding file-level coverage requirements for error handling, request classification, actor resolution, security headers, forwarded headers, rate limiting, persistence normalization, timestamp handling, and `ApplicationDbContext` save hooks.
+* Strengthened centralized error-handling confidence by pinning Problem Details mappings and safe production sanitization behavior with focused tests.
+* Strengthened audit attribution behavior by verifying authenticated actor resolution and fallback behavior for HTTP request contexts.
+* Strengthened authentication-provider confidence by covering enabled registration paths and provider option behavior for supported external authentication providers.
+* Strengthened production readiness guidance by clarifying that readiness probes must include the dependency checks required by each deployed service.
+
 ## 0.5.8 - 2026-05-30
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.8"
-date-released: "2026-05-30"
+version: "0.5.9"
+date-released: "2026-05-31"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.8</VersionPrefix>
+    <VersionPrefix>0.5.9</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.8.0</AssemblyVersion>
-    <FileVersion>0.5.8.0</FileVersion>
+    <AssemblyVersion>0.5.9.0</AssemblyVersion>
+    <FileVersion>0.5.9.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.8</VersionPrefix>
+    <VersionPrefix>0.5.9</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -23,7 +23,7 @@ dotnet new install CDCavell.NetCoreApplicationTemplate
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.8.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.9.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.8](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.8)__
+Current release: __[Release 0.5.9](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.9)__
 
-Tag: `v0.5.8`
+Tag: `v0.5.9`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.8.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.9.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.8. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.9. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.8` |
+| Current package version | `0.5.9` |
 
 ## Consumer Scaffold Boundaries
 
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.8.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.9.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary 

- Added the `0.5.9` changelog entry. 
- Documented post-`0.5.8` CI and test hardening work. 
- Documented the new security-critical coverage gate and protected file-level coverage expectations. 
- Documented expanded branch and contract coverage for Problem Details, actor resolution, ApplicationDbContext save hooks, persistence normalization, authentication providers, API versioning, OpenTelemetry, forwarded headers, and request logging. 
- Documented readiness-probe clarification, opt-in fallback authorization guidance, README badge updates, AGENTS.md, and NuGet package signing policy clarification. 
 
## Validation 

- Documentation-only change. 
- Reviewed merged work since `0.5.8` and summarized user-facing, release-governance, CI, test, and security-relevant changes. 
- Confirmed the changelog entry is grouped under `Added`, `Changed`, and `Security`.