### PR TITLE
Release/1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 1.0.2 - 2026-06-09
+
+### Changed
+
+* Updated pinned GitHub Actions workflow dependencies used by CI, CodeQL analysis, documentation publishing, release automation, version consistency validation, container publishing, and template package publishing.
+* Updated `actions/checkout` from `6.0.2` to `6.0.3`.
+* Updated `actions/setup-dotnet` from `5.2.0` to `5.3.0`.
+* Updated `github/codeql-action` from `4.36.0` to `4.36.2`.
+
+### Maintenance
+
+* Normalized GitHub workflow file formatting after dependency updates without changing template source code, generated scaffold behavior, package metadata, or runtime application behavior.
+
+
 ## 1.0.1 - 2026-06-01
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "1.0.1"
-date-released: "2026-06-01"
+version: "1.0.2"
+date-released: "2026-06-09"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Stable 1.0.1 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <PackageReleaseNotes>Stable 1.0.2 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -23,7 +23,7 @@ dotnet new install CDCavell.NetCoreApplicationTemplate
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.2.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 1.0.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.1)__
+Current release: __[Release 1.0.2](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.2)__
 
-Tag: `v1.0.1`
+Tag: `v1.0.2`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.2.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.1. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.2. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/docs/articles/build-quality.md
+++ b/docs/articles/build-quality.md
@@ -122,7 +122,7 @@ These files are part of the consumer build contract because package versions and
 
 ## Coverage Policy
 
-The CI coverage gate is intentionally held at 75% for v1.0.1 as a minimum safety net. Contract-level integration tests protect advertised runtime behavior directly, while the global threshold prevents broad coverage regression without forcing low-value tests.
+The CI coverage gate is intentionally held at 75% for v1.0.2 as a minimum safety net. Contract-level integration tests protect advertised runtime behavior directly, while the global threshold prevents broad coverage regression without forcing low-value tests.
 
 Security-critical files also have a stricter file-level coverage gate. This second gate exists because global line coverage can hide concentrated risk in files responsible for error handling, request classification, identity resolution, audit attribution, security headers, forwarded headers, rate limiting, and persistence normalization.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -13,7 +13,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template short name | `netcoreapp-template` |
 | Template package ID | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `1.0.1` |
+| Current package version | `1.0.2` |
 
 ## Consumer Scaffold Boundaries
 
@@ -85,7 +85,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 ## Install the Template Package
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.1.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.2.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

Prepares the repository for the `v1.0.2` maintenance release of `CDCavell.NetCoreApplicationTemplate`.

This release keeps the stable `1.0.x` line current by documenting the latest GitHub Actions dependency updates and workflow maintenance changes. No template source code, generated scaffold behavior, package metadata, or runtime application behavior is changed.

## Changes

* Added the `1.0.2` changelog entry.
* Documented GitHub Actions dependency updates for:

  * `actions/checkout`
  * `actions/setup-dotnet`
  * `github/codeql-action`
* Noted workflow formatting normalization across CI, CodeQL, documentation, release, version consistency, container publishing, and template package publishing workflows.
* Classified the release as maintenance-only.

## Validation

Recommended validation for this patch release:

* Run `./scripts/Validate-VersionConsistency.ps1`.
* Confirm CI, CodeQL, version consistency, documentation publishing, and template package workflows continue to pass.
* Pack and install the generated `CDCavell.NetCoreApplicationTemplate.1.0.2.nupkg`.
* Create a default scaffold with `dotnet new netcoreapp-template`.
* Create a non-default scaffold with representative options such as `--authProvider none` and `--dbProvider sqlserver`.
* Restore, build, and test scaffolded output.

## Notes

This patch does not introduce consumer-facing template changes. It is intended to keep the release trail accurate and the GitHub Actions supply-chain baseline current.
