### PR TITLE
Short-circuit no-op SaveChanges calls

### DIFF
--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -85,6 +85,11 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
+        if (!ChangeTracker.HasChanges())
+        {
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+
         ApplyPersistedStringCanonicalization();
         ApplyLookupStringNormalization();
         ApplyTimestampNormalization();
@@ -117,6 +122,13 @@ public sealed partial class ApplicationDbContext(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
+        if (!ChangeTracker.HasChanges())
+        {
+            return await base.SaveChangesAsync(
+                acceptAllChangesOnSuccess,
+                cancellationToken).ConfigureAwait(false);
+        }
+
         ApplyPersistedStringCanonicalization();
         ApplyLookupStringNormalization();
         ApplyTimestampNormalization();

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSaveHookBranchCoverageTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSaveHookBranchCoverageTests.cs
@@ -117,6 +117,36 @@ public sealed class ApplicationDbContextSaveHookBranchCoverageTests
     }
 
     [Fact]
+    public async Task SaveChanges_UnchangedEntity_DoesNotCreateAuditRecordOrChangeStamp()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        Guid accountId = await SeedExternalLoginAccountAsync(
+            connection,
+            providerName: "Microsoft",
+            providerUserId: "unchanged-sync-user",
+            displayName: "Unchanged Sync User",
+            email: "unchanged.sync@example.com");
+
+        await using ApplicationDbContext context = CreateContext(connection, auditingEnabled: true);
+
+        ExternalLoginAccount account = await context.ExternalLoginAccounts
+            .SingleAsync(item => item.Id == accountId, TestContext.Current.CancellationToken);
+
+        string originalStamp = account.ConcurrencyStamp;
+
+        int result = context.SaveChanges();
+
+        Assert.Equal(0, result);
+        Assert.Equal(originalStamp, account.ConcurrencyStamp);
+
+        int auditRecordCount = await context.AuditRecords
+            .CountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, auditRecordCount);
+    }
+
+    [Fact]
     public async Task SaveChangesAsync_UnchangedEntity_DoesNotCreateAuditRecordOrChangeStamp()
     {
         await using SqliteConnection connection = await CreateOpenConnectionAsync();


### PR DESCRIPTION
## Summary

- Adds early `ChangeTracker.HasChanges()` checks to `ApplicationDbContext.SaveChanges(...)` and `SaveChangesAsync(...)`.
- Returns through EF Core base save behavior immediately when there are no tracked changes.
- Preserves canonicalization, lookup normalization, timestamp normalization, concurrency stamp updates, auditing, and concurrency handling for real changes.
- Adds explicit sync no-op save coverage while retaining existing async no-op and changed-entity behavior coverage.

## Validation

- [ ] Ran `dotnet build NetCoreApplicationTemplate.slnx --configuration Release`.
- [ ] Ran `dotnet test NetCoreApplicationTemplate.slnx --configuration Release`.
- [ ] Ran `dotnet format NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
- [ ] Ran `dotnet tool run docfx -- .\docs\docfx.json`.
- [x] Not run / explained below.

Validation note: Changes were made through the GitHub connector, so I could not execute the repository test suite locally from this environment. The PR adds focused test coverage for the new sync no-op path and relies on existing async no-op plus changed-entity save-hook tests.

## Issue Link

Closes #298

## Notes

This is a minor performance/cleanup change. No transaction behavior is changed for real data modifications.