### PR TITLE
Harden rate-limit unknown client fallback

### DIFF
--- a/docs/articles/forwarded-headers.md
+++ b/docs/articles/forwarded-headers.md
@@ -33,5 +33,16 @@ By default, the application processes:
 Production deployments should explicitly configure trusted proxy IP addresses or trusted proxy
 networks using `KnownProxies` or `KnownNetworks`.
 
+Do not trust raw `X-Forwarded-For` values in application code. Forwarded headers are safe to use
+only after ASP.NET Core has processed them through trusted proxy configuration. Middleware that
+reads `HttpContext.Connection.RemoteIpAddress`, including request logging and client IP rate
+limiting, should rely on the corrected `RemoteIpAddress` value rather than parsing forwarded
+headers directly.
+
+`UseForwardedHeaders()` must run before middleware that depends on the client IP, request scheme,
+host, or path base. The template's centralized pipeline applies forwarded headers before request
+logging, HTTPS redirection, routing, CORS, rate limiting, authentication, authorization, and
+endpoint execution.
+
 `XForwardedHost` is intentionally not enabled by default. If enabled, configure `AllowedHosts`
 to reduce the risk of host header spoofing.

--- a/docs/articles/rate-limiting.md
+++ b/docs/articles/rate-limiting.md
@@ -26,6 +26,7 @@ The application supports:
 - JSON rejection responses.
 - `429 Too Many Requests` responses when limits are exceeded.
 - Logging for rejected requests.
+- Warning logging when client IP partitioning must use the unknown-client fallback path.
 
 Rejected requests return a response similar to:
 
@@ -45,6 +46,8 @@ Rate limiting values can be configured from `appsettings.json`:
   "RateLimiting": {
     "Enabled": true,
     "UseGlobalLimiter": true,
+    "UseSharedUnknownClientPartition": false,
+    "UnknownClientPartitionKey": "unknown-client",
     "GlobalFixedWindow": {
       "PermitLimit": 60,
       "WindowSeconds": 60,
@@ -64,6 +67,25 @@ Rate limiting values can be configured from `appsettings.json`:
 ```
 
 These defaults are intentionally conservative and should be reviewed before production use.
+
+## Client Partitioning and Unknown-Client Fallback
+
+The fixed-window limiters partition clients by `HttpContext.Connection.RemoteIpAddress`. The template intentionally relies on ASP.NET Core Forwarded Headers Middleware to correct that value when the application runs behind a trusted reverse proxy, load balancer, ingress controller, CDN, or gateway.
+
+The rate limiter does **not** parse or trust raw `X-Forwarded-For` values directly. Raw forwarded headers are client-controllable unless ASP.NET Core has first validated them through trusted `KnownProxies` or `KnownNetworks` configuration.
+
+When `RemoteIpAddress` is unavailable, the default behavior is to use a per-request fallback partition based on `UnknownClientPartitionKey` and the request trace identifier. This avoids silently collapsing unrelated unresolved clients into one shared bucket.
+
+Set `UseSharedUnknownClientPartition` to `true` only when you intentionally want every unresolved client to share the configured `UnknownClientPartitionKey` bucket:
+
+```json
+"RateLimiting": {
+  "UseSharedUnknownClientPartition": true,
+  "UnknownClientPartitionKey": "unknown-client"
+}
+```
+
+A warning is emitted whenever this fallback path is used. In production, treat that warning as a signal to review forwarded-header configuration, proxy trust settings, and middleware ordering.
 
 ## Endpoint-Specific Policies
 
@@ -111,15 +133,20 @@ If a policy needs authenticated user, tenant, role, or permission data, review m
 
 ## Middleware Order
 
-The application pipeline applies rate limiting after routing:
+Forwarded headers must run before middleware that depends on client IP. The application pipeline applies forwarded headers early and rate limiting after routing:
 
 ```csharp
+app.UseApplicationForwardedHeaders();
+app.UseApplicationRequestLogging();
+
+// ...
+
 app.UseRouting();
-
 app.UseCors();
-
 app.UseRateLimiter();
 ```
+
+This ordering lets request logging and rate limiting see the corrected `RemoteIpAddress` when trusted proxy configuration is correct.
 
 If a future policy depends on the authenticated user identity, rate limiting may need to move after authentication so user-specific partitioning can be applied.
 
@@ -137,5 +164,6 @@ This keeps production endpoints unchanged while allowing the tests to verify:
 - JSON `429 Too Many Requests` rejection responses.
 - Disabled rate limiting behavior.
 - Configuration binding for application rate limiting options.
+- Client IP partition fallback behavior when `RemoteIpAddress` is unavailable.
 
 See [Runtime Readiness Baseline](runtime-readiness.md) for the consolidated release-readiness view.

--- a/src/ProjectTemplate.Web/Extensions/RateLimitingServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/RateLimitingServiceExtensions.cs
@@ -30,6 +30,8 @@ public static partial class RateLimitingServiceExtensions
 
             options.Enabled = defaultOptions.Enabled;
             options.UseGlobalLimiter = defaultOptions.UseGlobalLimiter;
+            options.UseSharedUnknownClientPartition = defaultOptions.UseSharedUnknownClientPartition;
+            options.UnknownClientPartitionKey = defaultOptions.UnknownClientPartitionKey;
 
             options.GlobalFixedWindow.PermitLimit = defaultOptions.GlobalFixedWindow.PermitLimit;
             options.GlobalFixedWindow.WindowSeconds = defaultOptions.GlobalFixedWindow.WindowSeconds;
@@ -46,6 +48,8 @@ public static partial class RateLimitingServiceExtensions
         services
             .AddOptions<ApplicationRateLimitingOptions>()
             .Bind(configuration.GetSection(ApplicationRateLimitingOptions.SectionName))
+            .Validate(options => !string.IsNullOrWhiteSpace(options.UnknownClientPartitionKey),
+                "ProjectTemplate:RateLimiting:UnknownClientPartitionKey must not be empty.")
             .Validate(options => options.GlobalFixedWindow.PermitLimit > 0,
                 "ProjectTemplate:RateLimiting:GlobalFixedWindow:PermitLimit must be greater than zero.")
             .Validate(options => options.GlobalFixedWindow.WindowSeconds > 0,
@@ -122,13 +126,13 @@ public static partial class RateLimitingServiceExtensions
                 {
                     options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
                         RateLimitPartition.GetFixedWindowLimiter(
-                            partitionKey: GetClientPartitionKey(httpContext),
+                            partitionKey: GetClientPartitionKey(httpContext, rateLimitingOptions),
                             factory: _ => CreateFixedWindowRateLimiterOptions(rateLimitingOptions.GlobalFixedWindow)));
                 }
 
                 options.AddPolicy(ApplicationRateLimitingPolicyNames.Fixed, httpContext =>
                     RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: GetClientPartitionKey(httpContext),
+                        partitionKey: GetClientPartitionKey(httpContext, rateLimitingOptions),
                         factory: _ => CreateFixedWindowRateLimiterOptions(rateLimitingOptions.FixedWindowPolicy)));
 
                 options.AddPolicy(ApplicationRateLimitingPolicyNames.Concurrency, httpContext =>
@@ -181,9 +185,49 @@ public static partial class RateLimitingServiceExtensions
         };
     }
 
-    private static string GetClientPartitionKey(HttpContext httpContext)
+    private static string GetClientPartitionKey(
+        HttpContext httpContext,
+        ApplicationRateLimitingOptions options)
     {
-        return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-client";
+        ILogger logger = httpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Template.Web.RateLimiting");
+
+        return GetClientPartitionKey(httpContext, options, logger);
+    }
+
+    internal static string GetClientPartitionKey(
+        HttpContext httpContext,
+        ApplicationRateLimitingOptions options,
+        ILogger logger)
+    {
+        string? remoteIpAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+
+        if (!string.IsNullOrWhiteSpace(remoteIpAddress))
+        {
+            return remoteIpAddress;
+        }
+
+        string fallbackPartitionKey = string.IsNullOrWhiteSpace(options.UnknownClientPartitionKey)
+            ? "unknown-client"
+            : options.UnknownClientPartitionKey.Trim();
+        string fallbackMode = options.UseSharedUnknownClientPartition ? "Shared" : "PerRequest";
+        string fallbackDiscriminator = string.IsNullOrWhiteSpace(httpContext.TraceIdentifier)
+            ? Guid.NewGuid().ToString("N")
+            : httpContext.TraceIdentifier;
+
+        if (!options.UseSharedUnknownClientPartition)
+        {
+            fallbackPartitionKey = $"{fallbackPartitionKey}:{fallbackDiscriminator}";
+        }
+
+        LogRateLimitingClientPartitionFallback(
+            logger,
+            fallbackMode,
+            fallbackPartitionKey,
+            fallbackDiscriminator);
+
+        return fallbackPartitionKey;
     }
 
     private static string GetEndpointPartitionKey(HttpContext httpContext)
@@ -209,5 +253,15 @@ public static partial class RateLimitingServiceExtensions
         string? remoteIpAddress,
         string? endpoint,
         double? retryAfterSeconds,
+        string traceIdentifier);
+
+    [LoggerMessage(
+        EventId = 6002,
+        Level = LogLevel.Warning,
+        Message = "Rate limiting used fallback client partition because RemoteIpAddress was unavailable. FallbackMode: {FallbackMode}; PartitionKey: {PartitionKey}; TraceIdentifier: {TraceIdentifier}. Verify forwarded headers and trusted proxy configuration when running behind a proxy or load balancer.")]
+    private static partial void LogRateLimitingClientPartitionFallback(
+        ILogger logger,
+        string fallbackMode,
+        string partitionKey,
         string traceIdentifier);
 }

--- a/src/ProjectTemplate.Web/Options/ApplicationRateLimitingOptions.cs
+++ b/src/ProjectTemplate.Web/Options/ApplicationRateLimitingOptions.cs
@@ -22,6 +22,17 @@ public sealed class ApplicationRateLimitingOptions
     public bool UseGlobalLimiter { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether requests without a resolved client IP address
+    /// should use one shared fallback partition key.
+    /// </summary>
+    public bool UseSharedUnknownClientPartition { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base fallback partition key used when the client IP address cannot be resolved.
+    /// </summary>
+    public string UnknownClientPartitionKey { get; set; } = "unknown-client";
+
+    /// <summary>
     /// Gets or sets the global fixed-window rate limiting options.
     /// </summary>
     public FixedWindowRateLimitingOptions GlobalFixedWindow { get; set; } = new()

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -82,6 +82,8 @@
     "RateLimiting": {
       "Enabled": true,
       "UseGlobalLimiter": true,
+      "UseSharedUnknownClientPartition": false,
+      "UnknownClientPartitionKey": "unknown-client",
       "GlobalFixedWindow": {
         "PermitLimit": 60,
         "WindowSeconds": 60,

--- a/tests/ProjectTemplate.Web.Tests/RateLimitingTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RateLimitingTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ProjectTemplate.Web.Extensions;
 using ProjectTemplate.Web.Options;
@@ -165,6 +167,8 @@ public sealed class RateLimitingTests
         {
             ["ProjectTemplate:RateLimiting:Enabled"] = "true",
             ["ProjectTemplate:RateLimiting:UseGlobalLimiter"] = "true",
+            ["ProjectTemplate:RateLimiting:UseSharedUnknownClientPartition"] = "true",
+            ["ProjectTemplate:RateLimiting:UnknownClientPartitionKey"] = "configured-unknown-client",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:PermitLimit"] = "7",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:WindowSeconds"] = "30",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:QueueLimit"] = "2",
@@ -181,6 +185,8 @@ public sealed class RateLimitingTests
 
         Assert.True(options.Enabled);
         Assert.True(options.UseGlobalLimiter);
+        Assert.True(options.UseSharedUnknownClientPartition);
+        Assert.Equal("configured-unknown-client", options.UnknownClientPartitionKey);
 
         Assert.Equal(7, options.GlobalFixedWindow.PermitLimit);
         Assert.Equal(30, options.GlobalFixedWindow.WindowSeconds);
@@ -192,6 +198,101 @@ public sealed class RateLimitingTests
 
         Assert.Equal(3, options.ConcurrencyPolicy.PermitLimit);
         Assert.Equal(1, options.ConcurrencyPolicy.QueueLimit);
+    }
+
+    /// <summary>
+    /// Verifies that client rate limiting uses the resolved remote IP address when available.
+    /// </summary>
+    [Fact]
+    public void GetClientPartitionKey_ReturnsRemoteIpAddress_WhenAvailable()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.10");
+        TestLogger logger = new();
+
+        string partitionKey = RateLimitingServiceExtensions.GetClientPartitionKey(
+            httpContext,
+            new ApplicationRateLimitingOptions(),
+            logger);
+
+        Assert.Equal("203.0.113.10", partitionKey);
+        Assert.Empty(logger.Entries);
+    }
+
+    /// <summary>
+    /// Verifies that unresolved client IP addresses use a per-request fallback partition by default.
+    /// </summary>
+    [Fact]
+    public void GetClientPartitionKey_UsesPerRequestFallback_WhenRemoteIpAddressIsUnavailableByDefault()
+    {
+        DefaultHttpContext httpContext = new()
+        {
+            TraceIdentifier = "trace-331"
+        };
+        TestLogger logger = new();
+
+        string partitionKey = RateLimitingServiceExtensions.GetClientPartitionKey(
+            httpContext,
+            new ApplicationRateLimitingOptions(),
+            logger);
+
+        LogEntry entry = Assert.Single(logger.Entries);
+
+        Assert.Equal("unknown-client:trace-331", partitionKey);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(6002, entry.EventId.Id);
+        Assert.Contains("RemoteIpAddress was unavailable", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("PerRequest", entry.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that unresolved client IP addresses only share a fallback partition when explicitly configured.
+    /// </summary>
+    [Fact]
+    public void GetClientPartitionKey_UsesSharedFallback_WhenExplicitlyConfigured()
+    {
+        DefaultHttpContext httpContext = new()
+        {
+            TraceIdentifier = "trace-331-shared"
+        };
+        TestLogger logger = new();
+        ApplicationRateLimitingOptions options = new()
+        {
+            UseSharedUnknownClientPartition = true,
+            UnknownClientPartitionKey = "configured-unknown-client"
+        };
+
+        string partitionKey = RateLimitingServiceExtensions.GetClientPartitionKey(
+            httpContext,
+            options,
+            logger);
+
+        LogEntry entry = Assert.Single(logger.Entries);
+
+        Assert.Equal("configured-unknown-client", partitionKey);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(6002, entry.EventId.Id);
+        Assert.Contains("Shared", entry.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that startup validation fails when the unknown client fallback partition key is empty.
+    /// </summary>
+    [Fact]
+    public void RateLimiting_EmptyUnknownClientPartitionKey_FailsStartup()
+    {
+        OptionsValidationException exception =
+            AssertRateLimitingOptionsValidationFails(
+                new Dictionary<string, string?>
+                {
+                    ["ProjectTemplate:RateLimiting:Enabled"] = "true",
+                    ["ProjectTemplate:RateLimiting:UnknownClientPartitionKey"] = " "
+                });
+
+        Assert.Contains(
+            "ProjectTemplate:RateLimiting:UnknownClientPartitionKey must not be empty",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -309,6 +410,46 @@ public sealed class RateLimitingTests
         return exception.InnerException is null
             ? null
             : FindOptionsValidationException(exception.InnerException);
+    }
+
+    private sealed class TestLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(
+                logLevel,
+                eventId,
+                formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, EventId EventId, string Message);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
     }
 
     private sealed class TestHostEnvironment : IHostEnvironment

--- a/tests/ProjectTemplate.Web.Tests/RateLimitingTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/RateLimitingTests.cs
@@ -31,6 +31,7 @@ public sealed class RateLimitingTests
         {
             ["ProjectTemplate:RateLimiting:Enabled"] = "true",
             ["ProjectTemplate:RateLimiting:UseGlobalLimiter"] = "true",
+            ["ProjectTemplate:RateLimiting:UseSharedUnknownClientPartition"] = "true",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:PermitLimit"] = "1",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:WindowSeconds"] = "60",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:QueueLimit"] = "0"
@@ -56,6 +57,7 @@ public sealed class RateLimitingTests
         {
             ["ProjectTemplate:RateLimiting:Enabled"] = "true",
             ["ProjectTemplate:RateLimiting:UseGlobalLimiter"] = "false",
+            ["ProjectTemplate:RateLimiting:UseSharedUnknownClientPartition"] = "true",
             ["ProjectTemplate:RateLimiting:FixedWindowPolicy:PermitLimit"] = "1",
             ["ProjectTemplate:RateLimiting:FixedWindowPolicy:WindowSeconds"] = "60",
             ["ProjectTemplate:RateLimiting:FixedWindowPolicy:QueueLimit"] = "0"
@@ -111,6 +113,7 @@ public sealed class RateLimitingTests
         {
             ["ProjectTemplate:RateLimiting:Enabled"] = "true",
             ["ProjectTemplate:RateLimiting:UseGlobalLimiter"] = "true",
+            ["ProjectTemplate:RateLimiting:UseSharedUnknownClientPartition"] = "true",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:PermitLimit"] = "1",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:WindowSeconds"] = "60",
             ["ProjectTemplate:RateLimiting:GlobalFixedWindow:QueueLimit"] = "0"
@@ -384,32 +387,6 @@ public sealed class RateLimitingTests
             provider
                 .GetRequiredService<IOptions<ApplicationRateLimitingOptions>>()
                 .Value);
-    }
-
-    private static OptionsValidationException? FindOptionsValidationException(Exception exception)
-    {
-        if (exception is OptionsValidationException optionsValidationException)
-        {
-            return optionsValidationException;
-        }
-
-        if (exception is AggregateException aggregateException)
-        {
-            foreach (Exception innerException in aggregateException.Flatten().InnerExceptions)
-            {
-                OptionsValidationException? foundException =
-                    FindOptionsValidationException(innerException);
-
-                if (foundException is not null)
-                {
-                    return foundException;
-                }
-            }
-        }
-
-        return exception.InnerException is null
-            ? null
-            : FindOptionsValidationException(exception.InnerException);
     }
 
     private sealed class TestLogger : ILogger


### PR DESCRIPTION
## Summary

- Keep client rate-limit partitioning anchored to `HttpContext.Connection.RemoteIpAddress`
- Add configurable unknown-client fallback behavior with per-request fallback as the default
- Emit a warning when `RemoteIpAddress` is unavailable and fallback partitioning is used
- Document trusted forwarded-header configuration, middleware ordering, and why raw `X-Forwarded-For` is not parsed by the rate limiter

## Changes

- Added `UseSharedUnknownClientPartition` and `UnknownClientPartitionKey` to `ApplicationRateLimitingOptions`
- Changed the default unresolved-client behavior from one shared `"unknown-client"` bucket to a per-request `unknown-client:{TraceIdentifier}` partition
- Preserved an explicit opt-in path for shared fallback partitioning when desired
- Added validation for the fallback partition key
- Added unit coverage for resolved IPs, per-request fallback behavior, shared fallback behavior, and option binding/validation
- Updated `appsettings.json`, rate-limiting docs, and forwarded-headers docs

## Validation

- Not run locally; changes were made through the GitHub connector
- Added/updated tests under `tests/ProjectTemplate.Web.Tests/RateLimitingTests.cs`

Closes #331