### PR TITLE
Require save changes pipeline DI registration

### DIFF
--- a/docs/articles/ef-core-save-pipeline.md
+++ b/docs/articles/ef-core-save-pipeline.md
@@ -4,6 +4,8 @@ The template uses a composite EF Core `SaveChangesInterceptor` to invoke the app
 
 The default interceptor is `ApplicationSaveChangesInterceptor`. It delegates save preparation to `IApplicationSaveChangesPipeline` during the EF Core save lifecycle instead of placing the cross-cutting mutation logic directly inside `ApplicationDbContext` save overrides.
 
+`ApplicationDbContext` requires `IApplicationSaveChangesPipeline` as a non-null dependency. Missing registration should fail during service resolution instead of falling back to an internally constructed pipeline.
+
 ## Default Pipeline Order
 
 The default `ApplicationSaveChangesPipeline` preserves the following order:

--- a/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplate.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,10 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using ProjectTemplate.Infrastructure.Data.Auditing;
 using ProjectTemplate.Infrastructure.Data.Entities;
-using ProjectTemplate.Infrastructure.Data.Options;
 
 namespace ProjectTemplate.Infrastructure.Data;
 
@@ -14,20 +11,14 @@ namespace ProjectTemplate.Infrastructure.Data;
 public sealed partial class ApplicationDbContext(
     DbContextOptions<ApplicationDbContext> options,
     ILogger<ApplicationDbContext> logger,
-    ICurrentActorAccessor currentActorAccessor,
-    IOptions<DataAccessOptions> dataAccessOptions,
-    IApplicationAuditStore? auditStore = null,
-    IApplicationSaveChangesPipeline? saveChangesPipeline = null,
+    IApplicationSaveChangesPipeline saveChangesPipeline,
     ApplicationSaveChangesInterceptor? saveChangesInterceptor = null
 )
     : DbContext(options)
 {
     private readonly ILogger<ApplicationDbContext> _logger = logger;
     private readonly IApplicationSaveChangesPipeline _saveChangesPipeline =
-        saveChangesPipeline ?? new ApplicationSaveChangesPipeline(
-            currentActorAccessor,
-            dataAccessOptions,
-            auditStore);
+        saveChangesPipeline ?? throw new ArgumentNullException(nameof(saveChangesPipeline));
     private readonly ApplicationSaveChangesInterceptor? _configuredSaveChangesInterceptor = saveChangesInterceptor;
 
     /// <summary>

--- a/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationAuditStoreSeamTests.cs
@@ -65,12 +65,15 @@ public sealed class ApplicationAuditStoreSeamTests
             }
         };
 
-        return new ApplicationDbContext(
-            options,
-            NullLogger<ApplicationDbContext>.Instance,
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
             new TestCurrentActorAccessor(),
             Microsoft.Extensions.Options.Options.Create(dataAccessOptions),
             auditStore);
+
+        return new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            saveChangesPipeline);
     }
 
     private sealed class CapturingApplicationAuditStore : IApplicationAuditStore

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextBranchGapTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextBranchGapTests.cs
@@ -233,11 +233,14 @@ public sealed class ApplicationDbContextBranchGapTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private static DateTime NormalizeExpectedUtc(DateTime value)

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextConcurrencyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextConcurrencyTests.cs
@@ -154,11 +154,14 @@ public sealed class ApplicationDbContextConcurrencyTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextDecimalPrecisionTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextDecimalPrecisionTests.cs
@@ -58,11 +58,14 @@ public sealed class ApplicationDbContextDecimalPrecisionTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSaveHookBranchCoverageTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSaveHookBranchCoverageTests.cs
@@ -308,11 +308,14 @@ public sealed class ApplicationDbContextSaveHookBranchCoverageTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSavePipelineTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextSavePipelineTests.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
-using ProjectTemplate.Infrastructure.Data.Options;
 
 namespace ProjectTemplate.Web.Tests;
 
@@ -59,6 +58,23 @@ public sealed class ApplicationDbContextSavePipelineTests
         Assert.Equal(1, saveChangesPipeline.AfterSaveChangesAsyncCallCount);
     }
 
+    [Fact]
+    public async Task Constructor_WithNullSaveChangesPipeline_ThrowsArgumentNullException()
+    {
+        await using SqliteConnection connection = await CreateOpenConnectionAsync();
+
+        DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new ApplicationDbContext(
+            options,
+            NullLogger<ApplicationDbContext>.Instance,
+            saveChangesPipeline: null!));
+
+        Assert.Equal("saveChangesPipeline", exception.ParamName);
+    }
+
     private static async Task<SqliteConnection> CreateOpenConnectionAsync()
     {
         SqliteConnection connection = new("Data Source=:memory:");
@@ -91,20 +107,10 @@ public sealed class ApplicationDbContextSavePipelineTests
             .UseSqlite(connection)
             .Options;
 
-        DataAccessOptions dataAccessOptions = new()
-        {
-            Auditing = new DataAuditingOptions
-            {
-                Enabled = false
-            }
-        };
-
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions),
-            saveChangesPipeline: saveChangesPipeline);
+            saveChangesPipeline);
     }
 
     private sealed class TrackingSaveChangesPipeline : IApplicationSaveChangesPipeline
@@ -158,10 +164,5 @@ public sealed class ApplicationDbContextSavePipelineTests
 
             return ValueTask.FromResult(false);
         }
-    }
-
-    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
-    {
-        public string CurrentActor => "PipelineTestActor";
     }
 }

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextStringCanonicalizationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextStringCanonicalizationTests.cs
@@ -158,11 +158,14 @@ public sealed class ApplicationDbContextStringCanonicalizationTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/ApplicationDbContextTimestampPersistenceTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationDbContextTimestampPersistenceTests.cs
@@ -122,11 +122,14 @@ public sealed class ApplicationDbContextTimestampPersistenceTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/ApplicationSaveChangesInterceptorBranchCoverageTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ApplicationSaveChangesInterceptorBranchCoverageTests.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using ProjectTemplate.Infrastructure.Data;
 using ProjectTemplate.Infrastructure.Data.Entities;
-using ProjectTemplate.Infrastructure.Data.Options;
 
 namespace ProjectTemplate.Web.Tests;
 
@@ -140,20 +139,10 @@ public sealed class ApplicationSaveChangesInterceptorBranchCoverageTests
             .UseSqlite(connection)
             .Options;
 
-        DataAccessOptions dataAccessOptions = new()
-        {
-            Auditing = new DataAuditingOptions
-            {
-                Enabled = false
-            }
-        };
-
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions),
-            saveChangesPipeline: saveChangesPipeline);
+            saveChangesPipeline);
     }
 
     private static ExternalLoginAccount CreatePersistableAccount(string providerUserId)
@@ -236,11 +225,6 @@ public sealed class ApplicationSaveChangesInterceptorBranchCoverageTests
             _afterSaveShouldReturnTrue = false;
             return true;
         }
-    }
-
-    private sealed class TestCurrentActorAccessor : ICurrentActorAccessor
-    {
-        public string CurrentActor => "InterceptorBranchTestActor";
     }
 
     private sealed class NonApplicationDbContext(DbContextOptions<NonApplicationDbContext> options)

--- a/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountNormalizationTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountNormalizationTests.cs
@@ -164,11 +164,14 @@ public sealed class ExternalLoginAccountNormalizationTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountResolverTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/ExternalLoginAccountResolverTests.cs
@@ -315,11 +315,14 @@ public sealed class ExternalLoginAccountResolverTests
             }
         };
 
+        IApplicationSaveChangesPipeline saveChangesPipeline = new ApplicationSaveChangesPipeline(
+            new TestCurrentActorAccessor(),
+            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+
         return new ApplicationDbContext(
             options,
             NullLogger<ApplicationDbContext>.Instance,
-            new TestCurrentActorAccessor(),
-            Microsoft.Extensions.Options.Options.Create(dataAccessOptions));
+            saveChangesPipeline);
     }
 
     private sealed class TestCurrentActorAccessor : ICurrentActorAccessor

--- a/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace ProjectTemplate.Web.Tests;
 public sealed class InfrastructureDataAccessServiceExtensionsTests
 {
     [Fact]
-    public void AddApplicationInfrastructureDataAccess_NonWebContainer_ResolvesDbContextAndFactory()
+    public void AddApplicationInfrastructureDataAccess_NonWebContainer_ResolvesDbContextFactoryAndPipeline()
     {
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(
@@ -28,7 +28,12 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
         services.AddLogging();
         services.AddApplicationInfrastructureDataAccess(configuration);
 
-        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+        using ServiceProvider serviceProvider = services.BuildServiceProvider(
+            new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
         using IServiceScope scope = serviceProvider.CreateScope();
 
         ICurrentActorAccessor actorAccessor = scope.ServiceProvider
@@ -36,6 +41,12 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
 
         IApplicationAuditStore auditStore = scope.ServiceProvider
             .GetRequiredService<IApplicationAuditStore>();
+
+        IApplicationSaveChangesPipeline saveChangesPipeline = scope.ServiceProvider
+            .GetRequiredService<IApplicationSaveChangesPipeline>();
+
+        ApplicationSaveChangesInterceptor saveChangesInterceptor = scope.ServiceProvider
+            .GetRequiredService<ApplicationSaveChangesInterceptor>();
 
         using ApplicationDbContext context = scope.ServiceProvider
             .GetRequiredService<ApplicationDbContext>();
@@ -47,8 +58,27 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
 
         Assert.Equal(SystemCurrentActorAccessor.ActorName, actorAccessor.CurrentActor);
         Assert.IsType<LocalApplicationAuditStore>(auditStore);
+        Assert.IsType<ApplicationSaveChangesPipeline>(saveChangesPipeline);
+        Assert.NotNull(saveChangesInterceptor);
         Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", context.Database.ProviderName);
         Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", factoryContext.Database.ProviderName);
+    }
+
+    [Fact]
+    public void ApplicationDbContext_MissingSaveChangesPipelineRegistration_ThrowsDuringResolution()
+    {
+        ServiceCollection services = new();
+
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite("Data Source=:memory:"));
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+        using IServiceScope scope = serviceProvider.CreateScope();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => scope.ServiceProvider.GetRequiredService<ApplicationDbContext>());
+
+        Assert.Contains(nameof(IApplicationSaveChangesPipeline), exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -71,6 +101,8 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
 
         Assert.Null(serviceProvider.GetService<ICurrentActorAccessor>());
         Assert.Null(serviceProvider.GetService<IApplicationAuditStore>());
+        Assert.Null(serviceProvider.GetService<IApplicationSaveChangesPipeline>());
+        Assert.Null(serviceProvider.GetService<ApplicationSaveChangesInterceptor>());
         Assert.Null(serviceProvider.GetService<ApplicationDbContext>());
         Assert.Null(serviceProvider.GetService<IDbContextFactory<ApplicationDbContext>>());
         Assert.Null(serviceProvider.GetService<IExternalLoginAccountResolver>());

--- a/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/InfrastructureDataAccessServiceExtensionsTests.cs
@@ -76,7 +76,7 @@ public sealed class InfrastructureDataAccessServiceExtensionsTests
         using IServiceScope scope = serviceProvider.CreateScope();
 
         InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
-            () => scope.ServiceProvider.GetRequiredService<ApplicationDbContext>());
+            scope.ServiceProvider.GetRequiredService<ApplicationDbContext>);
 
         Assert.Contains(nameof(IApplicationSaveChangesPipeline), exception.Message, StringComparison.Ordinal);
     }


### PR DESCRIPTION
Closes #337

## Summary
- require `ApplicationDbContext` to receive `IApplicationSaveChangesPipeline` directly and remove the internal `ApplicationSaveChangesPipeline` fallback construction
- update direct DbContext construction tests to pass an explicit save pipeline
- add DI regression coverage so missing save-pipeline registration fails during normal service-provider resolution
- document that the save pipeline is a required DbContext dependency

## Testing
- Not run locally; changes were made through the GitHub connector.