### PR TITLE
Release/v1.0.0

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -153,7 +153,6 @@
         ".gitattributes",
         ".gitignore",
         "ASSETS-LICENSES.md",
-        "CITATION.cff",
         "Directory.Build.props",
         "Directory.Packages.props",
         "Dockerfile",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 1.0.0 - 2026-06-01
+
+### Added
+
+* Added the first stable `1.0.0` release baseline for the NetCoreApplicationTemplate package and repository.
+* Added final `v1.0.0` release-readiness closure tracking for release validation, documentation and metadata consistency, supply-chain/security evidence, consumer package validation, and intentional deferral review.
+* Added final release-candidate validation coverage for build, format, test, pack, coverage-report generation, and coverage-gate confirmation.
+* Added stable-release validation expectations for clean template installation, scaffolded project restore, build, test, and consumer documentation review.
+
+### Changed
+
+* Promoted the project from the `0.5.x` hardening stream to the stable `1.0.0` release line.
+* Consolidated the broad `v1.0.0` readiness epic into a concise final closure issue set so remaining release work is visible from one tracking view.
+* Updated release readiness posture around version consistency, package metadata, release notes, documentation links, citation metadata, and release artifact validation.
+* Confirmed NuGet package author signing remains intentionally deferred while the repository is solo-maintained, with official packages produced only through the maintainer-controlled release workflow.
+* Confirmed stable release guidance for GitHub Release publication, NuGet package validation, Zenodo archival sequencing, DocFX documentation publication, and clean-environment post-release smoke testing.
+
+### Security
+
+* Carried forward the global coverage gate and security-critical per-file coverage gate as part of the stable release baseline.
+* Preserved security-critical coverage expectations for centralized Problem Details handling, request classification, actor resolution, security headers, forwarded headers, rate limiting, persistence normalization, timestamp handling, and `ApplicationDbContext` save hooks.
+* Preserved release-governance controls for dependency review, vulnerability scanning, SBOM/provenance evidence, protected publish environments, and manual maintainer approval.
+* Preserved the release-blocking rule that any deferred work must not affect package correctness, publication safety, security posture, citation metadata, or consumer smoke-test behavior.
+
+### Validation
+
+* Locally validated Release build, formatting, test execution, and template package generation before the stable release-candidate review.
+* Confirmed the local coverage-gate verification path using ReportGenerator Cobertura output and the security-critical coverage threshold script.
+
 ## 0.5.9 - 2026-05-31
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "0.5.9"
-date-released: "2026-05-31"
+version: "1.0.0"
+date-released: "2026-06-01"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,15 +3,19 @@ message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
 version: "1.0.0"
 date-released: "2026-06-01"
+repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
+url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
+type: software
+license: MIT
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.20373042"
+    description: "Zenodo Concept DOI"
 authors:
   - family-names: "Cavell"
     given-names: "Christopher D."
     orcid: "https://orcid.org/0009-0002-2113-0245"
 abstract: "NetCoreApplicationTemplate is a reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes common application infrastructure concerns including startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, and DocFX documentation. The project is intended as a practical baseline for small-to-medium web applications, internal line-of-business systems, and prototypes that may grow into production systems."
-type: software
-license: MIT
-repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
-url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 keywords:
   - aspnetcore
   - dotnet

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>0.5.9</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>0.5.9.0</AssemblyVersion>
-    <FileVersion>0.5.9.0</FileVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
     <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
-    <VersionPrefix>0.5.9</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Preview release-readiness package metadata. Production publication requires the protected NuGet publish workflow, NuGet package identity ownership, and release checklist validation.</PackageReleaseNotes>
+    <PackageReleaseNotes>Stable 1.0.0 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -23,7 +23,7 @@ dotnet new install CDCavell.NetCoreApplicationTemplate
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.9.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.0.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.0. Zenodo. MIT Li
 
 ## Roadmap
 
-The project is being developed toward a reusable .NET application template. Future work may include additional provider modules, stronger packaging support, template parameterization, expanded examples, and release-ready template distribution.
+The project is a reusable .NET application template with a stable `1.0.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
 
 See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 0.5.9](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v0.5.9)__
+Current release: __[Release 1.0.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.0)__
 
-Tag: `v0.5.9`
+Tag: `v1.0.0`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.9.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.0.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 0.5.9. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Checklist and v1.0.0 Release Candidate Runbook
 
-Use this checklist before publishing a stable template package or creating the future `v1.0.0` release.
+Use this checklist before publishing the stable `v1.0.0` template package and associated release artifacts.
 
 ## v1.0.0 release candidate runbook
 
@@ -132,13 +132,13 @@ Use this guidance for critical post-release issues:
 
 ## NuGet package identity and publish gate
 
-The intended stable package identity is:
+The stable package identity is:
 
 ```text
 CDCavell.NetCoreApplicationTemplate
 ```
 
-Reserve the package identity by publishing the first validated package to NuGet.org before the stable `v1.0.0` tag, or document a decision to use a different registry.
+Confirm package identity ownership and publish access.
 
 Recommended order:
 
@@ -189,7 +189,7 @@ Recommended stable release order:
 8. Tag `v1.0.0`.
 9. Confirm tag-triggered version consistency validation passes before approving protected publish environments.
 10. Approve protected publish environments only after reviewing generated artifacts.
-11. Update README with final NuGet install command, Zenodo DOI badge, and copyable citation block.
+11. Confirm or update README with final NuGet install command, Zenodo DOI badge, and copyable citation block.
 
 ## Rollback notes
 
@@ -228,14 +228,14 @@ Before creating a stable release:
 
 ## v1.0.0 blocker issue confirmation
 
-Before tagging `v1.0.0`, confirm all release-blocking issues tracked from parent issue #138 are closed, merged, or explicitly deferred with maintainer approval.
+Before tagging `v1.0.0`, confirm all release-blocking issues tracked from completed parent issue #138 and final closure tracker #271 are closed, merged, or explicitly deferred with maintainer approval.
 
 Minimum confirmation:
 
 - Parent issue #138 has no unresolved v1.0.0 blockers.
-- Every blocker issue referenced from #138 is either closed as completed or documented as deferred.
+- Final closure tracker #271 and its linked release-hardening issues are closed or explicitly deferred.
 - Deferred items do not affect package correctness, publication safety, security posture, citation metadata, or consumer smoke-test behavior.
-- The final release PR references #138 and summarizes the remaining release risk, if any.
+- The final release PR references #138 and #271 and summarizes the remaining release risk, if any.
 
 ## Maintainer review points for first public publication
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,7 +82,7 @@ Plaintext credentials are not allowed in workflow files, repository files, examp
 
 ## Package Signing and External Contributor Controls
 
-NuGet package signing is currently deferred for pre-`v1.0.0` releases and remains a release-readiness decision point until a project-controlled signing certificate, timestamping approach, signing owner, certificate storage process, and verification policy are documented.
+NuGet package author signing is deferred for `v1.0.0` while the repository remains solo-maintained and official package artifacts are produced only through the maintainer-controlled release workflow.
 
 Official package artifacts are produced only by the maintainer-controlled release workflow. External contributors do not publish NuGet packages directly and are not expected to sign generated `.nupkg` artifacts. If package signing is introduced later, release artifacts should be signed by a project-controlled certificate through the protected release workflow, not by individual contributors.
 
@@ -90,7 +90,7 @@ External contributor trust is handled separately from package signing. External 
 
 Revisit the package-signing decision when any of the following conditions occur:
 
-- Before publishing the stable `v1.0.0` NuGet package.
+- Before each stable NuGet package publication.
 - Before enabling fully automated package publication.
 - Before adding additional maintainers or package owners.
 - Before accepting external pull requests that affect workflows, package metadata, release automation, security policy, or template packaging.

--- a/docs/articles/project-structure.md
+++ b/docs/articles/project-structure.md
@@ -242,7 +242,7 @@ The goal is not only to test individual methods, but to protect the template's b
 
 ## Documentation and Repository Metadata
 
-The repository includes documentation and governance files because the template is intended to be reused, cited, reviewed, and eventually packaged.
+The repository includes documentation and governance files because the template is intended to be reused, cited, reviewed, packaged, and distributed as a stable `dotnet new` template.
 
 Important repository-level files include:
 

--- a/docs/articles/project-structure.md
+++ b/docs/articles/project-structure.md
@@ -8,53 +8,76 @@ The .NET Core Application Template is organized as a compact, production-oriente
 /
 ├── src/
 │   ├── ProjectTemplate.Web/
-│   │   └── ASP.NET Core host, startup composition, middleware, auth, UI endpoints, and web concerns
+│   │   └── ASP.NET Core host, startup composition, middleware, authentication, UI, API, health checks, and web-facing configuration
 │   │
 │   └── ProjectTemplate.Infrastructure/
-│       └── Infrastructure and data access concerns used by the web application
+│       └── Infrastructure, EF Core data access, persistence normalization, migrations, auditing, and provider-specific implementation details
 │
 ├── tests/
 │   └── ProjectTemplate.Web.Tests/
-│       └── Automated tests for startup, configuration, middleware, auth, and runtime behavior
+│       └── Automated tests for startup, configuration, middleware, authentication, authorization, data access, error handling, and runtime behavior
 │
 ├── docs/
 │   ├── adr/
 │   │   └── Architecture decision records
 │   ├── articles/
 │   │   └── DocFX conceptual documentation
+│   ├── examples/
+│   │   └── Safe configuration examples
 │   ├── images/
 │   │   └── Documentation and README images
 │   └── docfx.json
 │
+├── eng/
+│   ├── Assert-SecurityCriticalCoverage.ps1
+│   ├── security-critical-coverage.json
+│   ├── scaffold-manifest.default.json
+│   ├── scaffold-manifest.schema.json
+│   └── Validate-ScaffoldManifest.ps1
+│
+├── scripts/
+│   ├── migration.sql
+│   └── Validate-VersionConsistency.ps1
+│
 ├── .template.config/
 │   └── dotnet new template metadata
 │
-├── scripts/
-│   └── Utility scripts for setup, build, migration, or maintenance work
+├── .template.content/
+│   └── consumer scaffold overlay content, including generated README and configuration replacements
 │
 ├── .github/
 │   ├── workflows/
-│   │   └── GitHub Actions CI and documentation publishing workflows
+│   │   └── GitHub Actions CI, documentation, package, container, CodeQL, and release validation workflows
 │   ├── ISSUE_TEMPLATE/
 │   │   └── Issue templates
+│   ├── CODEOWNERS
 │   ├── dependabot.yml
 │   └── pull_request_template.md
 │
 ├── .dockerignore
 ├── .editorconfig
+├── .env.example
 ├── .gitattributes
 ├── .gitignore
 ├── ASSETS-LICENSES.md
 ├── CHANGELOG.md
 ├── CITATION.cff
+├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
+├── Directory.Build.props
+├── Directory.Packages.props
 ├── Dockerfile
 ├── docker-compose.yml
+├── global.json
 ├── LICENSE.txt
 ├── NetCoreApplicationTemplate.slnx
+├── NetCoreApplicationTemplate.Template.csproj
+├── PACKAGE-README.md
 ├── README.md
+├── RELEASE.md
 └── SECURITY.md
 ```
+
 
 ## Solution Projects
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -196,16 +196,16 @@ Docker runtime validation is intentionally limited to Linux runners. The goal is
 
 ## Distribution Direction
 
-The intended stable distribution model is a published NuGet template package installable with `dotnet new install`.
+The stable distribution model is a published NuGet template package installable with `dotnet new install`.
 
-Future stable usage is expected to follow this pattern:
+Stable usage follows this pattern:
 
 ```powershell
 dotnet new install CDCavell.NetCoreApplicationTemplate
 dotnet new netcoreapp-template -n ContosoSecurityPortal
 ```
 
-Clone-and-modify remains valid for source review, contribution, and direct customization. However, after package publishing is available, the NuGet template package should be treated as the primary stable distribution path for normal template consumers.
+Clone-and-modify remains valid for source review, contribution, and direct customization. However, the NuGet template package is the primary stable distribution path for normal template consumers.
 
 After the `v1.0.0` release, changes to the template short name, package identity, template parameters, symbols, or source-name replacement behavior should be reviewed as release-surface changes.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -108,6 +108,7 @@ The template intentionally exposes a small set of stable options for common scaf
 |:---|:---|:---|:---|
 | `--authProvider` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. Use `cookie` for the default cookie-authentication-ready baseline or `none` to generate the application with application authentication disabled by default. |
 | `--dbProvider` | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated data access mode. Use `sqlite` for the default local development configuration, `sqlserver` for the SQL Server provider configuration, or `none` to generate the application with EF Core data access disabled. |
+| `--skipRestore` | `false` | `true`, `false` | Skips the post-create NuGet restore action when set to `true`. |
 
 Example non-default scaffold:
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `0.5.9` |
+| Current package version | `1.0.0` |
 
 ## Consumer Scaffold Boundaries
 
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.0.5.9.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.0.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

Prepares the repository for the stable `v1.0.0` release by aligning version metadata, release documentation, NuGet package metadata, citation metadata, template packaging documentation, and consumer-facing README guidance.

This release branch promotes the project from the `0.5.x` hardening stream to the first stable `1.0.0` baseline.

## Changes

- Updated project/package version metadata to `1.0.0`.
- Added the `1.0.0` changelog entry.
- Updated NuGet package release notes for the stable release.
- Updated `CITATION.cff` for `1.0.0`, including release date, repository/documentation links, ORCID, and Zenodo DOI metadata.
- Removed repository citation metadata from the generated scaffold surface.
- Updated `PACKAGE-README.md` and template packaging docs to reflect the stable NuGet package experience.
- Added `--skipRestore` to documented template options.
- Refreshed `README.md` wording to remove stale pre-`1.0.0` language.
- Updated `RELEASE.md` to reflect the current `v1.0.0` release sequence and final closure tracking.
- Updated `SECURITY.md` package-signing language for the stable release posture.
- Updated project structure documentation to reflect the current repository layout, including `eng/`, `.template.content/`, package metadata, and release validation files.

## Validation

Local validation completed successfully:

- `dotnet build ./NetCoreApplicationTemplate.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true`
- `dotnet format ./NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`
- `dotnet test ./NetCoreApplicationTemplate.slnx --configuration Release --no-build --verbosity normal /p:ContinuousIntegrationBuild=true`
- `dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release --output ./artifacts/template-package /p:ContinuousIntegrationBuild=true`

Additional release-readiness checks reviewed:

- README reflects shipped template behavior.
- `PACKAGE-README.md` reflects NuGet package usage.
- `RELEASE.md` reflects the current release sequence.
- `docs/articles` reflect the current project layout and template packaging behavior.
- `CITATION.cff`, package metadata, repository links, and documentation links are consistent.
- Remaining supply-chain/security evidence is tracked under #276.

## Related Issues

- Closes #275
- Related to #271
- Related to #276
- Related to #278
- Parent readiness epic: #138