### PR TITLE
Invoke EF Core save pipeline from SaveChangesInterceptor

### DIFF
--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -17,7 +17,8 @@ public sealed partial class ApplicationDbContext(
     ICurrentActorAccessor currentActorAccessor,
     IOptions<DataAccessOptions> dataAccessOptions,
     IApplicationAuditStore? auditStore = null,
-    IApplicationSaveChangesPipeline? saveChangesPipeline = null
+    IApplicationSaveChangesPipeline? saveChangesPipeline = null,
+    ApplicationSaveChangesInterceptor? saveChangesInterceptor = null
 )
     : DbContext(options)
 {
@@ -27,6 +28,7 @@ public sealed partial class ApplicationDbContext(
             currentActorAccessor,
             dataAccessOptions,
             auditStore);
+    private readonly ApplicationSaveChangesInterceptor? _configuredSaveChangesInterceptor = saveChangesInterceptor;
 
     /// <summary>
     /// Gets the audit records for the application.
@@ -71,8 +73,12 @@ public sealed partial class ApplicationDbContext(
     {
         ArgumentNullException.ThrowIfNull(optionsBuilder);
 
+        ApplicationSaveChangesInterceptor interceptor =
+            _configuredSaveChangesInterceptor ?? new ApplicationSaveChangesInterceptor(_saveChangesPipeline);
+
         _ = optionsBuilder
             .LogTo(message => LogEfCoreMessage(_logger, message), LogLevel.Trace)
+            .AddInterceptors(interceptor)
             .EnableDetailedErrors();
 
         base.OnConfiguring(optionsBuilder);
@@ -90,22 +96,8 @@ public sealed partial class ApplicationDbContext(
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess = true)
     {
-        bool hasChanges = _saveChangesPipeline.ApplyBeforeSaveChanges(this);
-
-        if (!hasChanges)
-        {
-            return base.SaveChanges(acceptAllChangesOnSuccess);
-        }
-
-        int result = SaveChangesWithConcurrencyHandling(
+        return SaveChangesWithConcurrencyHandling(
             () => base.SaveChanges(acceptAllChangesOnSuccess));
-
-        if (_saveChangesPipeline.ApplyAfterSaveChanges(this))
-        {
-            _ = base.SaveChanges();
-        }
-
-        return result;
     }
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
@@ -115,36 +107,14 @@ public sealed partial class ApplicationDbContext(
             cancellationToken);
     }
 
-    public override async Task<int> SaveChangesAsync(
+    public override Task<int> SaveChangesAsync(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
-        bool hasChanges = await _saveChangesPipeline
-            .ApplyBeforeSaveChangesAsync(this, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!hasChanges)
-        {
-            return await base.SaveChangesAsync(
-                acceptAllChangesOnSuccess,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        int result = await SaveChangesWithConcurrencyHandlingAsync(
+        return SaveChangesWithConcurrencyHandlingAsync(
             () => base.SaveChangesAsync(
                 acceptAllChangesOnSuccess,
-                cancellationToken)).ConfigureAwait(false);
-
-        if (await _saveChangesPipeline
-            .ApplyAfterSaveChangesAsync(this, cancellationToken)
-            .ConfigureAwait(false))
-        {
-            _ = await base
-                .SaveChangesAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return result;
+                cancellationToken));
     }
 
     private static bool IsUtcTimestampProperty(string propertyName)

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationSaveChangesInterceptor.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationSaveChangesInterceptor.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace ProjectTemplate.Infrastructure.Data;
+
+/// <summary>
+/// Invokes the application save pipeline from the EF Core SaveChanges interception lifecycle.
+/// </summary>
+public sealed class ApplicationSaveChangesInterceptor : SaveChangesInterceptor
+{
+    private readonly IApplicationSaveChangesPipeline _saveChangesPipeline;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationSaveChangesInterceptor" /> class.
+    /// </summary>
+    /// <param name="saveChangesPipeline">The application-owned save pipeline.</param>
+    public ApplicationSaveChangesInterceptor(IApplicationSaveChangesPipeline saveChangesPipeline)
+    {
+        ArgumentNullException.ThrowIfNull(saveChangesPipeline);
+
+        _saveChangesPipeline = saveChangesPipeline;
+    }
+
+    /// <inheritdoc />
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        if (eventData.Context is ApplicationDbContext dbContext)
+        {
+            _ = _saveChangesPipeline.ApplyBeforeSaveChanges(dbContext);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is ApplicationDbContext dbContext)
+        {
+            _ = await _saveChangesPipeline
+                .ApplyBeforeSaveChangesAsync(dbContext, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override int SavedChanges(
+        SaveChangesCompletedEventData eventData,
+        int result)
+    {
+        if (eventData.Context is ApplicationDbContext dbContext &&
+            _saveChangesPipeline.ApplyAfterSaveChanges(dbContext))
+        {
+            _ = dbContext.SaveChanges();
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is ApplicationDbContext dbContext &&
+            await _saveChangesPipeline
+                .ApplyAfterSaveChangesAsync(dbContext, cancellationToken)
+                .ConfigureAwait(false))
+        {
+            _ = await dbContext
+                .SaveChangesAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return result;
+    }
+}

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationSaveChangesInterceptor.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationSaveChangesInterceptor.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace ProjectTemplate.Infrastructure.Data;

--- a/src/ProjectTemplate.Infrastructure/Data/Entities/DataEntity.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Entities/DataEntity.cs
@@ -12,8 +12,12 @@ public abstract class DataEntity
 
 
     /// <summary>
-    /// Gets or sets the optimistic concurrency token used to detect conflicting updates.
+    /// Gets or sets the application-managed optimistic concurrency token used to detect conflicting updates.
     /// </summary>
+    /// <remarks>
+    /// This token is application-managed so the default template model remains portable across SQLite and SQL Server.
+    /// SQL Server-only applications can replace this pattern with a provider-native rowversion column when appropriate.
+    /// </remarks>
     public string ConcurrencyStamp { get; set; } = NewConcurrencyStamp();
 
     internal static string NewConcurrencyStamp()

--- a/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/Extensions/InfrastructureDataAccessServiceExtensions.cs
@@ -55,6 +55,7 @@ public static class InfrastructureDataAccessServiceExtensions
                 serviceProvider.GetRequiredService<ICurrentActorAccessor>(),
                 serviceProvider.GetRequiredService<IOptions<DataAccessOptions>>(),
                 serviceProvider.GetService<IApplicationAuditStore>()));
+        services.TryAddScoped<ApplicationSaveChangesInterceptor>();
 
         services.AddDbContext<ApplicationDbContext>(options => ConfigureProvider(
                 options,


### PR DESCRIPTION
## Summary

- Added `ApplicationSaveChangesInterceptor` as the composite EF Core save lifecycle interceptor.
- Moved save-pipeline invocation out of the heavy `ApplicationDbContext` save overrides and into EF Core `SavingChanges` / `SavingChangesAsync` and `SavedChanges` / `SavedChangesAsync` hooks.
- Reduced the `ApplicationDbContext` save overrides to optimistic-concurrency exception handling around EF Core's native save flow.
- Registered the interceptor with infrastructure data access services and configured it through `ApplicationDbContext.OnConfiguring`.
- Added XML remarks documenting why the default `ConcurrencyStamp` remains application-managed for SQLite / SQL Server portability.

## Validation

- Not run locally; changes were made through the GitHub connector.
- Existing save-hook and save-pipeline tests should verify that normalization, timestamp handling, concurrency stamps, audit records, and injected pipeline calls continue through the EF Core save flow.

Closes #321