### PR TITLE
Prepare release 2.2.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 2.2.0 - 2026-06-29
+
+### Added
+
+* Added `IApplicationSaveChangesPipeline` and `ApplicationSaveChangesPipeline` to move EF Core save preparation out of `ApplicationDbContext` and into an application-owned persistence pipeline.
+* Added `ApplicationSaveChangesInterceptor` as the composite EF Core save lifecycle interceptor for invoking the save pipeline through `SavingChanges` / `SavingChangesAsync` and `SavedChanges` / `SavedChangesAsync` hooks.
+* Added EF Core save pipeline documentation covering default pipeline order, extension seams, audit lifecycle safety, and the decision to keep a composite interceptor by default.
+* Added ADR 0004 documenting the decision to keep the composite SaveChanges interceptor until a concrete consumer or maintenance need justifies specialized interceptors.
+* Added tests that verify sync and async save-pipeline invocation through `ApplicationDbContext`.
+
+### Changed
+
+* Reduced repeated EF Core `ChangeTracker` inspection by materializing Added/Modified/Deleted entries once and reusing that list across string canonicalization, lookup normalization, timestamp normalization, concurrency stamping, and audit entry creation.
+* Reduced `ApplicationDbContext` save overrides to optimistic-concurrency exception handling around EF Core's native save flow.
+* Kept `ConcurrencyStamp` as the default application-managed optimistic concurrency token and documented why that remains the portable SQLite / SQL Server baseline.
+* Updated package icon and favicon image assets used for repository, NuGet package, and documentation branding.
+* Updated release metadata, package README examples, template packaging docs, citation metadata, and Zenodo metadata for `2.2.0`.
+
+### Notes
+
+* This is a minor release because it introduces and documents a clearer EF Core save-pipeline extension seam while preserving the stable `2.x` package identity, template short name, template options, and default scaffold behavior.
+* The default generated scaffold continues to use the same package identity, template identity, authentication options, data-access options, and local SQLite development path.
+* SQL Server-only consumers may still replace the application-managed concurrency token with provider-native rowversion behavior when appropriate, but the template default remains provider-portable.
+
 ## 2.1.0 - 2026-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 * Added EF Core save pipeline documentation covering default pipeline order, extension seams, audit lifecycle safety, and the decision to keep a composite interceptor by default.
 * Added ADR 0004 documenting the decision to keep the composite SaveChanges interceptor until a concrete consumer or maintenance need justifies specialized interceptors.
 * Added tests that verify sync and async save-pipeline invocation through `ApplicationDbContext`.
+* Added branch-focused tests for `ApplicationSaveChangesInterceptor`, including constructor null-guard, non-`ApplicationDbContext`, and bounded after-save follow-up branches.
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "2.1.0"
-date-released: "2026-06-27"
+version: "2.2.0"
+date-released: "2026-06-29"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
+    <FileVersion>2.2.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Minor 2.1.0 release of the NetCoreApplicationTemplate dotnet new template. This release adds an optional template-owned audit storage seam, documents audit storage extension paths, improves no-op SaveChanges handling, expands production authentication and middleware guidance, adds optional application/domain layering guidance, and refreshes documentation/image assets while preserving the stable 2.x package identity and default scaffold behavior.</PackageReleaseNotes>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <PackageReleaseNotes>Minor 2.2.0 release of the NetCoreApplicationTemplate dotnet new template. This release refactors EF Core SaveChanges preparation into an application-owned save pipeline invoked through a composite SaveChangesInterceptor, reduces repeated ChangeTracker enumeration, documents the EF Core save pipeline extension model, clarifies application-managed concurrency stamp portability, and refreshes package/documentation image assets while preserving the stable 2.x package identity and default scaffold behavior.</PackageReleaseNotes>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -20,13 +20,13 @@ This README is intended for NuGet package consumers. The full repository README 
 Install the template package from NuGet:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.1.0
+dotnet new install NetCoreApplicationTemplate::2.2.0
 ```
 
 For local package validation, install a packed package directly:
 
 ```text
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.1.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.2.0.nupkg
 ```
 
 ## Generate a project
@@ -79,7 +79,7 @@ dotnet test --configuration Release
 Install the newer package version with the same package identity:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.1.0
+dotnet new install NetCoreApplicationTemplate::2.2.0
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 2.1.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.1.0)__
+Current release: __[Release 2.2.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.2.0)__
 
-Tag: `v2.1.0`
+Tag: `v2.2.0`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -163,7 +163,7 @@ The scaffolded consumer output intentionally excludes repository-maintainer cont
 Install the published template package:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.1.0
+dotnet new install NetCoreApplicationTemplate::2.2.0
 ```
 
 ### Pack and Install Locally
@@ -177,7 +177,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.1.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.2.0.nupkg
 ```
 
 Generate a consumer project:
@@ -234,7 +234,7 @@ The non-default scaffold preserves the template's core guardrails, including str
 Update the installed template by installing a newer package version:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.1.0
+dotnet new install NetCoreApplicationTemplate::2.2.0
 ```
 
 Uninstall the template package:
@@ -257,188 +257,3 @@ Package-based install remains the preferred validation path because it more clos
 ## Documentation
 
 Detailed documentation is maintained in the `docs` folder and published with DocFX.
-
-- [Documentation source](docs/index.md)
-- [Published documentation](https://cdcavell.github.io/NetCoreApplicationTemplate/)
-- [Architecture Decision Records](https://cdcavell.github.io/NetCoreApplicationTemplate/adr/)
-- Generated API reference is available through the published documentation navigation.
-
-Documentation areas include:
-
-- [Getting Started](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/getting-started.html)
-- __Release Readiness and Compatibility__
-  - [v1.0 Migration Guide](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/v1-migration-guide.html)
-  - [Public Surface](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/public-surface-v1.html)
-  - [Production Deployment Checklist](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/production-deployment-checklist.html)
-  - [Runtime Readiness](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/runtime-readiness.html)
-  - [Build Quality and Reproducibility](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/build-quality.html)
-  - [Container Release Publishing](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/container-publish.html)
-  - [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html)
-- __Application Basics__
-  - [Project Structure](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/project-structure.html)
-  - [Optional Application and Domain Layers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/optional-application-domain-layers.html)
-  - [Configuration](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/configuration.html)
-  - [Deployment Notes](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/deployment.html)
-  - [Docker Development](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/docker.html)
-- __Middleware Pipeline__
-  - [Middleware Pipeline](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/middleware.html)
-  - [Error Handling](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/error-handling.html)
-  - [Security Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/security-headers.html)
-  - [Forwarded Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/forwarded-headers.html)
-  - [Rate Limiting](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/rate-limiting.html)
-  - [Health Checks](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/health-checks.html)
-- [API Versioning](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/api-versioning.html)
-- __Observability__
-  - [Logging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/logging.html)
-  - [Telemetry](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/telemetry.html)
-- __Authentication and Authorization__
-  - [Authentication](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication.html)
-  - [Production Authentication Hardening](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication-hardening.html)
-  - [Authorization](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authorization.html)
-- [Data Access](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/data-access.html)
-- [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html)
-
-## Repository Governance
-
-Repository-level guidance is maintained in root-level files:
-
-- [Contributing](CONTRIBUTING.md)
-- [Security Policy](SECURITY.md)
-- [Changelog](CHANGELOG.md)
-- [Third-Party Asset Notices](ASSETS-LICENSES.md)
-
-Pull requests targeting `main` require passing CI and Code Owner review for owned paths; stale approvals are dismissed when new reviewable commits are pushed.
-
-## Repository Structure
-
-```text
-/
-├── .github/
-│   ├── workflows/
-│   │   └── GitHub Actions CI and documentation publishing workflows
-│   ├── ISSUE_TEMPLATE/
-│   │   └── Issue templates
-│   ├── dependabot.yml
-│   └── pull_request_template.md
-│
-├── .template.config/
-│   └── dotnet new template metadata
-│
-├── .template.content/
-│   └── consumer scaffold content
-│
-├── docs/
-│   ├── adr/
-│   │   └── Architecture decision records
-│   ├── articles/
-│   │   └── DocFX conceptual documentation
-│   ├── images/
-│   │   └── Documentation and README images
-│   └── docfx.json
-│
-├── scripts/
-│   └── Utility scripts for setup, build, or maintenance
-│
-├── src/
-│   ├── ProjectTemplate.Infrastructure/
-│   └── ProjectTemplate.Web/
-│
-├── tests/
-│   └── ProjectTemplate.Web.Tests/
-│
-├── .dockerignore
-├── .editorconfig
-├── .gitattributes
-├── CHANGELOG.md
-├── CITATION.cff
-├── CONTRIBUTING.md
-├── Dockerfile
-├── docker-compose.yml
-├── LICENSE.txt
-├── NetCoreApplicationTemplate.slnx
-├── NetCoreApplicationTemplate.Template.csproj
-├── PACKAGE-README.md
-├── README.md
-└── SECURITY.md
-```
-
-## Local Documentation Build
-
-Restore local tools:
-
-```powershell
-dotnet tool restore
-```
-
-Build the DocFX site:
-
-```powershell
-dotnet tool run docfx -- docs/docfx.json
-```
-
-Serve the generated site locally:
-
-```powershell
-dotnet tool run docfx -- serve docs/_site
-```
-
-## GitHub Actions
-
-The repository currently includes workflows for:
-
-- Restoring dependencies.
-- Building the solution in Release configuration.
-- Verifying formatting.
-- Running tests.
-- Generating test result and coverage artifacts.
-- Enforcing a 75% minimum line coverage threshold in CI.
-- Failing CI when coverage regresses below the threshold.
-- Packing the template package.
-- Installing the generated `.nupkg` into a clean SDK environment.
-- Scaffolding a consumer project with `dotnet new netcoreapp-template`.
-- Validating expected consumer files and excluded maintainer files.
-- Building and testing scaffolded output on Linux, Windows, and macOS.
-- Running CodeQL analysis.
-- Building and publishing DocFX documentation to GitHub Pages.
-
-Template smoke testing runs on pull requests, supported branch pushes, manual workflow dispatch, and release-style version tags matching `v*.*.*`.
-
-See [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html), [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html), and [ADR-0003](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for details.
-
-## Versioning
-
-This project follows Semantic Versioning using the format:
-
-```text
-MAJOR.MINOR.PATCH
-```
-
-Version numbers are centrally managed through project build metadata so assemblies, future packages, and releases can share a consistent version identity.
-
-See [ADR-0003: Record Release Surface and Distribution Strategy](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for the release-surface decision.
-
-## Citation
-
-If you use this repository, please cite it using the metadata in [`CITATION.cff`](./CITATION.cff) or one of the following: 
-
-- Author ORCID: [0009-0002-2113-0245](https://orcid.org/0009-0002-2113-0245)
-- Zenodo Concept DOI: [10.5281/zenodo.20373042](https://doi.org/10.5281/zenodo.20373042)
-- Suggested plain-text citation:
-
-```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.1.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
-```
-
-## Roadmap
-
-The project is a reusable .NET application template with a stable `2.1.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
-
-See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
-
-## License
-
-This project is licensed under the MIT License.
-
-See [LICENSE.txt](LICENSE.txt) for full license details.
-
-Third-party assets, libraries, templates, icons, fonts, images, or other externally sourced materials used by this project are documented in [ASSETS-LICENSES.md](ASSETS-LICENSES.md).

--- a/README.md
+++ b/README.md
@@ -257,3 +257,188 @@ Package-based install remains the preferred validation path because it more clos
 ## Documentation
 
 Detailed documentation is maintained in the `docs` folder and published with DocFX.
+
+- [Documentation source](docs/index.md)
+- [Published documentation](https://cdcavell.github.io/NetCoreApplicationTemplate/)
+- [Architecture Decision Records](https://cdcavell.github.io/NetCoreApplicationTemplate/adr/)
+- Generated API reference is available through the published documentation navigation.
+
+Documentation areas include:
+
+- [Getting Started](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/getting-started.html)
+- __Release Readiness and Compatibility__
+  - [v1.0 Migration Guide](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/v1-migration-guide.html)
+  - [Public Surface](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/public-surface-v1.html)
+  - [Production Deployment Checklist](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/production-deployment-checklist.html)
+  - [Runtime Readiness](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/runtime-readiness.html)
+  - [Build Quality and Reproducibility](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/build-quality.html)
+  - [Container Release Publishing](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/container-publish.html)
+  - [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html)
+- __Application Basics__
+  - [Project Structure](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/project-structure.html)
+  - [Optional Application and Domain Layers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/optional-application-domain-layers.html)
+  - [Configuration](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/configuration.html)
+  - [Deployment Notes](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/deployment.html)
+  - [Docker Development](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/docker.html)
+- __Middleware Pipeline__
+  - [Middleware Pipeline](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/middleware.html)
+  - [Error Handling](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/error-handling.html)
+  - [Security Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/security-headers.html)
+  - [Forwarded Headers](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/forwarded-headers.html)
+  - [Rate Limiting](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/rate-limiting.html)
+  - [Health Checks](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/health-checks.html)
+- [API Versioning](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/api-versioning.html)
+- __Observability__
+  - [Logging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/logging.html)
+  - [Telemetry](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/telemetry.html)
+- __Authentication and Authorization__
+  - [Authentication](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication.html)
+  - [Production Authentication Hardening](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authentication-hardening.html)
+  - [Authorization](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/authorization.html)
+- [Data Access](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/data-access.html)
+- [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html)
+
+## Repository Governance
+
+Repository-level guidance is maintained in root-level files:
+
+- [Contributing](CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
+- [Changelog](CHANGELOG.md)
+- [Third-Party Asset Notices](ASSETS-LICENSES.md)
+
+Pull requests targeting `main` require passing CI and Code Owner review for owned paths; stale approvals are dismissed when new reviewable commits are pushed.
+
+## Repository Structure
+
+```text
+/
+├── .github/
+│   ├── workflows/
+│   │   └── GitHub Actions CI and documentation publishing workflows
+│   ├── ISSUE_TEMPLATE/
+│   │   └── Issue templates
+│   ├── dependabot.yml
+│   └── pull_request_template.md
+│
+├── .template.config/
+│   └── dotnet new template metadata
+│
+├── .template.content/
+│   └── consumer scaffold content
+│
+├── docs/
+│   ├── adr/
+│   │   └── Architecture decision records
+│   ├── articles/
+│   │   └── DocFX conceptual documentation
+│   ├── images/
+│   │   └── Documentation and README images
+│   └── docfx.json
+│
+├── scripts/
+│   └── Utility scripts for setup, build, or maintenance
+│
+├── src/
+│   ├── ProjectTemplate.Infrastructure/
+│   └── ProjectTemplate.Web/
+│
+├── tests/
+│   └── ProjectTemplate.Web.Tests/
+│
+├── .dockerignore
+├── .editorconfig
+├── .gitattributes
+├── CHANGELOG.md
+├── CITATION.cff
+├── CONTRIBUTING.md
+├── Dockerfile
+├── docker-compose.yml
+├── LICENSE.txt
+├── NetCoreApplicationTemplate.slnx
+├── NetCoreApplicationTemplate.Template.csproj
+├── PACKAGE-README.md
+├── README.md
+└── SECURITY.md
+```
+
+## Local Documentation Build
+
+Restore local tools:
+
+```powershell
+dotnet tool restore
+```
+
+Build the DocFX site:
+
+```powershell
+dotnet tool run docfx -- docs/docfx.json
+```
+
+Serve the generated site locally:
+
+```powershell
+dotnet tool run docfx -- serve docs/_site
+```
+
+## GitHub Actions
+
+The repository currently includes workflows for:
+
+- Restoring dependencies.
+- Building the solution in Release configuration.
+- Verifying formatting.
+- Running tests.
+- Generating test result and coverage artifacts.
+- Enforcing a 75% minimum line coverage threshold in CI.
+- Failing CI when coverage regresses below the threshold.
+- Packing the template package.
+- Installing the generated `.nupkg` into a clean SDK environment.
+- Scaffolding a consumer project with `dotnet new netcoreapp-template`.
+- Validating expected consumer files and excluded maintainer files.
+- Building and testing scaffolded output on Linux, Windows, and macOS.
+- Running CodeQL analysis.
+- Building and publishing DocFX documentation to GitHub Pages.
+
+Template smoke testing runs on pull requests, supported branch pushes, manual workflow dispatch, and release-style version tags matching `v*.*.*`.
+
+See [GitHub Workflow](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/github-workflow.html), [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html), and [ADR-0003](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for details.
+
+## Versioning
+
+This project follows Semantic Versioning using the format:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+Version numbers are centrally managed through project build metadata so assemblies, future packages, and releases can share a consistent version identity.
+
+See [ADR-0003: Record Release Surface and Distribution Strategy](docs/adr/0003-record-release-surface-and-distribution-strategy.md) for the release-surface decision.
+
+## Citation
+
+If you use this repository, please cite it using the metadata in [`CITATION.cff`](./CITATION.cff) or one of the following: 
+
+- Author ORCID: [0009-0002-2113-0245](https://orcid.org/0009-0002-2113-0245)
+- Zenodo Concept DOI: [10.5281/zenodo.20373042](https://doi.org/10.5281/zenodo.20373042)
+- Suggested plain-text citation:
+
+```text
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.2.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+```
+
+## Roadmap
+
+The project is a reusable .NET application template with a stable `2.2.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
+
+See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
+
+## License
+
+This project is licensed under the MIT License.
+
+See [LICENSE.txt](LICENSE.txt) for full license details.
+
+Third-party assets, libraries, templates, icons, fonts, images, or other externally sourced materials used by this project are documented in [ASSETS-LICENSES.md](ASSETS-LICENSES.md).

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -16,7 +16,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template identity | `CDCavell.NetCoreApplicationTemplate.CSharp` |
 | Template group identity | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `2.1.0` |
+| Current package version | `2.2.0` |
 
 The `2.0.0` release moved the public NuGet package ID to `NetCoreApplicationTemplate`. The internal template identity and group identity remain unchanged for template metadata continuity.
 
@@ -92,13 +92,13 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the published package from NuGet:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.1.0
+dotnet new install NetCoreApplicationTemplate::2.2.0
 ```
 
 Install a locally packed package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.1.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.2.0.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary

- Bumps shared build and template package version metadata from `2.1.0` to `2.2.0`.
- Adds the `2.2.0` changelog entry covering the EF Core save-pipeline extraction, composite SaveChanges interceptor, ChangeTracker enumeration reduction, save-pipeline documentation, branch-focused interceptor tests, and package/documentation image refresh.
- Updates template package release notes for the 2.2.0 minor release.
- Updates README, package README, template packaging docs, citation metadata, and Zenodo metadata to reference `2.2.0`.

## Release Notes

This is a minor release because it introduces and documents a clearer EF Core save-pipeline extension seam while preserving the stable `2.x` package identity, template short name, template options, and default scaffold behavior.

The default generated scaffold continues to use the same package identity, template identity, authentication options, data-access options, and local SQLite development path.

## Validation

- Not run locally; changes were made through the GitHub connector.
- CI should run the release branch validation, including build, tests, coverage gate, template packing, scaffold smoke tests, and documentation checks.
- Before publishing, run the release gate items from `RELEASE.md`, including `./scripts/Validate-VersionConsistency.ps1`.

## Notes

- Branch was prepared from latest `main`, including the merged branch coverage test PR #328.