### PR TITLE
Prepare release 2.3.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 2.3.1 - 2026-07-06
+
+### Changed
+
+* Changed centralized Problem Details exception mapping so plain `ArgumentException` is treated as an internal server fault instead of a bad request.
+* Preserved `BadHttpRequestException` mapping to HTTP 400 for request-level malformed input failures.
+* Updated Problem Details tests to verify status, title, and production detail-hiding behavior for both request-level and internal exception paths.
+* Updated release metadata, package README examples, template packaging docs, citation metadata, and Zenodo metadata for `2.3.1`.
+
+### Notes
+
+* This is a patch release because it hardens exception classification and diagnostics without changing package identity, template identity, template options, or the default scaffold purpose.
+* Internal/developer argument failures now contribute to server-error diagnostics instead of being misclassified as client bad-request traffic.
+
 ## 2.3.0 - 2026-07-03
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "2.3.0"
-date-released: "2026-07-03"
+version: "2.3.1"
+date-released: "2026-07-06"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
-    <FileVersion>2.3.0.0</FileVersion>
+    <AssemblyVersion>2.3.1.0</AssemblyVersion>
+    <FileVersion>2.3.1.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Minor 2.3.0 release of the NetCoreApplicationTemplate dotnet new template. This release hardens rate-limit client partition fallback behavior when RemoteIpAddress is unavailable, adds explicit configuration for shared unknown-client partitioning, logs fallback usage, and expands forwarded-header documentation around trusted proxy configuration and middleware ordering while preserving the stable 2.x package identity and default scaffold purpose.</PackageReleaseNotes>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <PackageReleaseNotes>Patch 2.3.1 release of the NetCoreApplicationTemplate dotnet new template. This release hardens centralized Problem Details exception classification by treating plain ArgumentException as an internal server fault while preserving BadHttpRequestException as the explicit request-level HTTP 400 path, with tests covering status, title, and production detail-hiding behavior.</PackageReleaseNotes>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -20,13 +20,13 @@ This README is intended for NuGet package consumers. The full repository README 
 Install the template package from NuGet:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.3.0
+dotnet new install NetCoreApplicationTemplate::2.3.1
 ```
 
 For local package validation, install a packed package directly:
 
 ```text
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.1.nupkg
 ```
 
 ## Generate a project
@@ -79,7 +79,7 @@ dotnet test --configuration Release
 Install the newer package version with the same package identity:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.3.0
+dotnet new install NetCoreApplicationTemplate::2.3.1
 ```
 
 ## Uninstall
@@ -93,8 +93,8 @@ dotnet new uninstall NetCoreApplicationTemplate
 - GitHub repository: https://github.com/cdcavell/NetCoreApplicationTemplate
 - Published documentation: https://cdcavell.github.io/NetCoreApplicationTemplate/
 - Template packaging documentation: https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html
-- Changelog: https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/CHANGELOG.md
-- License: https://github.com/cdcavell/NetCoreApplicationTemplate/blob/main/LICENSE.txt
+- Changelog: CHANGELOG.md
+- License: LICENSE.txt
 - Releases: https://github.com/cdcavell/NetCoreApplicationTemplate/releases
 - Coverage Report: https://cdcavell.github.io/NetCoreApplicationTemplate/coverage/index.html
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This repository provides a working application baseline with common infrastructu
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 2.3.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.3.0)__
+Current release: __[Release 2.3.1](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.3.1)__
 
-Tag: `v2.3.0`
+Tag: `v2.3.1`
 <!-- END LATEST_RELEASE -->
 
 ## Project Goals
@@ -163,7 +163,7 @@ The scaffolded consumer output intentionally excludes repository-maintainer cont
 Install the published template package:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.3.0
+dotnet new install NetCoreApplicationTemplate::2.3.1
 ```
 
 ### Pack and Install Locally
@@ -177,7 +177,7 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the generated package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.1.nupkg
 ```
 
 Generate a consumer project:
@@ -234,7 +234,7 @@ The non-default scaffold preserves the template's core guardrails, including str
 Update the installed template by installing a newer package version:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.3.0
+dotnet new install NetCoreApplicationTemplate::2.3.1
 ```
 
 Uninstall the template package:
@@ -426,12 +426,12 @@ If you use this repository, please cite it using the metadata in [`CITATION.cff`
 - Suggested plain-text citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.3.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.3.1. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## Roadmap
 
-The project is a reusable .NET application template with a stable `2.3.0` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
+The project is a reusable .NET application template with a stable `2.3.1` package baseline. Future work may include additional provider modules, expanded examples, optional template parameters, and continued hardening of the documented release surface.
 
 See [Template Packaging](https://cdcavell.github.io/NetCoreApplicationTemplate/articles/template-packaging.html) for the current packaging direction.
 

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -16,7 +16,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template identity | `CDCavell.NetCoreApplicationTemplate.CSharp` |
 | Template group identity | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `2.3.0` |
+| Current package version | `2.3.1` |
 
 The `2.0.0` release moved the public NuGet package ID to `NetCoreApplicationTemplate`. The internal template identity and group identity remain unchanged for template metadata continuity.
 
@@ -92,13 +92,13 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the published package from NuGet:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.3.0
+dotnet new install NetCoreApplicationTemplate::2.3.1
 ```
 
 Install a locally packed package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.3.1.nupkg
 ```
 
 ## Create a New Project from the Template


### PR DESCRIPTION
## Summary
- bump repository and template package version metadata to `2.3.1`
- add the `2.3.1` changelog entry for the Problem Details exception-classification hardening
- update README, package README, template-packaging guidance, citation metadata, and Zenodo metadata for the release

## Testing
- Not run locally; release-prep metadata updates should be validated by CI.