### PR TITLE
Document EF Core SaveChanges interceptor extension decision

### DIFF
--- a/docs/adr/0004-keep-composite-savechanges-interceptor.md
+++ b/docs/adr/0004-keep-composite-savechanges-interceptor.md
@@ -1,0 +1,78 @@
+# ADR 0004: Keep the Composite EF Core SaveChanges Interceptor
+
+## Status
+
+Accepted
+
+## Context
+
+The EF Core save pipeline has been moved out of the heavy `ApplicationDbContext` save overrides and into a composite `ApplicationSaveChangesInterceptor` backed by `IApplicationSaveChangesPipeline`.
+
+The pipeline currently coordinates several ordered persistence concerns:
+
+1. persisted string canonicalization
+2. lookup string normalization
+3. timestamp normalization
+4. application-managed concurrency stamp generation
+5. audit entry creation and after-save audit completion
+
+Issue #322 evaluated whether this composite interceptor should immediately be split into specialized interceptors such as string canonicalization, lookup normalization, timestamp normalization, concurrency stamp, and audit interceptors.
+
+## Decision
+
+Keep the composite `ApplicationSaveChangesInterceptor` as the default implementation for now.
+
+Do not split the save behavior into multiple specialized interceptors until there is a concrete consumer or maintenance need that outweighs the ordering and audit-safety risks.
+
+## Rationale
+
+A composite interceptor keeps save behavior easier to reason about because the pipeline has strict ordering requirements:
+
+- display values must be canonicalized before lookup values are normalized
+- timestamps must be normalized before audit records are created
+- concurrency stamps must be updated before audit records capture current values
+- audit records with temporary values must be completed after EF Core persists the primary entities
+
+Splitting the behavior into multiple interceptors would make that ordering less obvious and could introduce hidden dependency between interceptor registration order and persisted data correctness.
+
+Auditing is the most sensitive part of the pipeline. Keeping audit preparation and after-save completion behind one pipeline preserves the current guardrails:
+
+- audit records are not recursively audited
+- local audit records remain part of the same EF Core save flow
+- generated keys can be captured after the primary save
+- SQLite development and SQL Server deployment behavior remain aligned
+
+## Extension Model
+
+Applications should prefer replacing or decorating `IApplicationSaveChangesPipeline` rather than splitting the interceptor by default.
+
+Replacement is appropriate when a consuming application wants to fully own save preparation behavior.
+
+Decoration is appropriate when a consuming application wants to add behavior before or after the template pipeline while preserving the baseline order.
+
+Audit storage extension should continue to use `IApplicationAuditStore` and `ProjectTemplate:DataAccess:Auditing:StorageMode` when the goal is to change where audit records are written without changing the rest of the save pipeline.
+
+## Consequences
+
+Positive consequences:
+
+- save behavior remains centralized and deterministic
+- audit behavior remains guarded against recursion and lifecycle-order bugs
+- consumer extension has a clear seam through `IApplicationSaveChangesPipeline`
+- the template avoids architectural splitting for its own sake
+
+Tradeoffs:
+
+- individual concerns are not independently replaceable as separate EF Core interceptors yet
+- consumers that need fine-grained replacement must replace or decorate the pipeline rather than swapping one small interceptor
+- a future split may still be worthwhile if real-world consumers need independent ordering, disabling, or replacement of specific save concerns
+
+## Revisit Criteria
+
+Revisit this decision if one or more of the following becomes true:
+
+- consumers need to disable one save concern without replacing the full pipeline
+- audit storage or audit lifecycle logic becomes too complex for the composite pipeline
+- new providers require provider-specific save behavior that cannot remain cleanly isolated
+- tests become difficult to maintain because too many unrelated concerns are coupled inside the pipeline
+- a real extension scenario proves that separate interceptors are safer than a composite pipeline

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -12,3 +12,6 @@
 
 - name: Record Release Surface and Distribution Strategy
   href: 0003-record-release-surface-and-distribution-strategy.md
+
+- name: Keep Composite SaveChanges Interceptor
+  href: 0004-keep-composite-savechanges-interceptor.md

--- a/docs/articles/ef-core-save-pipeline.md
+++ b/docs/articles/ef-core-save-pipeline.md
@@ -1,0 +1,86 @@
+# EF Core Save Pipeline
+
+The template uses a composite EF Core `SaveChangesInterceptor` to invoke the application-owned save pipeline.
+
+The default interceptor is `ApplicationSaveChangesInterceptor`. It delegates save preparation to `IApplicationSaveChangesPipeline` during the EF Core save lifecycle instead of placing the cross-cutting mutation logic directly inside `ApplicationDbContext` save overrides.
+
+## Default Pipeline Order
+
+The default `ApplicationSaveChangesPipeline` preserves the following order:
+
+1. persisted string canonicalization
+2. lookup string normalization
+3. timestamp normalization
+4. application-managed concurrency stamp generation
+5. audit entry creation
+6. after-save audit completion for database-generated values
+
+This order is intentional. Lookup values depend on canonicalized display values. Audit records should capture normalized timestamps and updated concurrency stamps. Audit records that depend on database-generated values must be completed after the primary save succeeds.
+
+## Why the Interceptor Stays Composite
+
+The template intentionally keeps one composite save interceptor rather than separate interceptors for each concern.
+
+Separate interceptors could look cleaner in isolation, but they would make save behavior depend more heavily on registration order. That would make auditing and current-value capture easier to break accidentally.
+
+The composite interceptor keeps the lifecycle easy to reason about:
+
+- `SavingChanges` and `SavingChangesAsync` run the before-save pipeline
+- EF Core performs the primary save
+- `SavedChanges` and `SavedChangesAsync` complete any pending audit records that require generated values
+- audit records are guarded from recursive auditing by the pipeline
+
+## Extension Seams
+
+Applications that need different save behavior should usually replace or decorate `IApplicationSaveChangesPipeline`.
+
+Use a replacement pipeline when the consuming application wants to fully own the save-preparation behavior.
+
+Use a decorator when the consuming application wants to add behavior before or after the default template pipeline while preserving the baseline order.
+
+For audit destination changes, prefer `IApplicationAuditStore` rather than replacing the full save pipeline. The audit store seam is intended for local, outbox, or external sink audit delivery while preserving the rest of the save lifecycle.
+
+## Recommended Extension Pattern
+
+A consuming application can register its own pipeline implementation before constructing `ApplicationDbContext` instances:
+
+```csharp
+services.AddScoped<IApplicationSaveChangesPipeline, MyApplicationSaveChangesPipeline>();
+```
+
+For audit storage changes, register a custom audit store:
+
+```csharp
+services.AddScoped<IApplicationAuditStore, MyApplicationAuditStore>();
+```
+
+Then configure the desired audit storage mode:
+
+```json
+"ProjectTemplate": {
+  "DataAccess": {
+    "Auditing": {
+      "Enabled": true,
+      "StorageMode": "ExternalSink"
+    }
+  }
+}
+```
+
+## Concurrency Token Portability
+
+The template uses an application-managed `ConcurrencyStamp` by default. This keeps the model portable across SQLite development and SQL Server deployments.
+
+SQL Server-only applications may choose to replace this pattern with a provider-native `rowversion` column, but that is not the default because the template is intended to remain provider-portable.
+
+## When to Split Later
+
+The composite interceptor should only be split into specialized interceptors if a real maintenance or consumer-extension need emerges.
+
+Reasonable revisit signals include:
+
+- consumers need to disable one save concern without replacing the full pipeline
+- audit behavior grows complex enough to require its own isolated lifecycle
+- provider-specific behavior cannot remain cleanly isolated inside the pipeline
+- test maintenance becomes harder because the pipeline has too many unrelated responsibilities
+- a real consuming application needs independent ordering or replacement of a specific save concern

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -69,7 +69,11 @@
       href: authorization.md
 
 - name: Data Access
-  href: data-access.md
+  items:
+    - name: Data Access
+      href: data-access.md
+    - name: EF Core Save Pipeline
+      href: ef-core-save-pipeline.md
 
 - name: GitHub Workflow
   href: github-workflow.md


### PR DESCRIPTION
## Summary

- Added ADR 0004 documenting the decision to keep the composite `ApplicationSaveChangesInterceptor` rather than splitting it into specialized interceptors at this stage.
- Documented the evaluation rationale around ordering, audit safety, provider portability, and consumer extension needs.
- Added an EF Core save pipeline article explaining the default pipeline order and extension seams.
- Updated ADR and article TOCs so the new documentation is included in DocFX navigation.

## Decision

Keep the composite interceptor for now. Prefer replacement or decoration of `IApplicationSaveChangesPipeline` for broader save-pipeline customization, and prefer `IApplicationAuditStore` for audit destination changes.

Splitting into specialized interceptors should be revisited only when a concrete consumer or maintenance need outweighs the ordering and audit lifecycle risks.

## Validation

- Not run locally; changes were made through the GitHub connector.
- Documentation-only change. DocFX navigation should include the new ADR and EF Core save pipeline article.

Closes #322