### PR TITLE
Document middleware ordering rationale

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,9 @@
 ## Validation
 
 - [ ] Documentation-only change.
-- [ ] Ran `dotnet build dotnet restore NetCoreApplicationTemplate.slnx --configuration Release`.
-- [ ] Ran `dotnet test dotnet restore NetCoreApplicationTemplate.slnx --configuration Release`.
-- [ ] Ran `dotnet format dotnet restore NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
+- [ ] Ran `dotnet build NetCoreApplicationTemplate.slnx --configuration Release`.
+- [ ] Ran `dotnet test NetCoreApplicationTemplate.slnx --configuration Release`.
+- [ ] Ran `dotnet format NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
 - [ ] Ran `dotnet tool run docfx -- .\docs\docfx.json`.
 - [ ] Not applicable / explained below.
 

--- a/docs/adr/0002-use-centralized-application-middleware-pipeline.md
+++ b/docs/adr/0002-use-centralized-application-middleware-pipeline.md
@@ -25,6 +25,63 @@ Use a centralized application middleware pipeline extension for template-owned m
 
 The application startup code delegates template-owned middleware registration to a central pipeline extension. Feature-specific middleware can still be implemented in focused extension methods, but their relative ordering is controlled from the centralized pipeline.
 
+The current baseline is implemented by `UseApplicationPipeline()` in `src/ProjectTemplate.Web/Extensions/PipelineExtensions.cs`.
+
+## Ordering Invariants
+
+The following ordering rules are intentional. They should not be changed casually because moving one step can affect request identity, logging accuracy, error handling, security posture, or endpoint behavior.
+
+1. **Forwarded headers must run before request-dependent middleware.**
+   Reverse proxy and load-balancer headers need to be applied before middleware that reads scheme, host, path base, remote IP, or client IP. This keeps logging, redirects, rate-limiting decisions, generated URLs, and security decisions aligned with the externally observed request.
+
+2. **Structured request logging should run after forwarded headers and near the start of the pipeline.**
+   Request logs should capture the corrected request identity while still wrapping most downstream behavior. Moving logging later can hide failures that occur before the logging middleware is reached.
+
+3. **Centralized exception and status-code handling should wrap most application behavior.**
+   Error handling belongs early enough to catch downstream exceptions and normalize error responses. Moving it after endpoint execution, authentication, authorization, or custom business middleware would reduce the protection provided by the centralized failure path.
+
+4. **Security headers should be applied before normal response-producing middleware.**
+   Security headers should be available on ordinary application responses and many error responses. Moving security headers late can miss responses that are generated earlier in the pipeline.
+
+5. **HTTPS redirection should run before routing and endpoint execution.**
+   Redirect behavior should be decided before endpoint-specific work runs. It also relies on forwarded-header correction being applied first when the application is hosted behind a reverse proxy or TLS-terminating load balancer.
+
+6. **Static files should remain before routing unless endpoint-aware static-file behavior is intentionally introduced.**
+   The template uses the conventional static-file placement for Razor Pages/MVC UI assets. Moving static files after authentication or authorization changes whether static assets are protected by default and should be treated as a deliberate behavior change.
+
+7. **Routing must run before endpoint-aware middleware.**
+   CORS, rate limiting, authentication, and authorization may depend on endpoint metadata. Routing establishes the selected endpoint context that those components use.
+
+8. **CORS should run after routing and before authentication/authorization.**
+   This placement lets endpoint metadata influence CORS behavior while still allowing cross-origin preflight handling before authentication challenges or authorization failures are produced.
+
+9. **Rate limiting should run after routing when endpoint-specific policies are used.**
+   Endpoint-aware rate-limiting policies require routing metadata. Moving rate limiting before routing changes the policy surface to mostly global behavior.
+
+10. **Authentication must run before authorization.**
+    Authorization decisions require the user principal created by authentication. Reversing these calls can cause valid users to appear anonymous to authorization policy evaluation.
+
+11. **Controller and Razor Page endpoint mapping should remain at the end of the template-owned pipeline.**
+    Endpoint mapping should occur after the middleware that prepares request identity, error behavior, security headers, routing metadata, rate limiting, and authorization behavior.
+
+12. **Health checks are mapped explicitly from `Program.cs`.**
+    `Program.cs` calls `MapApplicationHealthChecks()` after `UseApplicationPipeline()` to keep health-check endpoint registration visible at startup. Consumers that add custom health behavior should preserve the intended health-check access model and avoid accidentally placing health endpoints behind unrelated UI or business authorization requirements unless that is intentional.
+
+## Review Guidance for Future Changes
+
+Before changing the pipeline order, reviewers should ask:
+
+- Does this change alter which scheme, host, path base, or client IP downstream middleware sees?
+- Does it change whether centralized error handling wraps a failure path?
+- Does it change whether security headers are emitted on normal, redirected, static-file, error, or endpoint responses?
+- Does it move endpoint-aware middleware before routing?
+- Does it change CORS preflight behavior?
+- Does it change which requests are rate limited before authentication or authorization?
+- Does it alter whether health-check endpoints remain reachable by the intended callers?
+- Does it require updates to integration tests, documentation, or deployment guidance?
+
+Pipeline changes that affect any of those questions should be treated as behavior changes, not simple refactoring.
+
 ## Consequences
 
 Positive consequences:

--- a/docs/articles/middleware.md
+++ b/docs/articles/middleware.md
@@ -2,6 +2,10 @@
 
 The application centralizes standard middleware ordering through `UseApplicationPipeline()` so `Program.cs` remains focused on application startup and service registration.
 
+The detailed architecture decision is recorded in [ADR-0002: Use Centralized Application Middleware Pipeline](../adr/0002-use-centralized-application-middleware-pipeline.md).
+
+## Baseline Order
+
 The pipeline order is:
 
 1. Forwarded headers
@@ -19,3 +23,39 @@ The pipeline order is:
 13. Controller and Razor Page endpoint mapping
 
 This order keeps proxy correction early, request logging close to the beginning of the request, error handling ahead of most application behavior, and endpoint-specific features such as CORS and rate limiting after routing.
+
+## Order-Sensitive Invariants
+
+The pipeline is intentionally ordered around a few security and behavior invariants.
+
+| Pipeline area | Why the order matters |
+| --- | --- |
+| Forwarded headers | Reverse proxy correction must happen before middleware reads scheme, host, path base, remote IP, or client IP. This keeps request logging, HTTPS redirection, generated URLs, and rate-limiting decisions aligned with the externally observed request. |
+| Request logging | Logging runs after forwarded-header correction so logs capture the corrected request identity, but still early enough to wrap most downstream behavior. |
+| Error handling and Problem Details | Centralized exception and status-code handling should wrap normal application behavior so failures collapse into consistent, safe responses. |
+| Security headers | Security headers should be applied before ordinary response-producing middleware so normal responses and many error responses carry the configured hardening headers. |
+| HTTPS redirection | HTTPS enforcement should run before routing and endpoint execution, after forwarded headers have corrected proxy-terminated HTTPS requests. |
+| Static files | Static assets are served before routing using the conventional Razor Pages/MVC placement. Moving them behind authentication or authorization changes static asset exposure and should be intentional. |
+| Routing | Routing establishes endpoint metadata used by later endpoint-aware middleware. |
+| CORS | CORS runs after routing and before authentication/authorization so endpoint metadata can influence CORS behavior and preflight requests are not accidentally converted into auth failures. |
+| Rate limiting | Rate limiting runs after routing so endpoint-specific policies can participate. Moving it before routing changes the policy surface toward global limiting only. |
+| Authentication and authorization | Authentication must run before authorization so policy checks evaluate the authenticated principal rather than an anonymous request. |
+| Endpoint mapping | Controller and Razor Page endpoint mapping remains at the end of the template-owned pipeline. |
+
+## Health Checks
+
+`Program.cs` maps health-check endpoints with `MapApplicationHealthChecks()` immediately after `UseApplicationPipeline()`.
+
+Health-check mapping is kept visible in startup because production deployments often treat health endpoints differently from UI or business endpoints. Consumers that adjust health checks should preserve the intended access model and avoid accidentally putting liveness/readiness checks behind unrelated UI or business authorization requirements unless that is deliberate.
+
+## Adding Custom Middleware
+
+When adding custom middleware, use the invariant that describes the behavior the middleware depends on:
+
+- Middleware that depends on corrected proxy information should run after forwarded headers.
+- Middleware that should be covered by centralized exception handling should run after the error-handling middleware.
+- Middleware that depends on endpoint metadata should run after routing.
+- Middleware that makes identity or policy decisions should normally run after authentication and before or during authorization-aware endpoint execution.
+- Middleware that emits response headers should be reviewed against redirects, static files, error responses, and endpoint responses to confirm where those headers should appear.
+
+Pipeline changes that alter request identity, error handling coverage, security-header coverage, CORS preflight behavior, rate-limiting policy selection, authorization behavior, or health-check reachability should be treated as behavior changes and reviewed accordingly.

--- a/src/ProjectTemplate.Web/Extensions/PipelineExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/PipelineExtensions.cs
@@ -5,7 +5,7 @@ namespace ProjectTemplate.Web.Extensions;
 
 /// <summary>
 /// Provides extension methods to configure the application's middleware pipeline
-/// with a predefined ordering suitable for this template.
+/// with a predefined, order-sensitive sequence suitable for this template.
 /// </summary>
 public static class PipelineExtensions
 {
@@ -19,6 +19,9 @@ public static class PipelineExtensions
     /// <returns>The same <see cref="WebApplication"/> instance for chaining.</returns>
     public static WebApplication UseApplicationPipeline(this WebApplication app)
     {
+        // Keep this sequence aligned with ADR-0002 and the middleware documentation.
+        // Move order-sensitive middleware only after reviewing the documented invariants.
+
         // 1. Proxy/load balancer correction must happen early.
         app.UseApplicationForwardedHeaders();
 
@@ -58,4 +61,3 @@ public static class PipelineExtensions
         return app;
     }
 }
-


### PR DESCRIPTION
## Summary

- Expands ADR-0002 with middleware ordering invariants for forwarded headers, logging, error handling, security headers, HTTPS redirection, routing, CORS, rate limiting, authentication, authorization, endpoint mapping, and health checks.
- Expands the Middleware Pipeline documentation with a baseline order table, health-check guidance, and custom middleware placement guidance.
- Adds a concise pointer comment in `UseApplicationPipeline()` so future edits review ADR-0002 before moving order-sensitive middleware.

## Validation

- [x] Documentation-only change.
- [x] Ran `dotnet build NetCoreApplicationTemplate.slnx --configuration Release`.
```bash
Restore complete (2.1s)
  ProjectTemplate.Infrastructure net10.0 succeeded (7.3s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (10.8s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (10.2s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll

Build succeeded in 30.2s
```
- [x] Ran `dotnet test NetCoreApplicationTemplate.slnx --configuration Release`.
```bash
Restore complete (1.1s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.3s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.9s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.0s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.9)
[xUnit.net 00:00:04.15]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:05.21]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:05.70]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:30.19]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (34.6s)

Test summary: total: 279, failed: 0, succeeded: 279, skipped: 0, duration: 34.6s
Build succeeded in 38.5s
```
- [x] Ran `dotnet format NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
- [x] Ran `dotnet tool run docfx -- .\docs\docfx.json`.
- [x] Not applicable / explained below.

Validation note: Changes are limited to Markdown documentation and non-functional comments. CI/DocFX should validate the branch after PR creation.

## Issue Link

Closes #305

## Notes

No runtime behavior changes are intended. The existing middleware sequence is preserved.