### PR TITLE
Prepare release 2.1.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 2.1.0 - 2026-06-27
+
+### Added
+
+* Added optional application and domain layer guidance for consumers who outgrow the default `Web` / `Infrastructure` split.
+* Added production authentication hardening guidance covering provider configuration, HTTPS/proxy behavior, redirect and callback URLs, cookie security, claims translation, token handling, session behavior, and provider smoke testing.
+* Added middleware ordering rationale and documented order-sensitive invariants for the centralized application pipeline.
+* Added a template-owned `IApplicationAuditStore` seam for application audit records.
+* Added `ProjectTemplate:DataAccess:Auditing:StorageMode` with `Local` as the built-in default and `Outbox` / `ExternalSink` as explicit extension-mode names.
+* Added focused tests for default local audit store registration, audit storage mode configuration, custom audit store behavior, and sync no-op save behavior.
+
+### Changed
+
+* Routed synchronous and asynchronous audit record creation through the audit store seam while preserving local EF Core audit storage by default.
+* Short-circuited `ApplicationDbContext.SaveChanges` and `SaveChangesAsync` when the EF Core change tracker has no pending changes.
+* Refreshed configuration, data-access, public-surface, and example appsettings documentation to align with the audit storage configuration shape.
+* Updated article index and documentation navigation coverage for newer guidance pages.
+* Reformatted documentation image assets for consistent repository and documentation display.
+
+### Notes
+
+* This is a minor release because it adds optional extension points and documentation while preserving the stable `2.x` package identity, template short name, template options, and default scaffold behavior.
+* Local audit storage remains the default. `Outbox` and `ExternalSink` modes require a consuming application to register a custom `IApplicationAuditStore` implementation.
+* Existing consumers do not need to change configuration unless they intentionally adopt a non-local audit storage mode.
+
 ## 2.0.1 - 2026-06-26
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "2.0.1"
-date-released: "2026-06-26"
+version: "2.1.0"
+date-released: "2026-06-27"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software
@@ -15,7 +15,7 @@ authors:
   - family-names: "Cavell"
     given-names: "Christopher D."
     orcid: "https://orcid.org/0009-0002-2113-0245"
-abstract: "NetCoreApplicationTemplate is a reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes common application infrastructure concerns including startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, and DocFX documentation. The project is intended as a practical baseline for small-to-medium web applications, internal line-of-business systems, and prototypes that may grow into production systems."
+abstract: "NetCoreApplicationTemplate is a reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications."
 keywords:
   - aspnetcore
   - dotnet

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
-    <FileVersion>2.0.1.0</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Patch 2.0.1 release of the NetCoreApplicationTemplate dotnet new template. This release refreshes post-2.0 documentation, updates repository/package branding assets, and confirms NuGet Trusted Publishing workflow permissions while preserving the stable 2.0 package identity and scaffold behavior.</PackageReleaseNotes>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <PackageReleaseNotes>Minor 2.1.0 release of the NetCoreApplicationTemplate dotnet new template. This release adds an optional template-owned audit storage seam, documents audit storage extension paths, improves no-op SaveChanges handling, expands production authentication and middleware guidance, adds optional application/domain layering guidance, and refreshes documentation/image assets while preserving the stable 2.x package identity and default scaffold behavior.</PackageReleaseNotes>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -1,6 +1,6 @@
 # .NET Core Application Template
 
-A reusable `dotnet new` template for creating a production-oriented ASP.NET Core application baseline with structured logging, security headers, forwarded headers, rate limiting, centralized error handling, authentication-ready architecture, and EF Core-ready structure.
+A reusable dotnet new template for creating a production-oriented ASP.NET Core application baseline with structured logging, security headers, forwarded headers, rate limiting, centralized error handling, authentication-ready architecture, and EF Core-ready structure.
 
 This README is intended for NuGet package consumers. The full repository README and documentation site provide deeper implementation and maintainer guidance.
 
@@ -17,60 +17,55 @@ This README is intended for NuGet package consumers. The full repository README 
 
 Install the template package from NuGet:
 
-```powershell
-dotnet new install NetCoreApplicationTemplate::2.0.1
+```text
+dotnet new install NetCoreApplicationTemplate::2.1.0
 ```
 
-## For local package validation, install a packed package directly:
-```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.0.1.nupkg
+For local package validation, install a packed package directly:
+
+```text
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.1.0.nupkg
 ```
 
 ## Generate a project
 
 Create a default scaffold:
-```powershell
+
+```text
 dotnet new netcoreapp-template -n ContosoSecurityPortal
 ```
 
 The default scaffold uses the cookie-authentication-ready baseline and SQLite development configuration.
 
-## Generate with authentication disabled
-```powershell
-dotnet new netcoreapp-template `
-  --name ContosoNoAuth `
-  --authProvider none
+Generate with authentication disabled:
+
+```text
+dotnet new netcoreapp-template --name ContosoNoAuth --authProvider none
 ```
 
-Use this option when the generated application should start with application authentication disabled by default.
+Generate with SQL Server selected:
 
-## Generate with SQL Server selected
-```powershell
-dotnet new netcoreapp-template `
-  --name ContosoSqlServer `
-  --dbProvider sqlserver
+```text
+dotnet new netcoreapp-template --name ContosoSqlServer --dbProvider sqlserver
 ```
 
-Use this option when the generated application should use the SQL Server provider configuration instead of the default SQLite development configuration.
+Generate with authentication disabled and SQL Server selected:
 
-## Generate with authentication disabled and SQL Server selected
-```powershell
-dotnet new netcoreapp-template `
-  --name ContosoNoAuthSqlServer `
-  --authProvider none `
-  --dbProvider sqlserver
+```text
+dotnet new netcoreapp-template --name ContosoNoAuthSqlServer --authProvider none --dbProvider sqlserver
 ```
 
 ## Template options
 
-| Option           | Default  | Supported values              | Description                                                    |
-| ---------------- | -------- | ----------------------------- | -------------------------------------------------------------- |
-| `--authProvider` | `cookie` | `cookie`, `none`              | Selects the generated authentication baseline.                 |
-| `--dbProvider`   | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated EF Core provider configuration.          |
-| `--skipRestore`  | `false`  | `true`, `false`               | Skips the post-create NuGet restore action when set to `true`. |
+| Option | Default | Supported values | Description |
+|---|---|---|---|
+| `--authProvider` | `cookie` | `cookie`, `none` | Selects the generated authentication baseline. |
+| `--dbProvider` | `sqlite` | `sqlite`, `sqlserver`, `none` | Selects the generated EF Core provider configuration. |
+| `--skipRestore` | `false` | `true`, `false` | Skips the post-create NuGet restore action when set to `true`. |
 
 ## Build and test generated output
-```powershell
+
+```text
 cd ContosoSecurityPortal
 dotnet restore
 dotnet build --configuration Release
@@ -80,16 +75,19 @@ dotnet test --configuration Release
 ## Update
 
 Install the newer package version with the same package identity:
-```powershell
-dotnet new install NetCoreApplicationTemplate::2.0.1
+
+```text
+dotnet new install NetCoreApplicationTemplate::2.1.0
 ```
 
 ## Uninstall
-```powershell
+
+```text
 dotnet new uninstall NetCoreApplicationTemplate
 ```
 
 ## Additional resources
+
 - GitHub repository: https://github.com/cdcavell/NetCoreApplicationTemplate
 - Published documentation: https://cdcavell.github.io/NetCoreApplicationTemplate/
 - Template packaging documentation: https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 2.0.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.0.1)__
+Current release: __[Release 2.1.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.1.0)__
 
-Tag: `v2.0.1`
+Tag: `v2.1.0`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -161,7 +161,7 @@ The scaffolded consumer output intentionally excludes repository-maintainer cont
 Install the published template package:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.0.1
+dotnet new install NetCoreApplicationTemplate::2.1.0
 ```
 
 ### Pack and Install Locally
@@ -175,7 +175,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.0.1.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.1.0.nupkg
 ```
 
 Generate a consumer project:
@@ -233,7 +233,7 @@ The non-default scaffold preserves the template's core guardrails, including str
 Update the installed template by installing a newer package version:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.0.1
+dotnet new install NetCoreApplicationTemplate::2.1.0
 ```
 
 Uninstall the template package:
@@ -358,84 +358,3 @@ Pull requests targeting `main` require passing CI and Code Owner review for owne
 ├── README.md
 └── SECURITY.md
 ```
-
-## Local Documentation Build
-
-Restore local tools:
-
-```powershell
-dotnet tool restore
-```
-
-Build the DocFX site:
-
-```powershell
-dotnet tool run docfx -- docs/docfx.json
-```
-
-Serve the generated site locally:
-
-```powershell
-dotnet tool run docfx -- serve docs/_site
-```
-
-## GitHub Actions
-
-The repository currently includes workflows for:
-
-- Restoring dependencies.
-- Building the solution in Release configuration.
-- Verifying formatting.
-- Running tests.
-- Generating test result and coverage artifacts.
-- Enforcing a 75% minimum line coverage threshold in CI.
-- Failing CI when coverage regresses below the threshold.
-- Packing the template package.
-- Installing the generated `.nupkg` into a clean SDK environment.
-- Scaffolding a consumer project with `dotnet new netcoreapp-template`.
-- Validating expected consumer files and excluded maintainer files.
-- Building and testing scaffolded output on Linux, Windows, and macOS.
-- Running CodeQL analysis.
-- Building and publishing DocFX documentation to GitHub Pages.
-
-Template smoke testing runs on pull requests, supported branch pushes, manual workflow dispatch, and release-style version tags matching `v*.*.*`.
-
-See [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html), [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html), and [ADR-0003](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for details.
-
-## Versioning
-
-This project follows Semantic Versioning using the format:
-
-```text
-MAJOR.MINOR.PATCH
-```
-
-Version numbers are centrally managed through project build metadata so assemblies, future packages, and releases can share a consistent version identity.
-
-See [ADR-0003: Record Release Surface and Distribution Strategy](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for the release-surface decision.
-
-## Citation
-
-If you use this repository, please cite it using the metadata in [`CITATION.cff`](./CITATION.cff) or one of the following: 
-
-- Author ORCID: [0009-0002-2113-0245](https://orcid.org/0009-0002-2113-0245)
-- Zenodo Concept DOI: [10.5281/zenodo.20373042](https://doi.org/10.5281/zenodo.20373042)
-- Suggested plain-text citation:
-
-```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.0.1. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
-```
-
-## Roadmap
-
-The project is a reusable .NET application template with a stable `2.0.1` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
-
-See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
-
-## License
-
-This project is licensed under the MIT License.
-
-See [LICENSE.txt](LICENSE.txt) for full license details.
-
-Third-party assets, libraries, templates, icons, fonts, images, or other externally sourced materials used by this project are documented in [ASSETS-LICENSES.md](ASSETS-LICENSES.md).

--- a/README.md
+++ b/README.md
@@ -229,7 +229,6 @@ dotnet test --configuration Release
 
 The non-default scaffold preserves the template's core guardrails, including structured logging, centralized error handling, health checks, security headers, rate limiting, and safe defaults.
 
-
 Update the installed template by installing a newer package version:
 
 ```powershell
@@ -275,6 +274,7 @@ Documentation areas include:
   - [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html)
 - __Application Basics__
   - [Project Structure](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/project-structure.html)
+  - [Optional Application and Domain Layers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/optional-application-domain-layers.html)
   - [Configuration](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/configuration.html)
   - [Deployment Notes](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/deployment.html)
   - [Docker Development](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/docker.html)
@@ -291,6 +291,7 @@ Documentation areas include:
   - [Telemetry](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/telemetry.html)
 - __Authentication and Authorization__
   - [Authentication](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication.html)
+  - [Production Authentication Hardening](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication-hardening.html)
   - [Authorization](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authorization.html)
 - [Data Access](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/data-access.html)
 - [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html)
@@ -358,3 +359,84 @@ Pull requests targeting `main` require passing CI and Code Owner review for owne
 ├── README.md
 └── SECURITY.md
 ```
+
+## Local Documentation Build
+
+Restore local tools:
+
+```powershell
+dotnet tool restore
+```
+
+Build the DocFX site:
+
+```powershell
+dotnet tool run docfx -- docs/docfx.json
+```
+
+Serve the generated site locally:
+
+```powershell
+dotnet tool run docfx -- serve docs/_site
+```
+
+## GitHub Actions
+
+The repository currently includes workflows for:
+
+- Restoring dependencies.
+- Building the solution in Release configuration.
+- Verifying formatting.
+- Running tests.
+- Generating test result and coverage artifacts.
+- Enforcing a 75% minimum line coverage threshold in CI.
+- Failing CI when coverage regresses below the threshold.
+- Packing the template package.
+- Installing the generated `.nupkg` into a clean SDK environment.
+- Scaffolding a consumer project with `dotnet new netcoreapp-template`.
+- Validating expected consumer files and excluded maintainer files.
+- Building and testing scaffolded output on Linux, Windows, and macOS.
+- Running CodeQL analysis.
+- Building and publishing DocFX documentation to GitHub Pages.
+
+Template smoke testing runs on pull requests, supported branch pushes, manual workflow dispatch, and release-style version tags matching `v*.*.*`.
+
+See [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html), [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html), and [ADR-0003](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for details.
+
+## Versioning
+
+This project follows Semantic Versioning using the format:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+Version numbers are centrally managed through project build metadata so assemblies, future packages, and releases can share a consistent version identity.
+
+See [ADR-0003: Record Release Surface and Distribution Strategy](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for the release-surface decision.
+
+## Citation
+
+If you use this repository, please cite it using the metadata in [`CITATION.cff`](./CITATION.cff) or one of the following: 
+
+- Author ORCID: [0009-0002-2113-0245](https://orcid.org/0009-0002-2113-0245)
+- Zenodo Concept DOI: [10.5281/zenodo.20373042](https://doi.org/10.5281/zenodo.20373042)
+- Suggested plain-text citation:
+
+```text
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.1.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+```
+
+## Roadmap
+
+The project is a reusable .NET application template with a stable `2.1.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
+
+See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
+
+## License
+
+This project is licensed under the MIT License.
+
+See [LICENSE.txt](LICENSE.txt) for full license details.
+
+Third-party assets, libraries, templates, icons, fonts, images, or other externally sourced materials used by this project are documented in [ASSETS-LICENSES.md](ASSETS-LICENSES.md).

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -16,7 +16,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template identity | `CDCavell.NetCoreApplicationTemplate.CSharp` |
 | Template group identity | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `2.0.1` |
+| Current package version | `2.1.0` |
 
 The `2.0.0` release moved the public NuGet package ID to `NetCoreApplicationTemplate`. The internal template identity and group identity remain unchanged for template metadata continuity.
 
@@ -92,13 +92,13 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the published package from NuGet:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.0.1
+dotnet new install NetCoreApplicationTemplate::2.1.0
 ```
 
 Install a locally packed package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.0.1.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.1.0.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

- Bumps shared project/package version metadata from `2.0.1` to `2.1.0`.
- Updates template package release notes for the 2.1.0 minor release.
- Adds the `2.1.0` changelog entry covering the audit storage seam, no-op SaveChanges short-circuit, optional layering guidance, authentication hardening guidance, middleware ordering documentation, documentation alignment, and image asset reformatting.
- Updates README, package README, and template packaging documentation install/package examples to reference `2.1.0`.
- Updates citation and Zenodo release metadata for `2.1.0`.

## Validation

- [ ] Ran `dotnet build NetCoreApplicationTemplate.slnx --configuration Release`.
- [ ] Ran `dotnet test NetCoreApplicationTemplate.slnx --configuration Release`.
- [ ] Ran `dotnet format NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
- [ ] Ran `dotnet tool run docfx -- .\docs\docfx.json`.
- [x] Not run / explained below.

Validation note: Release-prep changes were made through the GitHub connector, so I could not execute the local build/test/format/docfx workflow in this environment. The branch was checked directly for the expected 2.1.0 version references in package metadata, shared props, README/package README, template packaging docs, changelog, citation metadata, and Zenodo metadata.

## Notes

This is release metadata and documentation preparation for the `2.1.0` minor release. The release keeps the stable `2.x` package identity and default scaffold behavior intact.