### PR TITLE
fix(deps): add SQLitePCLRaw e_sqlite3 bundle

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
+  "version": "1.0.4",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## [1.0.4] - 2026-06-22
+
+### Fixed
+
+* Added `SQLitePCLRaw.bundle_e_sqlite3` package reference to replace deprecated SQLite bundle usage.
+* Updated SQLite dependency path to use the supported bundled native SQLite provider.
+* Resolved dependency warning related to deprecated SQLite library usage.
+
+### Notes
+
+* This is a dependency maintenance release.
+* No application behavior, public APIs, or template structure were intentionally changed.
+
 ## 1.0.3 - 2026-06-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
-## [1.0.4] - 2026-06-22
+## 1.0.4 - 2026-06-22
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "1.0.3"
-date-released: "2026-06-15"
+version: "1.0.4"
+date-released: "2026-06-22"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,5 +34,6 @@
     <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 </Project>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Stable 1.0.3 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <PackageReleaseNotes>Stable 1.0.4 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -23,7 +23,7 @@ dotnet new install CDCavell.NetCoreApplicationTemplate
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.3.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.4.nupkg
 ```
 
 ## Generate a project

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 1.0.3](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.3)__
+Current release: __[Release 1.0.4](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.4)__
 
-Tag: `v1.0.3`
+Tag: `v1.0.4`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.3.nupkg
+dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.4.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.3. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.4. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/src/ProjectTemplate.Infrastructure/ProjectTemplate.Infrastructure.csproj
+++ b/src/ProjectTemplate.Infrastructure/ProjectTemplate.Infrastructure.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Condition="'$(EnableSourceLink)' == 'true'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
+++ b/src/ProjectTemplate.Web/ProjectTemplate.Web.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="Sustainsys.Saml2.AspNetCore2" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
+++ b/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

This PR prepares the `NetCoreApplicationTemplate` project for release `1.0.4`.

The release updates package/version metadata, documentation references, and release notes while also adding the supported `SQLitePCLRaw.bundle_e_sqlite3` package reference to replace deprecated SQLite bundle usage.

## Changes

* Updated project version metadata from `1.0.3` to `1.0.4`.
* Updated assembly and file versions to `1.0.4.0`.
* Updated template package metadata and release notes for `1.0.4`.
* Added the `1.0.4` entry to `CHANGELOG.md`.
* Updated `README.md` and `PACKAGE-README.md` release/package references from `1.0.3` to `1.0.4`.
* Updated `CITATION.cff` and `.zenodo.json` metadata for the new release.
* Added `SQLitePCLRaw.bundle_e_sqlite3` as a centrally managed package version.
* Added `SQLitePCLRaw.bundle_e_sqlite3` package references where SQLite support is required.

## Validation

* Confirmed the release metadata is aligned for `1.0.4`.
* Confirmed documentation references now point to the `1.0.4` package and release tag.
* Confirmed the SQLite dependency update is dependency-only and does not intentionally change application behavior, public APIs, or template structure.

## Notes

This is a patch-level maintenance release focused on dependency modernization and release metadata alignment.
