### PR TITLE
chore: prepare NetCoreApplicationTemplate 2.0.0 release

### DIFF
--- a/.github/workflows/publish-template-package.yml
+++ b/.github/workflows/publish-template-package.yml
@@ -119,14 +119,22 @@ jobs:
             echo "url=https://api.nuget.org/v3/index.json" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: NuGet login
+        if: steps.source.outputs.url == 'https://api.nuget.org/v3/index.json'
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: nuget-login
+        with:
+          user: CDCavell
+          
       - name: Publish template package
         shell: bash
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_TRUSTED_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_SOURCE: ${{ steps.source.outputs.url }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
 
           package=$(find ./artifacts/template-package -maxdepth 1 -name '*.nupkg' | head -n 1)
 
@@ -135,13 +143,13 @@ jobs:
             exit 1
           fi
 
-          api_key="$NUGET_API_KEY"
+          api_key="$NUGET_TRUSTED_API_KEY"
           if [ "$PACKAGE_SOURCE" = "https://nuget.pkg.github.com/cdcavell/index.json" ]; then
             api_key="$GITHUB_TOKEN"
           fi
 
           if [ -z "$api_key" ]; then
-            echo "Package source requires an API key. Configure NUGET_API_KEY or publish to GitHub Packages with GITHUB_TOKEN."
+            echo "Package source requires an API key. Configure NUGET_TRUSTED_API_KEY or publish to GitHub Packages with GITHUB_TOKEN."
             exit 1
           fi
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 2.0.0 - 2026-06-25
+
+### Breaking Changes
+
+* Renamed the NuGet package from `CDCavell.NetCoreApplicationTemplate` to `NetCoreApplicationTemplate`.
+* Consumers should update package installation commands and references to use the new package ID.
+
+### Changed
+
+* Updated the public NuGet package identity to the simplified project-centered name `NetCoreApplicationTemplate`.
+* Updated package metadata to align with the new package ID.
+* Updated release metadata for the `2.0.0` package line.
+* Switched NuGet.org publication to **NuGet Trusted Publishing**, removing the need for a long-lived NuGet API key for public package publishing.
+* Updated the package publishing workflow to use GitHub Actions OIDC authentication for NuGet.org publishing.
+
+### Migration Notes
+
+Replace package installation commands such as:
+
+```powershell
+dotnet new install CDCavell.NetCoreApplicationTemplate
+```
+
+with:
+
+```powershell
+dotnet new install NetCoreApplicationTemplate
+```
+
+If the old package is already installed locally, uninstall it first:
+
+```powershell
+dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+dotnet new install NetCoreApplicationTemplate
+```
+
+### Notes
+
+The previous `CDCavell.NetCoreApplicationTemplate` package should be treated as the legacy package identity and deprecated on NuGet with alternate package guidance pointing to `NetCoreApplicationTemplate`.
+
+This release does not change the project’s core purpose: providing a production-oriented ASP.NET Core application template with structured logging, security headers, forwarded headers, rate limiting, centralized error handling, authentication-ready architecture, and EF Core-ready structure.
+
 ## 1.0.4 - 2026-06-22
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "1.0.4"
+version: "2.0.0"
 date-released: "2026-06-22"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>1.0.4.0</AssemblyVersion>
-    <FileVersion>1.0.4.0</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageId>CDCavell.NetCoreApplicationTemplate</PackageId>
+    <PackageId>NetCoreApplicationTemplate</PackageId>
     <Title>.NET Core Application Template</Title>
     <Authors>Christopher D. Cavell</Authors>
     <Description>Production-oriented ASP.NET Core application template with structured logging, security headers, forwarded headers, rate limiting, centralized error handling, authentication-ready architecture, and EF Core-ready structure.</Description>
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Stable 1.0.4 release of the NetCoreApplicationTemplate dotnet new template, including the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <PackageReleaseNotes>Stable 2.0.0 release of the NetCoreApplicationTemplate dotnet new template. This release moves the public NuGet package ID from CDCavell.NetCoreApplicationTemplate to NetCoreApplicationTemplate while preserving the production-oriented ASP.NET Core baseline, template package validation, consumer scaffold support, documentation, coverage gates, and release-readiness hardening.</PackageReleaseNotes>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -18,7 +18,7 @@ This README is intended for NuGet package consumers. The full repository README 
 Install the template package from NuGet:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate
+dotnet new install NetCoreApplicationTemplate::2.0.0
 ```
 
 ## For local package validation, install a packed package directly:
@@ -81,7 +81,7 @@ dotnet test --configuration Release
 
 Install the newer package version with the same package identity:
 ```powershell
-dotnet new install NetCoreApplicationTemplate
+dotnet new install NetCoreApplicationTemplate::2.0.0
 ```
 
 ## Uninstall

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -18,12 +18,12 @@ This README is intended for NuGet package consumers. The full repository README 
 Install the template package from NuGet:
 
 ```powershell
-dotnet new install CDCavell.NetCoreApplicationTemplate
+dotnet new install NetCoreApplicationTemplate
 ```
 
 ## For local package validation, install a packed package directly:
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.4.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.0.0.nupkg
 ```
 
 ## Generate a project
@@ -81,12 +81,12 @@ dotnet test --configuration Release
 
 Install the newer package version with the same package identity:
 ```powershell
-dotnet new install CDCavell.NetCoreApplicationTemplate
+dotnet new install NetCoreApplicationTemplate
 ```
 
 ## Uninstall
 ```powershell
-dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+dotnet new uninstall NetCoreApplicationTemplate
 ```
 
 ## Additional resources

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -8,7 +8,7 @@ This README is intended for NuGet package consumers. The full repository README 
 
 | Item | Value |
 |---|---|
-| Package ID | `CDCavell.NetCoreApplicationTemplate` |
+| Package ID | `NetCoreApplicationTemplate` |
 | Template short name | `netcoreapp-template` |
 | Default authentication provider | `cookie` |
 | Default data provider | `sqlite` |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ The scaffolded consumer output intentionally includes:
 
 The scaffolded consumer output intentionally excludes repository-maintainer content such as `.github/`, DocFX documentation source, ADRs, release-management files, citation metadata, contribution policy, security policy, and repository badges.
 
+### Install from NuGet
+
+Install the published template package:
+
+```powershell
+dotnet new install NetCoreApplicationTemplate::2.0.0
+```
+
 ### Pack and Install Locally
 
 Pack the template package:
@@ -225,7 +233,7 @@ The non-default scaffold preserves the template's core guardrails, including str
 Update the installed template by installing a newer package version:
 
 ```powershell
-dotnet new install <path-or-package-id-for-new-version>
+dotnet new install NetCoreApplicationTemplate::2.0.0
 ```
 
 Uninstall the template package:
@@ -422,7 +430,7 @@ Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.0.0. Zenodo. MIT Li
 
 ## Roadmap
 
-The project is a reusable .NET application template with a stable `1.0.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
+The project is a reusable .NET application template with a stable `2.0.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
 
 See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE.txt)
 [![GitHub Release](https://img.shields.io/github/v/release/cdcavell/NetCoreApplicationTemplate?display_name=tag)](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/latest)
-[![NuGet](https://img.shields.io/nuget/v/CDCavell.NetCoreApplicationTemplate?label=NuGet)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/CDCavell.NetCoreApplicationTemplate?label=downloads)](https://www.nuget.org/packages/CDCavell.NetCoreApplicationTemplate)
+[![NuGet](https://img.shields.io/nuget/v/NetCoreApplicationTemplate?label=NuGet)](https://www.nuget.org/packages/NetCoreApplicationTemplate)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/NetCoreApplicationTemplate?label=downloads)](https://www.nuget.org/packages/NetCoreApplicationTemplate)
 [![Zenodo DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20373042-blue)](https://doi.org/10.5281/zenodo.20373042)
 
 A reusable, production-oriented .NET application template designed to provide a secure, maintainable, and extensible baseline for building ASP.NET Core applications.
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 1.0.4](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v1.0.4)__
+Current release: __[Release 2.0.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.0.0)__
 
-Tag: `v1.0.4`
+Tag: `v2.0.0`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/CDCavell.NetCoreApplicationTemplate.1.0.4.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.1.0.4.nupkg
 ```
 
 Generate a consumer project:
@@ -231,7 +231,7 @@ dotnet new install <path-or-package-id-for-new-version>
 Uninstall the template package:
 
 ```powershell
-dotnet new uninstall CDCavell.NetCoreApplicationTemplate
+dotnet new uninstall NetCoreApplicationTemplate
 ```
 
 ### Local Repository Install

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.1.0.4.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.0.0.nupkg
 ```
 
 Generate a consumer project:
@@ -417,7 +417,7 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 1.0.4. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.0.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap

--- a/scripts/Validate-VersionConsistency.ps1
+++ b/scripts/Validate-VersionConsistency.ps1
@@ -164,7 +164,7 @@ if (-not [string]::IsNullOrWhiteSpace($templatePackageVersion)) {
 
 $escapedVersion = [regex]::Escape($ExpectedVersion)
 $escapedReleaseTag = [regex]::Escape('`v' + $ExpectedVersion + '`')
-$escapedPackageId = [regex]::Escape('CDCavell.NetCoreApplicationTemplate')
+$escapedPackageId = [regex]::Escape('NetCoreApplicationTemplate')
 
 $readme = Get-RequiredFileText 'README.md'
 Assert-Matches $readme "Current release:\s*__\[Release $escapedVersion\]\([^\)]*/releases/tag/v$escapedVersion\)__" 'README current-release block'
@@ -207,7 +207,7 @@ if (-not [string]::IsNullOrWhiteSpace($PackageDirectory)) {
     }
     else {
         $packages = @(Get-ChildItem -LiteralPath $packageDirectoryPath -Filter '*.nupkg' -File)
-        $expectedPackageName = "CDCavell.NetCoreApplicationTemplate.$ExpectedVersion.nupkg"
+        $expectedPackageName = "NetCoreApplicationTemplate.$ExpectedVersion.nupkg"
         $matchingPackages = @($packages | Where-Object { $_.Name -eq $expectedPackageName })
         $driftedPackages = @($packages | Where-Object { $_.Name -ne $expectedPackageName })
 


### PR DESCRIPTION
## Summary

This PR prepares **NetCoreApplicationTemplate** for the **2.0.0** release.

The release renames the public NuGet package from `CDCavell.NetCoreApplicationTemplate` to `NetCoreApplicationTemplate` and updates the publishing workflow to use **NuGet Trusted Publishing** for NuGet.org publication.

Because the public package ID changed, this is treated as a breaking release.

## Changes

* Renamed the NuGet package ID from `CDCavell.NetCoreApplicationTemplate` to `NetCoreApplicationTemplate`.
* Updated package metadata for the `2.0.0` release.
* Updated release notes / changelog guidance for the new package identity.
* Switched NuGet.org publishing to NuGet Trusted Publishing.
* Added GitHub Actions OIDC support for trusted publishing.
* Removed dependency on a long-lived NuGet API key for NuGet.org publication.
* Preserved the project’s existing template purpose and functionality.

## Breaking Changes

Consumers should install the new package ID going forward.

Replace:

```powershell
dotnet new install CDCavell.NetCoreApplicationTemplate
```

with:

```powershell
dotnet new install NetCoreApplicationTemplate
```

If the previous package is already installed locally:

```powershell
dotnet new uninstall CDCavell.NetCoreApplicationTemplate
dotnet new install NetCoreApplicationTemplate
```

## Why

The simplified package ID gives the project a cleaner, project-centered public identity and avoids tying the public NuGet package name to the maintainer’s personal namespace.

NuGet Trusted Publishing also improves the release process by replacing long-lived NuGet API keys with GitHub Actions OIDC-based trusted publication.

## Notes

After the new `NetCoreApplicationTemplate` package is published, the previous `CDCavell.NetCoreApplicationTemplate` package should be deprecated on NuGet as a legacy package with alternate package guidance pointing to `NetCoreApplicationTemplate`.
