### PR TITLE
Prepare release 2.3.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 2.3.0 - 2026-07-03
+
+### Added
+
+* Added `UseSharedUnknownClientPartition` to make shared unknown-client rate-limit partitioning an explicit opt-in behavior.
+* Added `UnknownClientPartitionKey` so the unresolved-client fallback partition key can be configured.
+* Added warning logging when client IP partitioning falls back because `HttpContext.Connection.RemoteIpAddress` is unavailable.
+* Added tests covering resolved client IP partitioning, default per-request fallback partitioning, explicit shared fallback partitioning, fallback warning logging, option binding, and fallback-key validation.
+
+### Changed
+
+* Changed unresolved-client rate-limit fallback behavior from a silent shared `"unknown-client"` bucket to a per-request fallback partition by default.
+* Preserved client rate-limit partitioning against `HttpContext.Connection.RemoteIpAddress` rather than parsing raw `X-Forwarded-For` headers inside the rate limiter.
+* Updated rate-limiting documentation to cover fallback partition behavior, production tuning, and forwarded-header trust requirements.
+* Updated forwarded-header documentation to emphasize `KnownProxies` / `KnownNetworks`, middleware ordering, and the risk of trusting raw forwarded headers directly.
+* Updated release metadata, package README examples, template packaging docs, citation metadata, and Zenodo metadata for `2.3.0`.
+
+### Notes
+
+* This is a minor release because it adds a new rate-limit configuration surface and changes unresolved-client fallback behavior while preserving the stable `2.x` package identity, template short name, template options, and default scaffold purpose.
+* Production deployments behind proxies, load balancers, ingress controllers, CDNs, or gateways should verify forwarded-header trust configuration so rate limiting and request logging see the corrected client IP address.
+* Set `ProjectTemplate:RateLimiting:UseSharedUnknownClientPartition` to `true` only when unresolved clients should intentionally share the configured unknown-client fallback bucket.
+
 ## 2.2.0 - 2026-06-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "2.2.0"
-date-released: "2026-06-29"
+version: "2.3.0"
+date-released: "2026-07-03"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>2.2.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <AssemblyVersion>2.3.0.0</AssemblyVersion>
+    <FileVersion>2.3.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Minor 2.2.0 release of the NetCoreApplicationTemplate dotnet new template. This release refactors EF Core SaveChanges preparation into an application-owned save pipeline invoked through a composite SaveChangesInterceptor, reduces repeated ChangeTracker enumeration, documents the EF Core save pipeline extension model, clarifies application-managed concurrency stamp portability, and refreshes package/documentation image assets while preserving the stable 2.x package identity and default scaffold behavior.</PackageReleaseNotes>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <PackageReleaseNotes>Minor 2.3.0 release of the NetCoreApplicationTemplate dotnet new template. This release hardens rate-limit client partition fallback behavior when RemoteIpAddress is unavailable, adds explicit configuration for shared unknown-client partitioning, logs fallback usage, and expands forwarded-header documentation around trusted proxy configuration and middleware ordering while preserving the stable 2.x package identity and default scaffold purpose.</PackageReleaseNotes>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -20,13 +20,13 @@ This README is intended for NuGet package consumers. The full repository README 
 Install the template package from NuGet:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.2.0
+dotnet new install NetCoreApplicationTemplate::2.3.0
 ```
 
 For local package validation, install a packed package directly:
 
 ```text
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.2.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.0.nupkg
 ```
 
 ## Generate a project
@@ -79,7 +79,7 @@ dotnet test --configuration Release
 Install the newer package version with the same package identity:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.2.0
+dotnet new install NetCoreApplicationTemplate::2.3.0
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 2.2.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.2.0)__
+Current release: __[Release 2.3.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.3.0)__
 
-Tag: `v2.2.0`
+Tag: `v2.3.0`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -163,7 +163,7 @@ The scaffolded consumer output intentionally excludes repository-maintainer cont
 Install the published template package:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.2.0
+dotnet new install NetCoreApplicationTemplate::2.3.0
 ```
 
 ### Pack and Install Locally
@@ -177,7 +177,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.2.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.0.nupkg
 ```
 
 Generate a consumer project:
@@ -234,7 +234,7 @@ The non-default scaffold preserves the template's core guardrails, including str
 Update the installed template by installing a newer package version:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.2.0
+dotnet new install NetCoreApplicationTemplate::2.3.0
 ```
 
 Uninstall the template package:
@@ -426,12 +426,12 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.2.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.3.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap
 
-The project is a reusable .NET application template with a stable `2.2.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
+The project is a reusable .NET application template with a stable `2.3.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
 
 See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -16,7 +16,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template identity | `CDCavell.NetCoreApplicationTemplate.CSharp` |
 | Template group identity | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `2.2.0` |
+| Current package version | `2.3.0` |
 
 The `2.0.0` release moved the public NuGet package ID to `NetCoreApplicationTemplate`. The internal template identity and group identity remain unchanged for template metadata continuity.
 
@@ -92,13 +92,13 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the published package from NuGet:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.2.0
+dotnet new install NetCoreApplicationTemplate::2.3.0
 ```
 
 Install a locally packed package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.2.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.0.nupkg
 ```
 
 ## Create a New Project from the Template
@@ -217,9 +217,3 @@ Stable usage follows this pattern:
 dotnet new install NetCoreApplicationTemplate
 dotnet new netcoreapp-template -n ContosoSecurityPortal
 ```
-
-Clone-and-modify remains valid for source review, contribution, and direct customization. However, the NuGet template package is the primary stable distribution path for normal template consumers.
-
-Changes to the template short name, public package identity, template parameters, symbols, or source-name replacement behavior should be reviewed as release-surface changes.
-
-See [ADR-0003: Record Release Surface and Distribution Strategy](../adr/0003-record-release-surface-and-distribution-strategy.md) for the release-surface decision.


### PR DESCRIPTION
## Summary

- Bump repository and template package metadata from `2.2.0` to `2.3.0`
- Add the `2.3.0` changelog entry for rate-limit unknown-client fallback hardening
- Refresh README, package README, template packaging docs, citation metadata, and Zenodo metadata for the release

## Release Focus

Release `2.3.0` captures the rate-limit client partition fallback hardening from #331 / #333:

- Default unresolved-client fallback now avoids silently sharing one `"unknown-client"` bucket
- Shared unknown-client partitioning is available only when explicitly configured
- Fallback usage is logged
- Forwarded-header documentation now emphasizes trusted proxy configuration and middleware ordering

## Validation

- Not run locally; release metadata changes were made through the GitHub connector
- CI should validate build, tests, template package smoke tests, version consistency, and documentation generation

## Notes

I did not find another obvious release-blocking modification before the `2.3.0` bump. No new issues were created.