### PR TITLE
Release/1.0.1

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -133,6 +133,9 @@
       "path": "ProjectTemplate.slnx"
     },
     {
+      "path": "src/ProjectTemplate.Infrastructure/ProjectTemplate.Infrastructure.csproj"
+    },
+    {
       "path": "src/ProjectTemplate.Web/ProjectTemplate.Web.csproj"
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
-## 1.0.1 - 2026-06-30
+## 1.0.1 - 2026-06-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 1.0.1 - 2026-06-30
+
+### Added
+
+* Add the Infrastructure project to template primaryOutputs so Visual Studio loads all generated projects when creating a new solution from the package.
+
 ## 1.0.0 - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
 ## 1.0.1 - 2026-06-01
 
-### Added
+### Fixed
 
 * Add the Infrastructure project to template primaryOutputs so Visual Studio loads all generated projects when creating a new solution from the package.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "1.0.0"
+version: "1.0.1"
 date-released: "2026-06-01"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Stable 1.0.0 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <PackageReleaseNotes>Stable 1.0.1 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -23,7 +23,7 @@ dotnet new install CDCavell.NetCoreApplicationTemplate
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.0.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 1.0.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.0)__
+Current release: __[Release 1.0.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.1)__
 
-Tag: `v1.0.0`
+Tag: `v1.0.1`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.0.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.1. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -103,7 +103,28 @@ Then confirm:
 - README/package usage instructions match the published package behavior.
 - The generated app can be started locally using documented instructions.
 
-### 7. Container smoke validation
+### 7. Visual Studio template validation
+
+After package publication, validate that the template also works through Visual Studio's
+Create a new project experience.
+
+Minimum Visual Studio smoke test:
+
+1. Install the published package using `dotnet new install CDCavell.NetCoreApplicationTemplate`.
+2. Restart Visual Studio.
+3. Create a new project from `.NET Core Application Template`.
+4. Validate at least the following option combinations:
+   - `authProvider = cookie`, `dbProvider = sqlite`
+   - `authProvider = cookie`, `dbProvider = sqlserver`
+   - `authProvider = none`, `dbProvider = none`
+5. Confirm the generated solution loads all expected projects.
+6. Confirm restore and build succeed from Visual Studio.
+7. Confirm the generated solution can also build from the command line.
+
+For generated solutions, confirm project references resolve correctly and no generated
+project references a project that Visual Studio failed to load.
+
+### 8. Container smoke validation
 
 If containers are published for v1.0.0, validate them after publication:
 
@@ -116,7 +137,7 @@ If containers are published for v1.0.0, validate them after publication:
 
 Skip this section only when no container image is published for the release.
 
-### 8. Rollback and hotfix guidance
+### 9. Rollback and hotfix guidance
 
 Stable public artifacts should not be overwritten after publication.
 
@@ -130,7 +151,7 @@ Use this guidance for critical post-release issues:
 - If documentation is incorrect but package artifacts are valid, patch the documentation and note the correction in the next release notes when appropriate.
 - If a security issue is discovered after release, create a hotfix branch from the release tag, apply the minimum safe fix, run the full release gate, and publish a patch release.
 
-## NuGet package identity and publish gate
+## 10. NuGet package identity and publish gate
 
 The stable package identity is:
 
@@ -149,7 +170,7 @@ Recommended order:
 5. Review the generated `.nupkg` metadata before publishing to NuGet.org.
 6. Publish the first NuGet.org package only after manual approval.
 
-## Package signing and contributor trust
+## 11. Package signing and contributor trust
 
 NuGet package signing is deferred for `v1.0.0` unless a repository signing certificate, signing owner, timestamping approach, and signing policy are added before release.
 
@@ -161,7 +182,7 @@ The publish workflow keeps the manual approval gate in place so unsigned package
 
 Before each stable release, confirm that [`SECURITY.md`](SECURITY.md) still reflects the current package-signing posture and that any trigger condition requiring a signing-policy review has been evaluated.
 
-## Zenodo archival sequence
+## 12. Zenodo archival sequence
 
 Zenodo archives GitHub releases created after the GitHub integration is enabled. Enable integration before the DOI-bearing release.
 
@@ -175,7 +196,7 @@ Recommended order:
 6. Create the stable `v1.0.0` release only after the dry-run DOI metadata is accepted.
 7. Add the Zenodo DOI badge and copyable citation block to README after the DOI is available.
 
-## Final release order
+## 13. Final release order
 
 Recommended stable release order:
 

--- a/docs/articles/build-quality.md
+++ b/docs/articles/build-quality.md
@@ -122,7 +122,7 @@ These files are part of the consumer build contract because package versions and
 
 ## Coverage Policy
 
-The CI coverage gate is intentionally held at 75% for v1.0.0 as a minimum safety net. Contract-level integration tests protect advertised runtime behavior directly, while the global threshold prevents broad coverage regression without forcing low-value tests.
+The CI coverage gate is intentionally held at 75% for v1.0.1 as a minimum safety net. Contract-level integration tests protect advertised runtime behavior directly, while the global threshold prevents broad coverage regression without forcing low-value tests.
 
 Security-critical files also have a stricter file-level coverage gate. This second gate exists because global line coverage can hide concentrated risk in files responsible for error handling, request classification, identity resolution, audit attribution, security headers, forwarded headers, rate limiting, and persistence normalization.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `1.0.0` |
+| Current package version | `1.0.1` |
 
 ## Consumer Scaffold Boundaries
 
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.0.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

This PR prepares the `v1.0.1` patch release for `CDCavell.NetCoreApplicationTemplate`.

The release fixes a Visual Studio template creation issue where generated solutions could omit the Infrastructure project even though the Web project still referenced it. This caused restore/build failures when creating a new template application through Visual Studio with `authProvider = none` and `dbProvider = none`.

Changes include:

* Added `ProjectTemplate.Infrastructure.csproj` to `.template.config/template.json` `primaryOutputs`.
* Updated version metadata from `1.0.0` to `1.0.1`.
* Updated README, package README, citation metadata, and template packaging documentation for the `1.0.1` package version.
* Added Visual Studio template validation guidance to the release checklist.
* Added a `1.0.1` changelog entry documenting the Visual Studio template output fix.

## Validation

Recommended validation for this patch release:

* Run `./scripts/Validate-VersionConsistency.ps1`.
* Pack and install the generated `CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg`.
* Create a default scaffold with `dotnet new netcoreapp-template`.
* Create a scaffold with `--authProvider none --dbProvider none`.
* Confirm restore, build, and tests succeed for generated output.
* Confirm Visual Studio can create the template project and loads all expected projects, including Infrastructure.

Closes #280 