### PR TITLE
Refactor EF Core SaveChanges pipeline extraction

### DIFF
--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -17,16 +16,17 @@ public sealed partial class ApplicationDbContext(
     ILogger<ApplicationDbContext> logger,
     ICurrentActorAccessor currentActorAccessor,
     IOptions<DataAccessOptions> dataAccessOptions,
-    IApplicationAuditStore? auditStore = null
+    IApplicationAuditStore? auditStore = null,
+    IApplicationSaveChangesPipeline? saveChangesPipeline = null
 )
     : DbContext(options)
 {
     private readonly ILogger<ApplicationDbContext> _logger = logger;
-    private readonly ICurrentActorAccessor _currentActorAccessor = currentActorAccessor;
-    private readonly bool _auditOptions = dataAccessOptions.Value.Auditing.Enabled;
-    private readonly IApplicationAuditStore _auditStore = ResolveAuditStore(
-        dataAccessOptions.Value.Auditing,
-        auditStore);
+    private readonly IApplicationSaveChangesPipeline _saveChangesPipeline =
+        saveChangesPipeline ?? new ApplicationSaveChangesPipeline(
+            currentActorAccessor,
+            dataAccessOptions,
+            auditStore);
 
     /// <summary>
     /// Gets the audit records for the application.
@@ -90,28 +90,22 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
-        if (!ChangeTracker.HasChanges())
+        ApplicationSaveChangesPipelineState pipelineState =
+            _saveChangesPipeline.ApplyBeforeSaveChanges(this);
+
+        if (!pipelineState.HasChanges)
         {
             return base.SaveChanges(acceptAllChangesOnSuccess);
         }
 
-        ApplyPersistedStringCanonicalization();
-        ApplyLookupStringNormalization();
-        ApplyTimestampNormalization();
-        ApplyConcurrencyStamps();
-
-        if (!_auditOptions)
-        {
-            return SaveChangesWithConcurrencyHandling(
-                () => base.SaveChanges(acceptAllChangesOnSuccess));
-        }
-
-        List<AuditEntry> auditEntries = OnBeforeSaveChanges();
-
         int result = SaveChangesWithConcurrencyHandling(
             () => base.SaveChanges(acceptAllChangesOnSuccess));
 
-        _ = OnAfterSaveChanges(auditEntries);
+        if (pipelineState.HasPendingAuditEntries)
+        {
+            _saveChangesPipeline.ApplyAfterSaveChanges(this, pipelineState);
+            _ = base.SaveChanges();
+        }
 
         return result;
     }
@@ -127,317 +121,40 @@ public sealed partial class ApplicationDbContext(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
-        if (!ChangeTracker.HasChanges())
+        ApplicationSaveChangesPipelineState pipelineState =
+            await _saveChangesPipeline
+                .ApplyBeforeSaveChangesAsync(this, cancellationToken)
+                .ConfigureAwait(false);
+
+        if (!pipelineState.HasChanges)
         {
             return await base.SaveChangesAsync(
                 acceptAllChangesOnSuccess,
                 cancellationToken).ConfigureAwait(false);
         }
 
-        ApplyPersistedStringCanonicalization();
-        ApplyLookupStringNormalization();
-        ApplyTimestampNormalization();
-        ApplyConcurrencyStamps();
-
-        if (!_auditOptions)
-        {
-            return await SaveChangesWithConcurrencyHandlingAsync(
-                () => base.SaveChangesAsync(
-                    acceptAllChangesOnSuccess,
-                    cancellationToken)).ConfigureAwait(false);
-        }
-
-        List<AuditEntry> auditEntries = await OnBeforeSaveChangesAsync(cancellationToken)
-            .ConfigureAwait(false);
-
         int result = await SaveChangesWithConcurrencyHandlingAsync(
             () => base.SaveChangesAsync(
                 acceptAllChangesOnSuccess,
                 cancellationToken)).ConfigureAwait(false);
 
-        _ = await OnAfterSaveChangesAsync(auditEntries, cancellationToken)
-            .ConfigureAwait(false);
+        if (pipelineState.HasPendingAuditEntries)
+        {
+            await _saveChangesPipeline
+                .ApplyAfterSaveChangesAsync(this, pipelineState, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await base
+                .SaveChangesAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         return result;
-    }
-
-    private void ApplyPersistedStringCanonicalization()
-    {
-        ChangeTracker.DetectChanges();
-
-        foreach (EntityEntry entry in ChangeTracker.Entries())
-        {
-            if (entry.Entity is AuditRecord ||
-                entry.State is not (EntityState.Added or EntityState.Modified))
-            {
-                continue;
-            }
-
-            foreach (PropertyEntry property in entry.Properties)
-            {
-                if (property.Metadata.ClrType != typeof(string) ||
-                    property.Metadata.IsPrimaryKey() ||
-                    property.Metadata.IsConcurrencyToken)
-                {
-                    continue;
-                }
-
-                if (entry.State == EntityState.Modified && !property.IsModified)
-                {
-                    continue;
-                }
-
-                if (property.CurrentValue is not string currentValue)
-                {
-                    continue;
-                }
-
-                string canonicalValue = PersistenceStringCanonicalizer.Canonicalize(currentValue);
-
-                if (!string.Equals(canonicalValue, currentValue, StringComparison.Ordinal))
-                {
-                    property.CurrentValue = canonicalValue;
-                }
-            }
-        }
-    }
-
-    private void ApplyLookupStringNormalization()
-    {
-        ChangeTracker.DetectChanges();
-
-        foreach (EntityEntry<ExternalLoginAccount> entry in ChangeTracker.Entries<ExternalLoginAccount>())
-        {
-            if (entry.State is not (EntityState.Added or EntityState.Modified))
-            {
-                continue;
-            }
-
-            ExternalLoginAccount account = entry.Entity;
-
-            account.ProviderName =
-                PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(account.ProviderName);
-
-            account.NormalizedProviderName =
-                PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(account.ProviderName);
-
-            account.ProviderUserId =
-                PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(account.ProviderUserId);
-
-            account.DisplayName =
-                PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(account.DisplayName);
-
-            account.Email =
-                PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(account.Email);
-
-            account.NormalizedEmail =
-                PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(account.Email);
-        }
-    }
-
-    private void ApplyTimestampNormalization()
-    {
-        ChangeTracker.DetectChanges();
-
-        foreach (EntityEntry entry in ChangeTracker.Entries())
-        {
-            if (entry.State is not (EntityState.Added or EntityState.Modified))
-            {
-                continue;
-            }
-
-            foreach (PropertyEntry property in entry.Properties)
-            {
-                if (!IsUtcTimestampProperty(property.Metadata.Name))
-                {
-                    continue;
-                }
-
-                Type propertyType = Nullable.GetUnderlyingType(property.Metadata.ClrType)
-                    ?? property.Metadata.ClrType;
-
-                if (propertyType == typeof(DateTime) &&
-                    property.CurrentValue is DateTime dateTimeValue)
-                {
-                    property.CurrentValue = PersistenceTimestamp.NormalizeUtc(dateTimeValue);
-                    continue;
-                }
-
-                if (propertyType == typeof(DateTimeOffset) &&
-                    property.CurrentValue is DateTimeOffset dateTimeOffsetValue)
-                {
-                    property.CurrentValue = PersistenceTimestamp.NormalizeUtc(dateTimeOffsetValue);
-                }
-            }
-        }
     }
 
     private static bool IsUtcTimestampProperty(string propertyName)
     {
         return propertyName.EndsWith("Utc", StringComparison.Ordinal);
-    }
-
-    private List<AuditEntry> OnBeforeSaveChanges()
-    {
-        List<AuditEntry> auditEntries = CreateAuditEntries();
-
-        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
-        {
-            _auditStore.Append(this, auditEntry.ToAuditRecord());
-        }
-
-        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
-    }
-
-    private async Task<List<AuditEntry>> OnBeforeSaveChangesAsync(CancellationToken cancellationToken)
-    {
-        List<AuditEntry> auditEntries = CreateAuditEntries();
-
-        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
-        {
-            await _auditStore
-                .AppendAsync(this, auditEntry.ToAuditRecord(), cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
-    }
-
-    private List<AuditEntry> CreateAuditEntries()
-    {
-        ChangeTracker.DetectChanges();
-        var auditEntries = new List<AuditEntry>();
-        foreach (EntityEntry entry in ChangeTracker.Entries())
-        {
-            if (entry.Entity is AuditRecord || entry.State == EntityState.Detached || entry.State == EntityState.Unchanged)
-            {
-                continue;
-            }
-
-            AuditEntry auditEntry = new(entry)
-            {
-                TableName = entry.Metadata.GetTableName() ?? string.Empty,
-                ModifiedBy = _currentActorAccessor.CurrentActor,
-                ModifiedOnUtc = PersistenceTimestamp.UtcNow(),
-                State = entry.State.ToString()
-            };
-            auditEntries.Add(auditEntry);
-
-            foreach (PropertyEntry property in entry.Properties)
-            {
-                if (property.IsTemporary)
-                {
-                    // value will be generated by the database, get the value after saving
-                    auditEntry.TemporaryProperties.Add(property);
-                    continue;
-                }
-
-                string propertyName = property.Metadata.Name;
-                if (property.Metadata.IsPrimaryKey())
-                {
-                    auditEntry.KeyValues[propertyName] = property.CurrentValue ?? string.Empty;
-                    continue;
-                }
-
-                switch (entry.State)
-                {
-                    case EntityState.Added:
-                        auditEntry.CurrentValues[propertyName] = property.CurrentValue ?? string.Empty;
-                        break;
-
-                    case EntityState.Deleted:
-                        auditEntry.OriginalValues[propertyName] = property.OriginalValue ?? string.Empty;
-                        break;
-
-                    case EntityState.Modified:
-                        if (property.IsModified)
-                        {
-                            auditEntry.OriginalValues[propertyName] = property.OriginalValue ?? string.Empty;
-                            auditEntry.CurrentValues[propertyName] = property.CurrentValue ?? string.Empty;
-                        }
-                        break;
-                    case EntityState.Detached:
-                    case EntityState.Unchanged:
-                    default:
-                        break;
-                }
-            }
-        }
-
-        return auditEntries;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Style",
-        "IDE0002:Simplify Member Access",
-        Justification = "The base call intentionally bypasses the overridden SaveChanges audit pipeline.")]
-    private int OnAfterSaveChanges(List<AuditEntry> auditEntries)
-    {
-        if (auditEntries == null || auditEntries.Count == 0)
-        {
-            return 0;
-        }
-
-        foreach (AuditEntry auditEntry in auditEntries)
-        {
-            // Get the final value of the temporary properties
-            foreach (PropertyEntry prop in auditEntry.TemporaryProperties)
-            {
-                if (prop.Metadata.IsPrimaryKey())
-                {
-                    auditEntry.KeyValues[prop.Metadata.Name] = prop.CurrentValue ?? string.Empty;
-                }
-                else
-                {
-                    auditEntry.CurrentValues[prop.Metadata.Name] = prop.CurrentValue ?? string.Empty;
-                }
-            }
-
-            // Save the audit entry.
-            _auditStore.Append(this, auditEntry.ToAuditRecord());
-
-        }
-
-        return base.SaveChanges();
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Style",
-        "IDE0002:Simplify Member Access",
-        Justification = "The base call intentionally bypasses the overridden SaveChanges audit pipeline.")]
-    private async Task<int> OnAfterSaveChangesAsync(
-        List<AuditEntry> auditEntries,
-        CancellationToken cancellationToken)
-    {
-        if (auditEntries == null || auditEntries.Count == 0)
-        {
-            return 0;
-        }
-
-        foreach (AuditEntry auditEntry in auditEntries)
-        {
-            // Get the final value of the temporary properties
-            foreach (PropertyEntry prop in auditEntry.TemporaryProperties)
-            {
-                if (prop.Metadata.IsPrimaryKey())
-                {
-                    auditEntry.KeyValues[prop.Metadata.Name] = prop.CurrentValue ?? string.Empty;
-                }
-                else
-                {
-                    auditEntry.CurrentValues[prop.Metadata.Name] = prop.CurrentValue ?? string.Empty;
-                }
-            }
-
-            // Save the audit entry.
-            await _auditStore
-                .AppendAsync(this, auditEntry.ToAuditRecord(), cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return await base
-            .SaveChangesAsync(cancellationToken)
-            .ConfigureAwait(false);
     }
 
     private static void ConfigureDataEntityDefaults(ModelBuilder modelBuilder)
@@ -475,29 +192,6 @@ public sealed partial class ApplicationDbContext(
         }
     }
 
-    private void ApplyConcurrencyStamps()
-    {
-        ChangeTracker.DetectChanges();
-
-        foreach (EntityEntry<DataEntity> entry in ChangeTracker.Entries<DataEntity>())
-        {
-            if (entry.State == EntityState.Added)
-            {
-                if (string.IsNullOrWhiteSpace(entry.Entity.ConcurrencyStamp))
-                {
-                    entry.Entity.ConcurrencyStamp = DataEntity.NewConcurrencyStamp();
-                }
-
-                continue;
-            }
-
-            if (entry.State == EntityState.Modified)
-            {
-                entry.Entity.ConcurrencyStamp = DataEntity.NewConcurrencyStamp();
-            }
-        }
-    }
-
     private int SaveChangesWithConcurrencyHandling(Func<int> saveChanges)
     {
         try
@@ -522,19 +216,5 @@ public sealed partial class ApplicationDbContext(
             LogOptimisticConcurrencyConflict(_logger, exception.Entries.Count, exception);
             throw;
         }
-    }
-
-    private static IApplicationAuditStore ResolveAuditStore(
-        DataAuditingOptions auditingOptions,
-        IApplicationAuditStore? auditStore)
-    {
-        ArgumentNullException.ThrowIfNull(auditingOptions);
-
-        return auditStore is not null
-            ? auditStore
-            : !auditingOptions.Enabled || AuditStorageModes.IsLocal(auditingOptions.StorageMode)
-            ? (IApplicationAuditStore)new LocalApplicationAuditStore()
-            : throw new InvalidOperationException(
-            $"Application audit storage mode '{AuditStorageModes.Normalize(auditingOptions.StorageMode)}' requires an {nameof(IApplicationAuditStore)} registration.");
     }
 }

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -90,10 +90,9 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
-        ApplicationSaveChangesPipelineState pipelineState =
-            _saveChangesPipeline.ApplyBeforeSaveChanges(this);
+        bool hasChanges = _saveChangesPipeline.ApplyBeforeSaveChanges(this);
 
-        if (!pipelineState.HasChanges)
+        if (!hasChanges)
         {
             return base.SaveChanges(acceptAllChangesOnSuccess);
         }
@@ -101,9 +100,8 @@ public sealed partial class ApplicationDbContext(
         int result = SaveChangesWithConcurrencyHandling(
             () => base.SaveChanges(acceptAllChangesOnSuccess));
 
-        if (pipelineState.HasPendingAuditEntries)
+        if (_saveChangesPipeline.ApplyAfterSaveChanges(this))
         {
-            _saveChangesPipeline.ApplyAfterSaveChanges(this, pipelineState);
             _ = base.SaveChanges();
         }
 
@@ -121,12 +119,11 @@ public sealed partial class ApplicationDbContext(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
-        ApplicationSaveChangesPipelineState pipelineState =
-            await _saveChangesPipeline
-                .ApplyBeforeSaveChangesAsync(this, cancellationToken)
-                .ConfigureAwait(false);
+        bool hasChanges = await _saveChangesPipeline
+            .ApplyBeforeSaveChangesAsync(this, cancellationToken)
+            .ConfigureAwait(false);
 
-        if (!pipelineState.HasChanges)
+        if (!hasChanges)
         {
             return await base.SaveChangesAsync(
                 acceptAllChangesOnSuccess,
@@ -138,12 +135,10 @@ public sealed partial class ApplicationDbContext(
                 acceptAllChangesOnSuccess,
                 cancellationToken)).ConfigureAwait(false);
 
-        if (pipelineState.HasPendingAuditEntries)
+        if (await _saveChangesPipeline
+            .ApplyAfterSaveChangesAsync(this, cancellationToken)
+            .ConfigureAwait(false))
         {
-            await _saveChangesPipeline
-                .ApplyAfterSaveChangesAsync(this, pipelineState, cancellationToken)
-                .ConfigureAwait(false);
-
             _ = await base
                 .SaveChangesAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationSaveChangesPipeline.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationSaveChangesPipeline.cs
@@ -1,0 +1,406 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Infrastructure.Data.Auditing;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Infrastructure.Data;
+
+/// <summary>
+/// Applies application-owned mutation, normalization, concurrency, and audit preparation during EF Core saves.
+/// </summary>
+public sealed class ApplicationSaveChangesPipeline : IApplicationSaveChangesPipeline
+{
+    private readonly ICurrentActorAccessor _currentActorAccessor;
+    private readonly bool _auditOptions;
+    private readonly IApplicationAuditStore _auditStore;
+    private List<AuditEntry> _pendingAuditEntries = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationSaveChangesPipeline" /> class.
+    /// </summary>
+    /// <param name="currentActorAccessor">The accessor for the actor responsible for the current save.</param>
+    /// <param name="dataAccessOptions">The application data access options.</param>
+    /// <param name="auditStore">The optional audit store used when auditing is enabled.</param>
+    public ApplicationSaveChangesPipeline(
+        ICurrentActorAccessor currentActorAccessor,
+        IOptions<DataAccessOptions> dataAccessOptions,
+        IApplicationAuditStore? auditStore = null)
+    {
+        ArgumentNullException.ThrowIfNull(currentActorAccessor);
+        ArgumentNullException.ThrowIfNull(dataAccessOptions);
+
+        _currentActorAccessor = currentActorAccessor;
+        _auditOptions = dataAccessOptions.Value.Auditing.Enabled;
+        _auditStore = ResolveAuditStore(
+            dataAccessOptions.Value.Auditing,
+            auditStore);
+    }
+
+    /// <inheritdoc />
+    public bool ApplyBeforeSaveChanges(ApplicationDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        _pendingAuditEntries = [];
+
+        if (!dbContext.ChangeTracker.HasChanges())
+        {
+            return false;
+        }
+
+        ApplyPersistedStringCanonicalization(dbContext);
+        ApplyLookupStringNormalization(dbContext);
+        ApplyTimestampNormalization(dbContext);
+        ApplyConcurrencyStamps(dbContext);
+
+        if (_auditOptions)
+        {
+            _pendingAuditEntries = OnBeforeSaveChanges(dbContext);
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> ApplyBeforeSaveChangesAsync(
+        ApplicationDbContext dbContext,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _pendingAuditEntries = [];
+
+        if (!dbContext.ChangeTracker.HasChanges())
+        {
+            return false;
+        }
+
+        ApplyPersistedStringCanonicalization(dbContext);
+        ApplyLookupStringNormalization(dbContext);
+        ApplyTimestampNormalization(dbContext);
+        ApplyConcurrencyStamps(dbContext);
+
+        if (_auditOptions)
+        {
+            _pendingAuditEntries = await OnBeforeSaveChangesAsync(dbContext, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool ApplyAfterSaveChanges(ApplicationDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        if (_pendingAuditEntries.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (AuditEntry auditEntry in _pendingAuditEntries)
+        {
+            CompleteTemporaryAuditProperties(auditEntry);
+            _auditStore.Append(dbContext, auditEntry.ToAuditRecord());
+        }
+
+        _pendingAuditEntries = [];
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> ApplyAfterSaveChangesAsync(
+        ApplicationDbContext dbContext,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_pendingAuditEntries.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (AuditEntry auditEntry in _pendingAuditEntries)
+        {
+            CompleteTemporaryAuditProperties(auditEntry);
+            await _auditStore
+                .AppendAsync(dbContext, auditEntry.ToAuditRecord(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        _pendingAuditEntries = [];
+
+        return true;
+    }
+
+    private static void ApplyPersistedStringCanonicalization(ApplicationDbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry entry in dbContext.ChangeTracker.Entries())
+        {
+            if (entry.Entity is AuditRecord ||
+                entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            foreach (PropertyEntry property in entry.Properties)
+            {
+                if (property.Metadata.ClrType != typeof(string) ||
+                    property.Metadata.IsPrimaryKey() ||
+                    property.Metadata.IsConcurrencyToken)
+                {
+                    continue;
+                }
+
+                if (entry.State == EntityState.Modified && !property.IsModified)
+                {
+                    continue;
+                }
+
+                if (property.CurrentValue is not string currentValue)
+                {
+                    continue;
+                }
+
+                string canonicalValue = PersistenceStringCanonicalizer.Canonicalize(currentValue);
+
+                if (!string.Equals(canonicalValue, currentValue, StringComparison.Ordinal))
+                {
+                    property.CurrentValue = canonicalValue;
+                }
+            }
+        }
+    }
+
+    private static void ApplyLookupStringNormalization(ApplicationDbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry<ExternalLoginAccount> entry in dbContext.ChangeTracker.Entries<ExternalLoginAccount>())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            ExternalLoginAccount account = entry.Entity;
+
+            account.ProviderName =
+                PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(account.ProviderName);
+
+            account.NormalizedProviderName =
+                PersistenceStringComparisonNormalizer.NormalizeRequiredLookupValue(account.ProviderName);
+
+            account.ProviderUserId =
+                PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(account.ProviderUserId);
+
+            account.DisplayName =
+                PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(account.DisplayName);
+
+            account.Email =
+                PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(account.Email);
+
+            account.NormalizedEmail =
+                PersistenceStringComparisonNormalizer.NormalizeOptionalLookupValue(account.Email);
+        }
+    }
+
+    private static void ApplyTimestampNormalization(ApplicationDbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry entry in dbContext.ChangeTracker.Entries())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            foreach (PropertyEntry property in entry.Properties)
+            {
+                if (!IsUtcTimestampProperty(property.Metadata.Name))
+                {
+                    continue;
+                }
+
+                Type propertyType = Nullable.GetUnderlyingType(property.Metadata.ClrType)
+                    ?? property.Metadata.ClrType;
+
+                if (propertyType == typeof(DateTime) &&
+                    property.CurrentValue is DateTime dateTimeValue)
+                {
+                    property.CurrentValue = PersistenceTimestamp.NormalizeUtc(dateTimeValue);
+                    continue;
+                }
+
+                if (propertyType == typeof(DateTimeOffset) &&
+                    property.CurrentValue is DateTimeOffset dateTimeOffsetValue)
+                {
+                    property.CurrentValue = PersistenceTimestamp.NormalizeUtc(dateTimeOffsetValue);
+                }
+            }
+        }
+    }
+
+    private static void ApplyConcurrencyStamps(ApplicationDbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+
+        foreach (EntityEntry<DataEntity> entry in dbContext.ChangeTracker.Entries<DataEntity>())
+        {
+            if (entry.State == EntityState.Added)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Entity.ConcurrencyStamp))
+                {
+                    entry.Entity.ConcurrencyStamp = DataEntity.NewConcurrencyStamp();
+                }
+
+                continue;
+            }
+
+            if (entry.State == EntityState.Modified)
+            {
+                entry.Entity.ConcurrencyStamp = DataEntity.NewConcurrencyStamp();
+            }
+        }
+    }
+
+    private static bool IsUtcTimestampProperty(string propertyName)
+    {
+        return propertyName.EndsWith("Utc", StringComparison.Ordinal);
+    }
+
+    private List<AuditEntry> OnBeforeSaveChanges(ApplicationDbContext dbContext)
+    {
+        List<AuditEntry> auditEntries = CreateAuditEntries(dbContext);
+
+        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
+        {
+            _auditStore.Append(dbContext, auditEntry.ToAuditRecord());
+        }
+
+        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
+    }
+
+    private async ValueTask<List<AuditEntry>> OnBeforeSaveChangesAsync(
+        ApplicationDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        List<AuditEntry> auditEntries = CreateAuditEntries(dbContext);
+
+        foreach (AuditEntry auditEntry in auditEntries.Where(_ => !_.HasTemporaryProperties))
+        {
+            await _auditStore
+                .AppendAsync(dbContext, auditEntry.ToAuditRecord(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return [.. auditEntries.Where(_ => _.HasTemporaryProperties)];
+    }
+
+    private List<AuditEntry> CreateAuditEntries(ApplicationDbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+        var auditEntries = new List<AuditEntry>();
+
+        foreach (EntityEntry entry in dbContext.ChangeTracker.Entries())
+        {
+            if (entry.Entity is AuditRecord ||
+                entry.State == EntityState.Detached ||
+                entry.State == EntityState.Unchanged)
+            {
+                continue;
+            }
+
+            AuditEntry auditEntry = new(entry)
+            {
+                TableName = entry.Metadata.GetTableName() ?? string.Empty,
+                ModifiedBy = _currentActorAccessor.CurrentActor,
+                ModifiedOnUtc = PersistenceTimestamp.UtcNow(),
+                State = entry.State.ToString()
+            };
+            auditEntries.Add(auditEntry);
+
+            foreach (PropertyEntry property in entry.Properties)
+            {
+                if (property.IsTemporary)
+                {
+                    // value will be generated by the database, get the value after saving
+                    auditEntry.TemporaryProperties.Add(property);
+                    continue;
+                }
+
+                string propertyName = property.Metadata.Name;
+                if (property.Metadata.IsPrimaryKey())
+                {
+                    auditEntry.KeyValues[propertyName] = property.CurrentValue ?? string.Empty;
+                    continue;
+                }
+
+                switch (entry.State)
+                {
+                    case EntityState.Added:
+                        auditEntry.CurrentValues[propertyName] = property.CurrentValue ?? string.Empty;
+                        break;
+
+                    case EntityState.Deleted:
+                        auditEntry.OriginalValues[propertyName] = property.OriginalValue ?? string.Empty;
+                        break;
+
+                    case EntityState.Modified:
+                        if (property.IsModified)
+                        {
+                            auditEntry.OriginalValues[propertyName] = property.OriginalValue ?? string.Empty;
+                            auditEntry.CurrentValues[propertyName] = property.CurrentValue ?? string.Empty;
+                        }
+
+                        break;
+
+                    case EntityState.Detached:
+                    case EntityState.Unchanged:
+                    default:
+                        break;
+                }
+            }
+        }
+
+        return auditEntries;
+    }
+
+    private static void CompleteTemporaryAuditProperties(AuditEntry auditEntry)
+    {
+        foreach (PropertyEntry property in auditEntry.TemporaryProperties)
+        {
+            if (property.Metadata.IsPrimaryKey())
+            {
+                auditEntry.KeyValues[property.Metadata.Name] = property.CurrentValue ?? string.Empty;
+            }
+            else
+            {
+                auditEntry.CurrentValues[property.Metadata.Name] = property.CurrentValue ?? string.Empty;
+            }
+        }
+    }
+
+    private static IApplicationAuditStore ResolveAuditStore(
+        DataAuditingOptions auditingOptions,
+        IApplicationAuditStore? auditStore)
+    {
+        ArgumentNullException.ThrowIfNull(auditingOptions);
+
+        return auditStore is not null
+            ? auditStore
+            : !auditingOptions.Enabled || AuditStorageModes.IsLocal(auditingOptions.StorageMode)
+            ? (IApplicationAuditStore)new LocalApplicationAuditStore()
+            : throw new InvalidOperationException(
+            $"Application audit storage mode '{AuditStorageModes.Normalize(auditingOptions.StorageMode)}' requires an {nameof(IApplicationAuditStore)} registration.");
+    }
+}

--- a/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using ProjectTemplate.Infrastructure.Data.Auditing;
 using ProjectTemplate.Infrastructure.Data.ExternalLogins;
 using ProjectTemplate.Infrastructure.Data.Options;
@@ -48,6 +49,12 @@ public static class InfrastructureDataAccessServiceExtensions
         {
             services.TryAddScoped<IApplicationAuditStore, LocalApplicationAuditStore>();
         }
+
+        services.TryAddScoped<IApplicationSaveChangesPipeline>(serviceProvider =>
+            new ApplicationSaveChangesPipeline(
+                serviceProvider.GetRequiredService<ICurrentActorAccessor>(),
+                serviceProvider.GetRequiredService<IOptions<DataAccessOptions>>(),
+                serviceProvider.GetService<IApplicationAuditStore>()));
 
         services.AddDbContext<ApplicationDbContext>(options => ConfigureProvider(
                 options,

--- a/src/ProjectTemplate.Infrastructure/Data/IApplicationSaveChangesPipeline.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/IApplicationSaveChangesPipeline.cs
@@ -9,8 +9,8 @@ public interface IApplicationSaveChangesPipeline
     /// Applies application save preparation before EF Core persists tracked changes.
     /// </summary>
     /// <param name="dbContext">The current application database context.</param>
-    /// <returns>State that should be carried into the after-save pipeline.</returns>
-    ApplicationSaveChangesPipelineState ApplyBeforeSaveChanges(
+    /// <returns><see langword="true" /> when tracked changes should be persisted; otherwise, <see langword="false" />.</returns>
+    bool ApplyBeforeSaveChanges(
         ApplicationDbContext dbContext);
 
     /// <summary>
@@ -18,8 +18,8 @@ public interface IApplicationSaveChangesPipeline
     /// </summary>
     /// <param name="dbContext">The current application database context.</param>
     /// <param name="cancellationToken">A token that can cancel the operation.</param>
-    /// <returns>State that should be carried into the after-save pipeline.</returns>
-    ValueTask<ApplicationSaveChangesPipelineState> ApplyBeforeSaveChangesAsync(
+    /// <returns><see langword="true" /> when tracked changes should be persisted; otherwise, <see langword="false" />.</returns>
+    ValueTask<bool> ApplyBeforeSaveChangesAsync(
         ApplicationDbContext dbContext,
         CancellationToken cancellationToken = default);
 
@@ -27,20 +27,17 @@ public interface IApplicationSaveChangesPipeline
     /// Completes application save handling after EF Core persists tracked changes.
     /// </summary>
     /// <param name="dbContext">The current application database context.</param>
-    /// <param name="pipelineState">The state produced by the before-save pipeline.</param>
-    void ApplyAfterSaveChanges(
-        ApplicationDbContext dbContext,
-        ApplicationSaveChangesPipelineState pipelineState);
+    /// <returns><see langword="true" /> when additional audit records were appended; otherwise, <see langword="false" />.</returns>
+    bool ApplyAfterSaveChanges(
+        ApplicationDbContext dbContext);
 
     /// <summary>
     /// Completes application save handling after EF Core asynchronously persists tracked changes.
     /// </summary>
     /// <param name="dbContext">The current application database context.</param>
-    /// <param name="pipelineState">The state produced by the before-save pipeline.</param>
     /// <param name="cancellationToken">A token that can cancel the operation.</param>
-    /// <returns>A task that completes when the after-save pipeline has finished.</returns>
-    ValueTask ApplyAfterSaveChangesAsync(
+    /// <returns><see langword="true" /> when additional audit records were appended; otherwise, <see langword="false" />.</returns>
+    ValueTask<bool> ApplyAfterSaveChangesAsync(
         ApplicationDbContext dbContext,
-        ApplicationSaveChangesPipelineState pipelineState,
         CancellationToken cancellationToken = default);
 }

--- a/src/ProjectTemplate.Infrastructure/Data/IApplicationSaveChangesPipeline.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/IApplicationSaveChangesPipeline.cs
@@ -1,0 +1,46 @@
+namespace ProjectTemplate.Infrastructure.Data;
+
+/// <summary>
+/// Defines the application-owned EF Core save preparation pipeline.
+/// </summary>
+public interface IApplicationSaveChangesPipeline
+{
+    /// <summary>
+    /// Applies application save preparation before EF Core persists tracked changes.
+    /// </summary>
+    /// <param name="dbContext">The current application database context.</param>
+    /// <returns>State that should be carried into the after-save pipeline.</returns>
+    ApplicationSaveChangesPipelineState ApplyBeforeSaveChanges(
+        ApplicationDbContext dbContext);
+
+    /// <summary>
+    /// Applies application save preparation before EF Core asynchronously persists tracked changes.
+    /// </summary>
+    /// <param name="dbContext">The current application database context.</param>
+    /// <param name="cancellationToken">A token that can cancel the operation.</param>
+    /// <returns>State that should be carried into the after-save pipeline.</returns>
+    ValueTask<ApplicationSaveChangesPipelineState> ApplyBeforeSaveChangesAsync(
+        ApplicationDbContext dbContext,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Completes application save handling after EF Core persists tracked changes.
+    /// </summary>
+    /// <param name="dbContext">The current application database context.</param>
+    /// <param name="pipelineState">The state produced by the before-save pipeline.</param>
+    void ApplyAfterSaveChanges(
+        ApplicationDbContext dbContext,
+        ApplicationSaveChangesPipelineState pipelineState);
+
+    /// <summary>
+    /// Completes application save handling after EF Core asynchronously persists tracked changes.
+    /// </summary>
+    /// <param name="dbContext">The current application database context.</param>
+    /// <param name="pipelineState">The state produced by the before-save pipeline.</param>
+    /// <param name="cancellationToken">A token that can cancel the operation.</param>
+    /// <returns>A task that completes when the after-save pipeline has finished.</returns>
+    ValueTask ApplyAfterSaveChangesAsync(
+        ApplicationDbContext dbContext,
+        ApplicationSaveChangesPipelineState pipelineState,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSavePipelineTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSavePipelineTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectTemplate.Infrastructure.Data;
+using ProjectTemplate.Infrastructure.Data.Entities;
+using ProjectTemplate.Infrastructure.Data.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class ApplicationDbContextSavePipelineTests
+{
+    [Fact]
+    public async Task SaveChanges_WithPendingChanges_InvokesInjectedPipeline()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        TrackingSaveChangesPipeline saveChangesPipeline = new();
+
+        await using ApplicationDbContext context = CreateContext(
+            connection,
+            saveChangesPipeline);
+
+        _ = context.Database.EnsureCreated();
+
+        context.ExternalLoginAccounts.Add(CreatePersistableAccount("pipeline-sync-user"));
+
+        int result = context.SaveChanges();
+
+        Assert.Equal(1, result);
+        Assert.Equal(1, saveChangesPipeline.BeforeSaveChangesCallCount);
+        Assert.Equal(0, saveChangesPipeline.BeforeSaveChangesAsyncCallCount);
+        Assert.Equal(1, saveChangesPipeline.AfterSaveChangesCallCount);
+        Assert.Equal(0, saveChangesPipeline.AfterSaveChangesAsyncCallCount);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WithPendingChanges_InvokesInjectedPipeline()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        TrackingSaveChangesPipeline saveChangesPipeline = new();
+
+        await using ApplicationDbContext context = CreateContext(
+            connection,
+            saveChangesPipeline);
+
+        _ = await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        await context.ExternalLoginAccounts.AddAsync(
+            CreatePersistableAccount("pipeline-async-user"),
+            TestContext.Current.CancellationToken);
+
+        int result = await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result);
+        Assert.Equal(0, saveChangesPipeline.BeforeSaveChangesCallCount);
+        Assert.Equal(1, saveChangesPipeline.BeforeSaveChangesAsyncCallCount);
+        Assert.Equal(0, saveChangesPipeline.AfterSaveChangesCallCount);
+        Assert.Equal(1, saveChangesPipeline.AfterSaveChangesAsyncCallCount);
+    }
+
+    private static async Task<SqliteConnection> CreateOpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        return connection;
+    }
+
+    private static ExternalLoginAccount CreatePersistableAccount(string providerUserId)
+    {
+        return new ExternalLoginAccount
+        {
+            LocalUserId = Guid.NewGuid(),
+            ProviderName = "GitHub",
+            NormalizedProviderName = "GITHUB",
+            ProviderUserId = providerUserId,
+            DisplayName = "Pipeline User",
+            Email = "pipeline.user@example.com",
+            NormalizedEmail = "PIPELINE.USER@EXAMPLE.COM",
+            CreatedOnUtc = new DateTime(2026, 6, 29, 12, 0, 0, DateTimeKind.Utc)
+        };
+    }
+
+    private static ApplicationDbContext CreateContext(
+        SqliteConnection connection,
+        IApplicationSaveChangesPipeline saveChangesPipeline)
+    {
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        DataAccessOptions dataAccessOptions = new()
+        {
+            Auditing = new DataAuditingOptions
+            {
+                Enabled = false
+            }
+        };
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions),
+            saveChangesPipeline: saveChangesPipeline);
+    }
+
+    private sealed class TrackingSaveChangesPipeline : IApplicationSaveChangesPipeline
+    {
+        public int BeforeSaveChangesCallCount { get; private set; }
+
+        public int BeforeSaveChangesAsyncCallCount { get; private set; }
+
+        public int AfterSaveChangesCallCount { get; private set; }
+
+        public int AfterSaveChangesAsyncCallCount { get; private set; }
+
+        public bool ApplyBeforeSaveChanges(ApplicationDbContext dbContext)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+
+            BeforeSaveChangesCallCount++;
+
+            return true;
+        }
+
+        public ValueTask<bool> ApplyBeforeSaveChangesAsync(
+            ApplicationDbContext dbContext,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            BeforeSaveChangesAsyncCallCount++;
+
+            return ValueTask.FromResult(true);
+        }
+
+        public bool ApplyAfterSaveChanges(ApplicationDbContext dbContext)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+
+            AfterSaveChangesCallCount++;
+
+            return false;
+        }
+
+        public ValueTask<bool> ApplyAfterSaveChangesAsync(
+            ApplicationDbContext dbContext,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            AfterSaveChangesAsyncCallCount++;
+
+            return ValueTask.FromResult(false);
+        }
+    }
+
+    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
+    {
+        public string CurrentActor => "PipelineTestActor";
+    }
+}


### PR DESCRIPTION
## Summary

- Extracted application-owned EF Core save preparation into `IApplicationSaveChangesPipeline` / `ApplicationSaveChangesPipeline`.
- Updated `ApplicationDbContext` to delegate save preparation and after-save audit completion to the pipeline while preserving the existing save override flow.
- Registered the pipeline in infrastructure data access services.
- Added sync/async tests that verify an injected save pipeline is invoked by `ApplicationDbContext`.

## Validation

- Not run locally; changes were made through the GitHub connector.
- Existing save-hook coverage should continue to validate normalization, concurrency stamps, timestamp normalization, and auditing behavior.

Closes #319