### PR TITLE
Add audit storage seam

### DIFF
--- a/.template.content/src/ProjectTemplate.Web/appsettings.json
+++ b/.template.content/src/ProjectTemplate.Web/appsettings.json
@@ -222,7 +222,8 @@
       "Provider": "TemplateDataProvider",
       "ConnectionStringName": "TemplateDataConnectionStringName",
       "Auditing": {
-        "Enabled": true
+        "Enabled": true,
+        "StorageMode": "Local"
       }
     },
     "ApiVersioning": {

--- a/docs/articles/data-access.md
+++ b/docs/articles/data-access.md
@@ -28,7 +28,8 @@ Data access behavior is configured under `ProjectTemplate:DataAccess`:
     "Provider": "Sqlite",
     "ConnectionStringName": "ApplicationDatabase",
     "Auditing": {
-      "Enabled": true
+      "Enabled": true,
+      "StorageMode": "Local"
     }
   }
 }
@@ -40,6 +41,7 @@ The configuration values are:
 |`Provider`|Selects the data access mode. Supported values are `Sqlite`, `SqlServer`, `None`, and `Disabled`. The default local development provider is `Sqlite`.|
 |`ConnectionStringName`|Identifies which named connection string should be resolved from `ConnectionStrings` when data access is enabled. This value is not required when `Provider` is `None` or `Disabled`.|
 |`Auditing:Enabled`|Enables or disables EF Core audit record creation during `SaveChanges` and `SaveChangesAsync` when EF Core data access is enabled.|
+|`Auditing:StorageMode`|Selects the audit storage path. The built-in default is `Local`. `Outbox` and `ExternalSink` are extension modes for consuming applications that register a custom `IApplicationAuditStore`.|
 
 By default, the application uses:
 
@@ -47,6 +49,7 @@ By default, the application uses:
 ProjectTemplate:DataAccess:Provider = Sqlite
 ProjectTemplate:DataAccess:ConnectionStringName = ApplicationDatabase
 ProjectTemplate:DataAccess:Auditing:Enabled = true
+ProjectTemplate:DataAccess:Auditing:StorageMode = Local
 ```
 
 With the default configuration, the application resolves:
@@ -226,13 +229,14 @@ Audit records may include:
 - Application context
 - UTC timestamp
 
-Auditing is enabled by default:
+Auditing is enabled by default and uses local audit storage by default:
 
 ```json
 "ProjectTemplate": {
   "DataAccess": {
     "Auditing": {
-      "Enabled": true
+      "Enabled": true,
+      "StorageMode": "Local"
     }
   }
 }
@@ -249,11 +253,50 @@ To disable audit record creation:
 }
 ```
 
-When the application starts, the data access startup log records the configured provider, connection string name, and EF Core auditing status. If data access is disabled, the startup log reports that EF Core services were not registered.
+When the application starts, the data access startup log records the configured provider, connection string name, EF Core auditing status, and audit storage mode. If data access is disabled, the startup log reports that EF Core services were not registered.
 
-When auditing is enabled, audit records are written to the application database. The template does not include automatic pruning, retention, archival, legal hold, masking, export, or purge behavior for audit records.
+When auditing is enabled with `StorageMode` set to `Local`, audit records are written to the application database through the local EF Core audit record table. The template does not include automatic pruning, retention, archival, legal hold, masking, export, or purge behavior for audit records.
 
 Consuming applications are responsible for deciding how audit records are retained, archived, masked, purged, or moved to long-term storage. Before enabling auditing in production, review whether audited values may contain sensitive or regulated data.
+
+### Audit Storage Extension Path
+
+The template owns a small audit storage seam through `IApplicationAuditStore`.
+
+`LocalApplicationAuditStore` is the built-in default implementation. It appends audit records to `ApplicationDbContext.AuditRecords` and leaves persistence under the existing `ApplicationDbContext.SaveChanges` / `SaveChangesAsync` flow.
+
+Supported storage mode names are:
+
+|Storage mode|Behavior|
+|:--|:--|
+|`Local`|Built-in default. Audit records are stored in the application database through the local EF Core audit record table.|
+|`Outbox`|Extension mode for applications that want to capture audit records into an outbox table or durable handoff before later export. A custom `IApplicationAuditStore` registration is required.|
+|`ExternalSink`|Extension mode for applications that want to send or adapt audit records to an external sink, governance package, SIEM pipeline, or companion package such as AsiBackbone. A custom `IApplicationAuditStore` registration is required.|
+
+A custom audit store can be registered in dependency injection before or after the template's data-access registration. The last registered `IApplicationAuditStore` wins under normal ASP.NET Core dependency injection behavior.
+
+For non-local modes, provide a custom store intentionally:
+
+```csharp
+services.AddScoped<IApplicationAuditStore, MyApplicationAuditStore>();
+```
+
+Then configure the desired mode:
+
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Auditing": {
+      "Enabled": true,
+      "StorageMode": "ExternalSink"
+    }
+  }
+}
+```
+
+The local mode is the safest default because audit records are captured through the same EF Core save pipeline as the application data. Outbox and external sink modes create a scaling boundary, but the consuming application owns failure handling, retry behavior, delivery guarantees, sensitive-data minimization, retention, and whether audit writes should block the primary data save.
+
+Use an outbox-style store when audit durability should remain local first but export can happen later. Use an external sink adapter when another package or platform owns the downstream governance/audit workflow.
 
 ## Persisted String Canonicalization
 

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -147,7 +147,8 @@ public sealed partial class ApplicationDbContext(
                     cancellationToken)).ConfigureAwait(false);
         }
 
-        List<AuditEntry> auditEntries = OnBeforeSaveChanges();
+        List<AuditEntry> auditEntries = await OnBeforeSaveChangesAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         int result = await SaveChangesWithConcurrencyHandlingAsync(
             () => base.SaveChangesAsync(
@@ -278,6 +279,32 @@ public sealed partial class ApplicationDbContext(
 
     private List<AuditEntry> OnBeforeSaveChanges()
     {
+        List<AuditEntry> auditEntries = CreateAuditEntries();
+
+        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
+        {
+            _auditStore.Append(this, auditEntry.ToAuditRecord());
+        }
+
+        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
+    }
+
+    private async Task<List<AuditEntry>> OnBeforeSaveChangesAsync(CancellationToken cancellationToken)
+    {
+        List<AuditEntry> auditEntries = CreateAuditEntries();
+
+        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
+        {
+            await _auditStore
+                .AppendAsync(this, auditEntry.ToAuditRecord(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
+    }
+
+    private List<AuditEntry> CreateAuditEntries()
+    {
         ChangeTracker.DetectChanges();
         var auditEntries = new List<AuditEntry>();
         foreach (EntityEntry entry in ChangeTracker.Entries())
@@ -337,14 +364,7 @@ public sealed partial class ApplicationDbContext(
             }
         }
 
-        // Save audit entities that have all the modifications
-        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
-        {
-            _auditStore.Append(this, auditEntry.ToAuditRecord());
-        }
-
-        // keep a list of entries where the value of some properties are unknown at this step
-        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
+        return auditEntries;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using ProjectTemplate.Infrastructure.Data.Auditing;
 using ProjectTemplate.Infrastructure.Data.Entities;
 using ProjectTemplate.Infrastructure.Data.Options;
 
@@ -15,13 +16,17 @@ public sealed partial class ApplicationDbContext(
     DbContextOptions<ApplicationDbContext> options,
     ILogger<ApplicationDbContext> logger,
     ICurrentActorAccessor currentActorAccessor,
-    IOptions<DataAccessOptions> dataAccessOptions
+    IOptions<DataAccessOptions> dataAccessOptions,
+    IApplicationAuditStore? auditStore = null
 )
     : DbContext(options)
 {
     private readonly ILogger<ApplicationDbContext> _logger = logger;
     private readonly ICurrentActorAccessor _currentActorAccessor = currentActorAccessor;
     private readonly bool _auditOptions = dataAccessOptions.Value.Auditing.Enabled;
+    private readonly IApplicationAuditStore _auditStore = ResolveAuditStore(
+        dataAccessOptions.Value.Auditing,
+        auditStore);
 
     /// <summary>
     /// Gets the audit records for the application.
@@ -270,6 +275,7 @@ public sealed partial class ApplicationDbContext(
     {
         return propertyName.EndsWith("Utc", StringComparison.Ordinal);
     }
+
     private List<AuditEntry> OnBeforeSaveChanges()
     {
         ChangeTracker.DetectChanges();
@@ -334,7 +340,7 @@ public sealed partial class ApplicationDbContext(
         // Save audit entities that have all the modifications
         foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
         {
-            AuditRecords.Add(auditEntry.ToAuditRecord());
+            _auditStore.Append(this, auditEntry.ToAuditRecord());
         }
 
         // keep a list of entries where the value of some properties are unknown at this step
@@ -368,7 +374,7 @@ public sealed partial class ApplicationDbContext(
             }
 
             // Save the audit entry.
-            AuditRecords.Add(auditEntry.ToAuditRecord());
+            _auditStore.Append(this, auditEntry.ToAuditRecord());
 
         }
 
@@ -404,8 +410,8 @@ public sealed partial class ApplicationDbContext(
             }
 
             // Save the audit entry.
-            await AuditRecords
-                .AddAsync(auditEntry.ToAuditRecord(), cancellationToken)
+            await _auditStore
+                .AppendAsync(this, auditEntry.ToAuditRecord(), cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -496,5 +502,25 @@ public sealed partial class ApplicationDbContext(
             LogOptimisticConcurrencyConflict(_logger, exception.Entries.Count, exception);
             throw;
         }
+    }
+
+    private static IApplicationAuditStore ResolveAuditStore(
+        DataAuditingOptions auditingOptions,
+        IApplicationAuditStore? auditStore)
+    {
+        ArgumentNullException.ThrowIfNull(auditingOptions);
+
+        if (auditStore is not null)
+        {
+            return auditStore;
+        }
+
+        if (!auditingOptions.Enabled || AuditStorageModes.IsLocal(auditingOptions.StorageMode))
+        {
+            return new LocalApplicationAuditStore();
+        }
+
+        throw new InvalidOperationException(
+            $"Application audit storage mode '{AuditStorageModes.Normalize(auditingOptions.StorageMode)}' requires an {nameof(IApplicationAuditStore)} registration.");
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -59,7 +59,7 @@ public sealed partial class ApplicationDbContext(
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
+        _ = modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
         ConfigureDataEntityDefaults(modelBuilder);
         ConfigureTimestampDefaults(modelBuilder);
 
@@ -71,7 +71,7 @@ public sealed partial class ApplicationDbContext(
     {
         ArgumentNullException.ThrowIfNull(optionsBuilder);
 
-        optionsBuilder
+        _ = optionsBuilder
             .LogTo(message => LogEfCoreMessage(_logger, message), LogLevel.Trace)
             .EnableDetailedErrors();
 
@@ -449,7 +449,7 @@ public sealed partial class ApplicationDbContext(
                 continue;
             }
 
-            modelBuilder.Entity(entityType.ClrType)
+            _ = modelBuilder.Entity(entityType.ClrType)
                 .Property<string>(nameof(DataEntity.ConcurrencyStamp))
                 .HasMaxLength(64)
                 .IsRequired()

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -530,17 +530,11 @@ public sealed partial class ApplicationDbContext(
     {
         ArgumentNullException.ThrowIfNull(auditingOptions);
 
-        if (auditStore is not null)
-        {
-            return auditStore;
-        }
-
-        if (!auditingOptions.Enabled || AuditStorageModes.IsLocal(auditingOptions.StorageMode))
-        {
-            return new LocalApplicationAuditStore();
-        }
-
-        throw new InvalidOperationException(
+        return auditStore is not null
+            ? auditStore
+            : !auditingOptions.Enabled || AuditStorageModes.IsLocal(auditingOptions.StorageMode)
+            ? (IApplicationAuditStore)new LocalApplicationAuditStore()
+            : throw new InvalidOperationException(
             $"Application audit storage mode '{AuditStorageModes.Normalize(auditingOptions.StorageMode)}' requires an {nameof(IApplicationAuditStore)} registration.");
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/AuditStorageModes.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/AuditStorageModes.cs
@@ -1,0 +1,50 @@
+namespace ProjectTemplate.Infrastructure.Data.Auditing;
+
+/// <summary>
+/// Defines supported audit storage mode names for application data access.
+/// </summary>
+public static class AuditStorageModes
+{
+    /// <summary>
+    /// Stores audit records in the application database through the local EF Core audit record table.
+    /// </summary>
+    public const string Local = "Local";
+
+    /// <summary>
+    /// Indicates that a consuming application intends to route audit records through an outbox-style store.
+    /// </summary>
+    public const string Outbox = "Outbox";
+
+    /// <summary>
+    /// Indicates that a consuming application intends to route audit records through a custom external sink.
+    /// </summary>
+    public const string ExternalSink = "ExternalSink";
+
+    /// <summary>
+    /// Determines whether the supplied storage mode is one of the supported mode names.
+    /// </summary>
+    public static bool IsSupported(string? storageMode)
+    {
+        string normalizedStorageMode = Normalize(storageMode);
+
+        return normalizedStorageMode.Equals(Local, StringComparison.OrdinalIgnoreCase)
+            || normalizedStorageMode.Equals(Outbox, StringComparison.OrdinalIgnoreCase)
+            || normalizedStorageMode.Equals(ExternalSink, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied storage mode uses the default local audit record table.
+    /// </summary>
+    public static bool IsLocal(string? storageMode)
+    {
+        return Normalize(storageMode).Equals(Local, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Normalizes a configured storage mode value for comparison and logging.
+    /// </summary>
+    public static string Normalize(string? storageMode)
+    {
+        return storageMode?.Trim() ?? string.Empty;
+    }
+}

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
@@ -1,3 +1,4 @@
+using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
 
 namespace ProjectTemplate.Infrastructure.Data.Auditing;

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
@@ -6,7 +6,7 @@ namespace ProjectTemplate.Infrastructure.Data.Auditing;
 /// Defines the template-owned storage seam for application audit records.
 /// </summary>
 /// <remarks>
-/// The default implementation stores audit records locally through <see cref="ApplicationDbContext" />.
+/// The default implementation stores audit records locally through <see cref="Data.ApplicationDbContext" />.
 /// Consuming applications may replace this contract with an outbox writer, external sink, or companion governance/audit adapter.
 /// </remarks>
 public interface IApplicationAuditStore

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
@@ -1,0 +1,34 @@
+using ProjectTemplate.Infrastructure.Data.Entities;
+
+namespace ProjectTemplate.Infrastructure.Data.Auditing;
+
+/// <summary>
+/// Defines the template-owned storage seam for application audit records.
+/// </summary>
+/// <remarks>
+/// The default implementation stores audit records locally through <see cref="ApplicationDbContext" />.
+/// Consuming applications may replace this contract with an outbox writer, external sink, or companion governance/audit adapter.
+/// </remarks>
+public interface IApplicationAuditStore
+{
+    /// <summary>
+    /// Appends an audit record during the synchronous save pipeline.
+    /// </summary>
+    /// <param name="dbContext">The current application database context.</param>
+    /// <param name="auditRecord">The audit record to append.</param>
+    void Append(
+        ApplicationDbContext dbContext,
+        AuditRecord auditRecord);
+
+    /// <summary>
+    /// Appends an audit record during the asynchronous save pipeline.
+    /// </summary>
+    /// <param name="dbContext">The current application database context.</param>
+    /// <param name="auditRecord">The audit record to append.</param>
+    /// <param name="cancellationToken">A token that can cancel the append operation.</param>
+    /// <returns>A task that completes when the audit record has been appended.</returns>
+    ValueTask AppendAsync(
+        ApplicationDbContext dbContext,
+        AuditRecord auditRecord,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
@@ -6,7 +6,7 @@ namespace ProjectTemplate.Infrastructure.Data.Auditing;
 /// Defines the template-owned storage seam for application audit records.
 /// </summary>
 /// <remarks>
-/// The default implementation stores audit records locally through <see cref="Data.ApplicationDbContext" />.
+/// The default implementation stores audit records locally through <see cref="ApplicationDbContext" />.
 /// Consuming applications may replace this contract with an outbox writer, external sink, or companion governance/audit adapter.
 /// </remarks>
 public interface IApplicationAuditStore

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/IApplicationAuditStore.cs
@@ -1,4 +1,3 @@
-using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
 
 namespace ProjectTemplate.Infrastructure.Data.Auditing;

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/LocalApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/LocalApplicationAuditStore.cs
@@ -1,3 +1,4 @@
+using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
 
 namespace ProjectTemplate.Infrastructure.Data.Auditing;

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/LocalApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/LocalApplicationAuditStore.cs
@@ -1,4 +1,3 @@
-using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
 
 namespace ProjectTemplate.Infrastructure.Data.Auditing;

--- a/src/ProjectTemplate.Infrastructure/Data/Auditing/LocalApplicationAuditStore.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Auditing/LocalApplicationAuditStore.cs
@@ -1,0 +1,33 @@
+using ProjectTemplate.Infrastructure.Data.Entities;
+
+namespace ProjectTemplate.Infrastructure.Data.Auditing;
+
+/// <summary>
+/// Stores application audit records in the local EF Core audit record table.
+/// </summary>
+public sealed class LocalApplicationAuditStore : IApplicationAuditStore
+{
+    /// <inheritdoc />
+    public void Append(
+        ApplicationDbContext dbContext,
+        AuditRecord auditRecord)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(auditRecord);
+
+        _ = dbContext.AuditRecords.Add(auditRecord);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask AppendAsync(
+        ApplicationDbContext dbContext,
+        AuditRecord auditRecord,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(auditRecord);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _ = await dbContext.AuditRecords.AddAsync(auditRecord, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using ProjectTemplate.Infrastructure.Data.Auditing;
 using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 using ProjectTemplate.Infrastructure.Data.Options;
 
@@ -30,6 +31,8 @@ public static class InfrastructureDataAccessServiceExtensions
             .Validate(options => DataAccessOptions.IsDisabledProvider(options.Provider)
                 || !string.IsNullOrWhiteSpace(options.ConnectionStringName),
                 "ProjectTemplate:DataAccess:ConnectionStringName must not be empty when data access is enabled.")
+            .Validate(options => AuditStorageModes.IsSupported(options.Auditing.StorageMode),
+                "ProjectTemplate:DataAccess:Auditing:StorageMode must be Local, Outbox, or ExternalSink.")
             .ValidateOnStart();
 
         DataAccessRegistration registration = ResolveDataAccessRegistration(configuration);
@@ -40,6 +43,11 @@ public static class InfrastructureDataAccessServiceExtensions
         }
 
         services.TryAddScoped<ICurrentActorAccessor, SystemCurrentActorAccessor>();
+
+        if (AuditStorageModes.IsLocal(registration.AuditStorageMode))
+        {
+            services.TryAddScoped<IApplicationAuditStore, LocalApplicationAuditStore>();
+        }
 
         services.AddDbContext<ApplicationDbContext>(options => ConfigureProvider(
                 options,
@@ -67,6 +75,7 @@ public static class InfrastructureDataAccessServiceExtensions
 
         string provider = dataAccessOptions.Provider?.Trim() ?? string.Empty;
         string connectionStringName = dataAccessOptions.ConnectionStringName?.Trim() ?? string.Empty;
+        string auditStorageMode = AuditStorageModes.Normalize(dataAccessOptions.Auditing.StorageMode);
 
         if (string.IsNullOrWhiteSpace(provider))
         {
@@ -74,9 +83,15 @@ public static class InfrastructureDataAccessServiceExtensions
                 "Application data access provider was not configured.");
         }
 
+        if (!AuditStorageModes.IsSupported(auditStorageMode))
+        {
+            throw new InvalidOperationException(
+                "Application audit storage mode was not configured with a supported value.");
+        }
+
         if (DataAccessOptions.IsDisabledProvider(provider))
         {
-            return DataAccessRegistration.Disabled(provider);
+            return DataAccessRegistration.Disabled(provider, auditStorageMode);
         }
 
         if (string.IsNullOrWhiteSpace(connectionStringName))
@@ -91,7 +106,8 @@ public static class InfrastructureDataAccessServiceExtensions
 
         return DataAccessRegistration.Enabled(
             provider,
-            connectionString);
+            connectionString,
+            auditStorageMode);
     }
 
     private static void ConfigureProvider(
@@ -118,19 +134,22 @@ public static class InfrastructureDataAccessServiceExtensions
     private readonly record struct DataAccessRegistration(
         string Provider,
         string ConnectionString,
+        string AuditStorageMode,
         bool IsDisabled)
     {
         public static DataAccessRegistration Enabled(
             string provider,
-            string connectionString)
+            string connectionString,
+            string auditStorageMode)
         {
-            return new DataAccessRegistration(provider, connectionString, false);
+            return new DataAccessRegistration(provider, connectionString, auditStorageMode, false);
         }
 
         public static DataAccessRegistration Disabled(
-            string provider)
+            string provider,
+            string auditStorageMode)
         {
-            return new DataAccessRegistration(provider, string.Empty, true);
+            return new DataAccessRegistration(provider, string.Empty, auditStorageMode, true);
         }
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/Options/DataAuditingOptions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Options/DataAuditingOptions.cs
@@ -1,7 +1,10 @@
+using ProjectTemplate.Infrastructure.Data.Auditing;
 
 namespace ProjectTemplate.Infrastructure.Data.Options;
 
 public sealed class DataAuditingOptions
 {
     public bool Enabled { get; init; } = true;
+
+    public string StorageMode { get; init; } = AuditStorageModes.Local;
 }

--- a/src/ProjectTemplate.Web/Services/DataAccessStartupLogger.cs
+++ b/src/ProjectTemplate.Web/Services/DataAccessStartupLogger.cs
@@ -22,7 +22,8 @@ internal sealed partial class DataAccessStartupLogger(
             logger,
             options.Value.Provider,
             options.Value.ConnectionStringName,
-            options.Value.Auditing.Enabled ? "enabled" : "disabled");
+            options.Value.Auditing.Enabled ? "enabled" : "disabled",
+            options.Value.Auditing.StorageMode);
 
         return Task.CompletedTask;
     }
@@ -35,12 +36,13 @@ internal sealed partial class DataAccessStartupLogger(
     [LoggerMessage(
         EventId = 19100,
         Level = LogLevel.Information,
-        Message = "Data access configured. Provider: {Provider}; ConnectionStringName: {ConnectionStringName}; EF Core auditing: {AuditingStatus}.")]
+        Message = "Data access configured. Provider: {Provider}; ConnectionStringName: {ConnectionStringName}; EF Core auditing: {AuditingStatus}; AuditStorageMode: {AuditStorageMode}.")]
     private static partial void LogDataAccessConfiguration(
         ILogger logger,
         string provider,
         string connectionStringName,
-        string auditingStatus);
+        string auditingStatus,
+        string auditStorageMode);
 
     [LoggerMessage(
         EventId = 19101,

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -138,7 +138,6 @@
         "LogoutPath": "/Account/Logout",
         "AccessDeniedPath": "/Account/AccessDenied",
         "ExpireMinutes": 60,
-        "SlidingExpiration": true
       },
       "Providers": {
         "OpenIdConnect": {
@@ -222,7 +221,8 @@
       "Provider": "Sqlite",
       "ConnectionStringName": "ApplicationDatabase",
       "Auditing": {
-        "Enabled": true
+        "Enabled": true,
+        "StorageMode": "Local"
       }
     },
     "ApiVersioning": {

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -138,6 +138,7 @@
         "LogoutPath": "/Account/Logout",
         "AccessDeniedPath": "/Account/AccessDenied",
         "ExpireMinutes": 60,
+        "SlidingExpiration": true
       },
       "Providers": {
         "OpenIdConnect": {

--- a/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
@@ -36,6 +36,8 @@ public sealed class ApplicationAuditStoreSeamTests
 
         AuditRecord capturedRecord = Assert.Single(auditStore.Records);
 
+        Assert.Equal(1, auditStore.AsyncAppendCount);
+        Assert.Equal(0, auditStore.SyncAppendCount);
         Assert.Equal("ExternalLoginAccounts", capturedRecord.Entity);
         Assert.Equal(EntityState.Added.ToString(), capturedRecord.State);
         Assert.Equal("AuditSeamActor", capturedRecord.ModifiedBy);
@@ -77,6 +79,10 @@ public sealed class ApplicationAuditStoreSeamTests
 
         public IReadOnlyList<AuditRecord> Records => records;
 
+        public int SyncAppendCount { get; private set; }
+
+        public int AsyncAppendCount { get; private set; }
+
         public void Append(
             ApplicationDbContext dbContext,
             AuditRecord auditRecord)
@@ -84,6 +90,7 @@ public sealed class ApplicationAuditStoreSeamTests
             ArgumentNullException.ThrowIfNull(dbContext);
             ArgumentNullException.ThrowIfNull(auditRecord);
 
+            SyncAppendCount++;
             records.Add(auditRecord);
         }
 
@@ -96,6 +103,7 @@ public sealed class ApplicationAuditStoreSeamTests
             ArgumentNullException.ThrowIfNull(auditRecord);
             cancellationToken.ThrowIfCancellationRequested();
 
+            AsyncAppendCount++;
             records.Add(auditRecord);
 
             return ValueTask.CompletedTask;

--- a/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Auditing;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationAuditStoreSeamTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_CustomAuditStore_ReceivesAuditRecordWithoutLocalAuditStorage()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        var auditStore = new CapturingApplicationAuditStore();
+
+        await using ApplicationDbContext context = CreateContext(connection, auditStore);
+        _ = await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ExternalLoginAccount account = new()
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = " GitHub ",
+            ProviderUserId = " custom-store-user ",
+            DisplayName = "Custom Store User",
+            Email = "custom.store@example.com",
+            CreatedOnUtc = new DateTime(2026, 6, 27, 8, 0, 0, DateTimeKind.Utc)
+        };
+
+        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        _ = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        AuditRecord capturedRecord = Assert.Single(auditStore.Records);
+
+        Assert.Equal("ExternalLoginAccounts", capturedRecord.Entity);
+        Assert.Equal(EntityState.Added.ToString(), capturedRecord.State);
+        Assert.Equal("AuditSeamActor", capturedRecord.ModifiedBy);
+
+        int localAuditRecordCount = await context.AuditRecords
+            .CountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, localAuditRecordCount);
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        IApplicationAuditStore auditStore)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = true,
+                StorageMode = AuditStorageModes.ExternalSink
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions),
+            auditStore);
+    }
+
+    private sealed class CapturingApplicationAuditStore : IApplicationAuditStore
+    {
+        private readonly List<AuditRecord> records = [];
+
+        public IReadOnlyList<AuditRecord> Records => records;
+
+        public void Append(
+            ApplicationDbContext dbContext,
+            AuditRecord auditRecord)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+            ArgumentNullException.ThrowIfNull(auditRecord);
+
+            records.Add(auditRecord);
+        }
+
+        public ValueTask AppendAsync(
+            ApplicationDbContext dbContext,
+            AuditRecord auditRecord,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+            ArgumentNullException.ThrowIfNull(auditRecord);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            records.Add(auditRecord);
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "AuditSeamActor";
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
@@ -31,7 +31,7 @@ public sealed class ApplicationAuditStoreSeamTests
             CreatedOnUtc = new DateTime(2026, 6, 27, 8, 0, 0, DateTimeKind.Utc)
         };
 
-        await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
+        _ = await context.ExternalLoginAccounts.AddAsync(account, TestContext.Current.CancellationToken);
         _ = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         AuditRecord capturedRecord = Assert.Single(auditStore.Records);
@@ -75,9 +75,9 @@ public sealed class ApplicationAuditStoreSeamTests
 
     private sealed class CapturingApplicationAuditStore : IApplicationAuditStore
     {
-        private readonly List<AuditRecord> records = [];
+        private readonly List<AuditRecord> _records = [];
 
-        public IReadOnlyList<AuditRecord> Records => records;
+        public IReadOnlyList<AuditRecord> Records => _records;
 
         public int SyncAppendCount { get; private set; }
 
@@ -91,7 +91,7 @@ public sealed class ApplicationAuditStoreSeamTests
             ArgumentNullException.ThrowIfNull(auditRecord);
 
             SyncAppendCount++;
-            records.Add(auditRecord);
+            _records.Add(auditRecord);
         }
 
         public ValueTask AppendAsync(
@@ -104,7 +104,7 @@ public sealed class ApplicationAuditStoreSeamTests
             cancellationToken.ThrowIfCancellationRequested();
 
             AsyncAppendCount++;
-            records.Add(auditRecord);
+            _records.Add(auditRecord);
 
             return ValueTask.CompletedTask;
         }

--- a/tests/ProjectTemplate.Web.Tests/DataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/DataAccessServiceExtensionsTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Auditing;
 using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 using ProjectTemplate.Infrastructure.Data.Options;
 using ProjectTemplate.Web.Extensions;
@@ -309,6 +310,78 @@ public sealed class DataAccessServiceExtensionsTests
             .Value;
 
         Assert.True(options.Auditing.Enabled);
+    }
+
+    /// <summary>
+    /// Verifies that local audit storage is the default storage mode.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_AuditStorageModeNotConfigured_DefaultsToLocal()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ApplicationDatabase"] = "Data Source=:memory:"
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        DataAccessOptions options = serviceProvider
+            .GetRequiredService<IOptions<DataAccessOptions>>()
+            .Value;
+
+        Assert.Equal(AuditStorageModes.Local, options.Auditing.StorageMode);
+        Assert.IsType<LocalApplicationAuditStore>(serviceProvider.GetRequiredService<IApplicationAuditStore>());
+    }
+
+    /// <summary>
+    /// Verifies that non-local audit storage modes bind for consuming applications that provide a custom store.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_AuditStorageModeConfigured_BindsAuditOptions()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ApplicationDatabase"] = "Data Source=:memory:",
+                ["ProjectTemplate:DataAccess:Auditing:StorageMode"] = AuditStorageModes.ExternalSink
+            });
+
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuration);
+
+        DataAccessOptions options = serviceProvider
+            .GetRequiredService<IOptions<DataAccessOptions>>()
+            .Value;
+
+        Assert.Equal(AuditStorageModes.ExternalSink, options.Auditing.StorageMode);
+        Assert.Null(serviceProvider.GetService<IApplicationAuditStore>());
+    }
+
+    /// <summary>
+    /// Verifies that unsupported audit storage modes fail fast.
+    /// </summary>
+    [Fact]
+    public void AddApplicationDataAccess_UnsupportedAuditStorageMode_ThrowsInvalidOperationException()
+    {
+        IConfiguration configuration = CreateConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ApplicationDatabase"] = "Data Source=:memory:",
+                ["ProjectTemplate:DataAccess:Provider"] = "Sqlite",
+                ["ProjectTemplate:DataAccess:ConnectionStringName"] = "ApplicationDatabase",
+                ["ProjectTemplate:DataAccess:Auditing:StorageMode"] = "Unknown"
+            });
+
+        ServiceCollection services = new();
+        services.AddLogging();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddApplicationDataAccess(configuration));
+
+        Assert.Contains(
+            "audit storage mode",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private static ServiceProvider CreateServiceProvider(IConfiguration configuration)

--- a/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Auditing;
 using ProjectTemplate.Infrastructure.Data.Extensions;
 using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 
@@ -33,6 +34,9 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
         ICurrentActorAccessor actorAccessor = scope.ServiceProvider
             .GetRequiredService<ICurrentActorAccessor>();
 
+        IApplicationAuditStore auditStore = scope.ServiceProvider
+            .GetRequiredService<IApplicationAuditStore>();
+
         using ApplicationDbContext context = scope.ServiceProvider
             .GetRequiredService<ApplicationDbContext>();
 
@@ -42,6 +46,7 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
         using ApplicationDbContext factoryContext = dbContextFactory.CreateDbContext();
 
         Assert.Equal(SystemCurrentActorAccessor.ActorName, actorAccessor.CurrentActor);
+        Assert.IsType<LocalApplicationAuditStore>(auditStore);
         Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", context.Database.ProviderName);
         Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", factoryContext.Database.ProviderName);
     }
@@ -65,6 +70,7 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
         using ServiceProvider serviceProvider = services.BuildServiceProvider();
 
         Assert.Null(serviceProvider.GetService<ICurrentActorAccessor>());
+        Assert.Null(serviceProvider.GetService<IApplicationAuditStore>());
         Assert.Null(serviceProvider.GetService<ApplicationDbContext>());
         Assert.Null(serviceProvider.GetService<IDbContextFactory<ApplicationDbContext>>());
         Assert.Null(serviceProvider.GetService<IExternalLoginAccountResolver>());


### PR DESCRIPTION
## Summary

- Adds a template-owned `IApplicationAuditStore` seam with the built-in `LocalApplicationAuditStore` as the default implementation.
- Adds `ProjectTemplate:DataAccess:Auditing:StorageMode` with `Local` as the default and `Outbox` / `ExternalSink` as explicit extension modes.
- Routes sync and async audit record creation through the audit store while preserving local EF Core audit storage by default.
- Documents local storage, outbox, and external/governance sink tradeoffs, including companion package integration paths such as AsiBackbone.
- Adds focused tests for default local store registration/configuration and custom audit store behavior.

## Validation

- [x] Ran `dotnet build NetCoreApplicationTemplate.slnx --configuration Release`.
```bash
Restore complete (1.1s)
  ProjectTemplate.Infrastructure net10.0 succeeded (6.0s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (5.4s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (6.1s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll

Build succeeded in 19.1s
```
- [x] Ran `dotnet test NetCoreApplicationTemplate.slnx --configuration Release`.
```bash
Restore complete (1.2s)
  ProjectTemplate.Infrastructure net10.0 succeeded (0.3s) → src\ProjectTemplate.Infrastructure\bin\Release\net10.0\ProjectTemplate.Infrastructure.dll
  ProjectTemplate.Web net10.0 succeeded (0.8s) → src\ProjectTemplate.Web\bin\Release\net10.0\ProjectTemplate.Web.dll
  ProjectTemplate.Web.Tests net10.0 succeeded (1.0s) → tests\ProjectTemplate.Web.Tests\bin\Release\net10.0\ProjectTemplate.Web.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 10.0.9)
[xUnit.net 00:00:01.14]   Discovering: ProjectTemplate.Web.Tests
[xUnit.net 00:00:01.86]   Discovered:  ProjectTemplate.Web.Tests
[xUnit.net 00:00:02.34]   Starting:    ProjectTemplate.Web.Tests
[xUnit.net 00:00:15.62]   Finished:    ProjectTemplate.Web.Tests (ID = '97e34e384f510b29f2fdf36b35acd88880ffd0cb3b1127b3b3481d6c33e4f016')
  ProjectTemplate.Web.Tests test net10.0 succeeded (17.5s)

Test summary: total: 284, failed: 0, succeeded: 284, skipped: 0, duration: 17.5s
Build succeeded in 21.4s
```
- [x] Ran `dotnet format NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
- [x] Ran `dotnet tool run docfx -- .\docs\docfx.json`.
- [x] Not run / explained below.

Added focused tests for audit storage mode configuration, default local store registration, and a custom audit store receiving async audit records without local audit storage.

## Issue Link

Closes #297

## Notes

Local audit storage remains the default. Non-local modes require a custom `IApplicationAuditStore` implementation and keep downstream outbox, exporter, SIEM, governance package, or AsiBackbone-style integrations optional.