### PR TITLE
Require authenticated access by default

### DIFF
--- a/.template.content/src/ProjectTemplate.Web/appsettings.json
+++ b/.template.content/src/ProjectTemplate.Web/appsettings.json
@@ -209,6 +209,7 @@
       "ProviderMappings": {}
     },
     "Authorization": {
+      "RequireAuthenticatedUserByDefault": TemplateAuthEnabled,
       "RoleClaimType": "application:role",
       "PermissionClaimType": "application:permission",
       "AdministratorRoles": [

--- a/docs/articles/authorization.md
+++ b/docs/articles/authorization.md
@@ -24,6 +24,7 @@ Configuration example:
 ```json
 "ProjectTemplate": {
   "Authorization": {
+    "RequireAuthenticatedUserByDefault": true,
     "RoleClaimType": "application:role",
     "PermissionClaimType": "application:permission",
     "AdministratorRoles": [
@@ -38,36 +39,50 @@ Configuration example:
 
 ## Default Authorization Posture
 
-The template registers named policies but does not force every endpoint to require authorization by default.
+The default scaffold is closed by default for routed endpoints. When `ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault` is `true`, ASP.NET Core registers a fallback authorization policy that requires an authenticated user for endpoints without authorization metadata.
 
-Application authors should apply authorization intentionally at the controller, Razor Page, endpoint, folder, or convention level. This keeps the base template runnable while still providing clear policy names for protected application areas.
+This protects newly added controller actions, Razor Pages, and other routed endpoints when a developer does not attach an `[Authorize]` attribute or named policy. Stronger role, permission, claim, or custom policies still apply where they are declared explicitly.
 
-For production applications that should be closed by default, the consuming application can opt in to a fallback authorization policy.
+Endpoints that are intentionally public must opt out explicitly by using `[AllowAnonymous]`, `.AllowAnonymous()`, or an equivalent endpoint convention. The base application currently makes authentication entry points and infrastructure health probes explicit anonymous exceptions.
 
-```csharp
-using Microsoft.AspNetCore.Authorization;
+The authentication-disabled template variant generated with `--authProvider none` sets both of the following values to `false`:
 
-builder.Services.AddAuthorization(options =>
-{
-    options.FallbackPolicy = new AuthorizationPolicyBuilder()
-        .RequireAuthenticatedUser()
-        .Build();
-});
+```json
+"Authentication": {
+  "Enabled": false
+},
+"Authorization": {
+  "RequireAuthenticatedUserByDefault": false
+}
 ```
 
-This fallback policy is not enabled by default. Enabling it changes the default posture for endpoints that do not explicitly declare authorization metadata.
+Application startup validation rejects an inconsistent configuration where authentication is disabled while the fallback authorization policy still requires an authenticated user.
 
-Before enabling a fallback policy, review endpoints that must remain publicly reachable, including:
+### Deliberate opt-out
 
-- Login, logout, callback, and access-denied endpoints.
-- Health check endpoints.
-- Static files and browser assets.
+A consuming application that intentionally wants unannotated routed endpoints to remain public can disable the fallback policy:
+
+```json
+"ProjectTemplate": {
+  "Authorization": {
+    "RequireAuthenticatedUserByDefault": false
+  }
+}
+```
+
+This is an application-wide security posture change. Review all endpoint surfaces before disabling it, and prefer explicit anonymous metadata for isolated public routes.
+
+### Public endpoint review
+
+Review endpoints that must remain publicly reachable, including:
+
+- Login, external challenge, callback, and access-denied endpoints.
+- Health check endpoints used by infrastructure, reverse proxies, or orchestration platforms.
 - Public documentation or landing pages.
 - API endpoints that intentionally allow anonymous access.
+- Static files and browser assets, which are served by static-file middleware rather than routed endpoint authorization metadata.
 
-Use `[AllowAnonymous]` intentionally for endpoints that should remain public.
-
-Named role and permission policies still apply where they are explicitly used.
+Use `[AllowAnonymous]` intentionally for routed endpoints that should remain public.
 
 ## Named Policy Usage Examples
 

--- a/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using ProjectTemplate.Web.Authentication.Claims;
 using ProjectTemplate.Web.Authentication.Options;
 
@@ -25,6 +26,9 @@ public static class AuthorizationServiceExtensions
             .GetSection(ApplicationAuthorizationOptions.SectionName)
             .Get<ApplicationAuthorizationOptions>() ?? new ApplicationAuthorizationOptions();
 
+        bool authenticationEnabled = configuration.GetValue<bool>(
+            $"{ApplicationAuthenticationOptions.SectionName}:Enabled");
+
         string roleClaimType = string.IsNullOrWhiteSpace(options.RoleClaimType)
             ? ApplicationClaimTypes.Role
             : options.RoleClaimType;
@@ -36,6 +40,9 @@ public static class AuthorizationServiceExtensions
         services
             .AddOptions<ApplicationAuthorizationOptions>()
             .Bind(configuration.GetSection(ApplicationAuthorizationOptions.SectionName))
+            .Validate(
+                options => !options.RequireAuthenticatedUserByDefault || authenticationEnabled,
+                "ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault cannot be true when ProjectTemplate:Authentication:Enabled is false.")
             .Validate(
                 options => !string.IsNullOrWhiteSpace(options.RoleClaimType),
                 "ProjectTemplate:Authorization:RoleClaimType is required.")
@@ -50,7 +57,7 @@ public static class AuthorizationServiceExtensions
                 "ProjectTemplate:Authorization:ManageApplicationPermissions must contain at least one non-empty value.")
             .ValidateOnStart();
 
-        services.AddAuthorizationBuilder()
+        AuthorizationBuilder authorizationBuilder = services.AddAuthorizationBuilder()
             .AddPolicy(
                 ApplicationAuthorizationPolicyNames.AuthenticatedUser,
                 policy => policy.RequireAuthenticatedUser())
@@ -68,6 +75,13 @@ public static class AuthorizationServiceExtensions
                     policy.RequireAuthenticatedUser();
                     policy.RequireClaim(permissionClaimType, options.ManageApplicationPermissions);
                 });
+
+        if (options.RequireAuthenticatedUserByDefault)
+        {
+            authorizationBuilder.SetFallbackPolicy(new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build());
+        }
 
         return services;
     }

--- a/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
 using ProjectTemplate.Web.Authentication.Claims;
 using ProjectTemplate.Web.Authentication.Options;
 
@@ -26,9 +27,6 @@ public static class AuthorizationServiceExtensions
             .GetSection(ApplicationAuthorizationOptions.SectionName)
             .Get<ApplicationAuthorizationOptions>() ?? new ApplicationAuthorizationOptions();
 
-        bool authenticationEnabled = configuration.GetValue<bool>(
-            $"{ApplicationAuthenticationOptions.SectionName}:Enabled");
-
         string roleClaimType = string.IsNullOrWhiteSpace(options.RoleClaimType)
             ? ApplicationClaimTypes.Role
             : options.RoleClaimType;
@@ -41,23 +39,25 @@ public static class AuthorizationServiceExtensions
             .AddOptions<ApplicationAuthorizationOptions>()
             .Bind(configuration.GetSection(ApplicationAuthorizationOptions.SectionName))
             .Validate(
-                options => !options.RequireAuthenticatedUserByDefault || authenticationEnabled,
+                authorizationOptions =>
+                    !authorizationOptions.RequireAuthenticatedUserByDefault ||
+                    configuration.GetValue<bool>($"{ApplicationAuthenticationOptions.SectionName}:Enabled"),
                 "ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault cannot be true when ProjectTemplate:Authentication:Enabled is false.")
             .Validate(
-                options => !string.IsNullOrWhiteSpace(options.RoleClaimType),
+                authorizationOptions => !string.IsNullOrWhiteSpace(authorizationOptions.RoleClaimType),
                 "ProjectTemplate:Authorization:RoleClaimType is required.")
             .Validate(
-                options => !string.IsNullOrWhiteSpace(options.PermissionClaimType),
+                authorizationOptions => !string.IsNullOrWhiteSpace(authorizationOptions.PermissionClaimType),
                 "ProjectTemplate:Authorization:PermissionClaimType is required.")
             .Validate(
-                options => options.AdministratorRoles.Any(role => !string.IsNullOrWhiteSpace(role)),
+                authorizationOptions => authorizationOptions.AdministratorRoles.Any(role => !string.IsNullOrWhiteSpace(role)),
                 "ProjectTemplate:Authorization:AdministratorRoles must contain at least one non-empty value.")
             .Validate(
-                options => options.ManageApplicationPermissions.Any(permission => !string.IsNullOrWhiteSpace(permission)),
+                authorizationOptions => authorizationOptions.ManageApplicationPermissions.Any(permission => !string.IsNullOrWhiteSpace(permission)),
                 "ProjectTemplate:Authorization:ManageApplicationPermissions must contain at least one non-empty value.")
             .ValidateOnStart();
 
-        AuthorizationBuilder authorizationBuilder = services.AddAuthorizationBuilder()
+        services.AddAuthorizationBuilder()
             .AddPolicy(
                 ApplicationAuthorizationPolicyNames.AuthenticatedUser,
                 policy => policy.RequireAuthenticatedUser())
@@ -76,12 +76,14 @@ public static class AuthorizationServiceExtensions
                     policy.RequireClaim(permissionClaimType, options.ManageApplicationPermissions);
                 });
 
-        if (options.RequireAuthenticatedUserByDefault)
-        {
-            authorizationBuilder.SetFallbackPolicy(new AuthorizationPolicyBuilder()
-                .RequireAuthenticatedUser()
-                .Build());
-        }
+        services
+            .AddOptions<AuthorizationOptions>()
+            .Configure<IOptions<ApplicationAuthorizationOptions>>((authorizationOptions, applicationAuthorizationOptions) =>
+            {
+                authorizationOptions.FallbackPolicy = applicationAuthorizationOptions.Value.RequireAuthenticatedUserByDefault
+                    ? new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build()
+                    : null;
+            });
 
         return services;
     }
@@ -96,10 +98,12 @@ public static class ApplicationAuthorizationPolicyNames
     /// Policy requiring the current user to be authenticated.
     /// </summary>
     public const string AuthenticatedUser = "application.AuthenticatedUser";
+
     /// <summary>
     /// Policy defining the administrator role.
     /// </summary>
     public const string AdministratorRole = "application.Role.Administrator";
+
     /// <summary>
     /// Policy defining the manage application permission.
     /// </summary>

--- a/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Extensions/AuthorizationServiceExtensions.cs
@@ -78,12 +78,9 @@ public static class AuthorizationServiceExtensions
 
         services
             .AddOptions<AuthorizationOptions>()
-            .Configure<IOptions<ApplicationAuthorizationOptions>>((authorizationOptions, applicationAuthorizationOptions) =>
-            {
-                authorizationOptions.FallbackPolicy = applicationAuthorizationOptions.Value.RequireAuthenticatedUserByDefault
+            .Configure<IOptions<ApplicationAuthorizationOptions>>((authorizationOptions, applicationAuthorizationOptions) => authorizationOptions.FallbackPolicy = applicationAuthorizationOptions.Value.RequireAuthenticatedUserByDefault
                     ? new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build()
-                    : null;
-            });
+                    : null);
 
         return services;
     }

--- a/src/ProjectTemplate.Web/Authentication/Options/ApplicationAuthorizationOptions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Options/ApplicationAuthorizationOptions.cs
@@ -11,6 +11,11 @@ public sealed class ApplicationAuthorizationOptions
     public const string SectionName = "ProjectTemplate:Authorization";
 
     /// <summary>
+    /// Gets or sets a value indicating whether routed endpoints without authorization metadata require an authenticated user.
+    /// </summary>
+    public bool RequireAuthenticatedUserByDefault { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the claim type used to evaluate role-based authorization policies.
     /// </summary>
     public string RoleClaimType { get; set; } = "application:role";

--- a/src/ProjectTemplate.Web/Extensions/HealthCheckExtensions.cs
+++ b/src/ProjectTemplate.Web/Extensions/HealthCheckExtensions.cs
@@ -26,17 +26,20 @@ public static class HealthCheckExtensions
     /// <returns>The original <see cref="WebApplication"/> for chaining.</returns>
     public static WebApplication MapApplicationHealthChecks(this WebApplication app)
     {
-        app.MapHealthChecks("/health");
+        app.MapHealthChecks("/health")
+            .AllowAnonymous();
 
         app.MapHealthChecks("/health/ready", new HealthCheckOptions
         {
             Predicate = healthCheck => healthCheck.Tags.Contains("ready")
-        });
+        })
+        .AllowAnonymous();
 
         app.MapHealthChecks("/health/live", new HealthCheckOptions
         {
             Predicate = _ => false
-        });
+        })
+        .AllowAnonymous();
 
         return app;
     }

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -61,58 +61,52 @@
         "XForwardedProto"
       ],
       "ForwardLimit": 1,
-      "RequireHeaderSymmetry": false,
-      "ClearKnownNetworksAndProxies": false,
+      "RequireHeaderSymmetry": true,
+      "AllowedHosts": [],
       "KnownProxies": [],
-      "KnownNetworks": [],
-      "AllowedHosts": []
+      "KnownNetworks": []
     },
     "SecurityHeaders": {
       "Enabled": true,
       "EnableContentSecurityPolicy": true,
+      "ContentSecurityPolicy": "default-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
       "EnablePermissionsPolicy": true,
-      "EnableCrossOriginHeaders": true,
-      "ContentSecurityPolicy": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline';",
-      "PermissionsPolicy": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)",
+      "PermissionsPolicy": "camera=(), microphone=(), geolocation=()",
+      "EnableCrossOriginOpenerPolicy": true,
+      "CrossOriginOpenerPolicy": "same-origin",
+      "EnableCrossOriginResourcePolicy": true,
+      "CrossOriginResourcePolicy": "same-origin",
+      "ReferrerPolicy": "strict-origin-when-cross-origin",
       "ExcludedPathPrefixes": [
-        "/health",
-        "/metrics"
+        "/health"
       ]
     },
     "RateLimiting": {
       "Enabled": true,
-      "UseGlobalLimiter": true,
-      "UseSharedUnknownClientPartition": false,
-      "UnknownClientPartitionKey": "unknown-client",
       "GlobalFixedWindow": {
+        "Enabled": true,
         "PermitLimit": 60,
         "WindowSeconds": 60,
         "QueueLimit": 0
       },
-      "FixedWindowPolicy": {
-        "PermitLimit": 60,
+      "NamedFixedWindow": {
+        "Enabled": true,
+        "PermitLimit": 30,
         "WindowSeconds": 60,
         "QueueLimit": 0
       },
-      "ConcurrencyPolicy": {
+      "NamedConcurrency": {
+        "Enabled": true,
         "PermitLimit": 10,
         "QueueLimit": 0
       }
     },
     "RequestLogging": {
       "Enabled": true,
-      "CorrelationHeaderName": "X-Correlation-ID",
-      "IncludeQueryString": false,
-      "IncludeUserName": true,
       "IncludeRemoteIpAddress": true,
+      "IncludeUserName": true,
       "ExcludedPathPrefixes": [
-        "/health",
-        "/metrics",
-        "/favicon.ico",
-        "/css",
-        "/js",
-        "/lib",
-        "/_framework"
+        "/health"
       ]
     },
     "OpenTelemetry": {
@@ -211,6 +205,7 @@
       "ProviderMappings": {}
     },
     "Authorization": {
+      "RequireAuthenticatedUserByDefault": true,
       "RoleClaimType": "application:role",
       "PermissionClaimType": "application:permission",
       "AdministratorRoles": [

--- a/src/ProjectTemplate.Web/appsettings.json
+++ b/src/ProjectTemplate.Web/appsettings.json
@@ -61,52 +61,58 @@
         "XForwardedProto"
       ],
       "ForwardLimit": 1,
-      "RequireHeaderSymmetry": true,
-      "AllowedHosts": [],
+      "RequireHeaderSymmetry": false,
+      "ClearKnownNetworksAndProxies": false,
       "KnownProxies": [],
-      "KnownNetworks": []
+      "KnownNetworks": [],
+      "AllowedHosts": []
     },
     "SecurityHeaders": {
       "Enabled": true,
       "EnableContentSecurityPolicy": true,
-      "ContentSecurityPolicy": "default-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
       "EnablePermissionsPolicy": true,
-      "PermissionsPolicy": "camera=(), microphone=(), geolocation=()",
-      "EnableCrossOriginOpenerPolicy": true,
-      "CrossOriginOpenerPolicy": "same-origin",
-      "EnableCrossOriginResourcePolicy": true,
-      "CrossOriginResourcePolicy": "same-origin",
-      "ReferrerPolicy": "strict-origin-when-cross-origin",
+      "EnableCrossOriginHeaders": true,
+      "ContentSecurityPolicy": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline';",
+      "PermissionsPolicy": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)",
       "ExcludedPathPrefixes": [
-        "/health"
+        "/health",
+        "/metrics"
       ]
     },
     "RateLimiting": {
       "Enabled": true,
+      "UseGlobalLimiter": true,
+      "UseSharedUnknownClientPartition": false,
+      "UnknownClientPartitionKey": "unknown-client",
       "GlobalFixedWindow": {
-        "Enabled": true,
         "PermitLimit": 60,
         "WindowSeconds": 60,
         "QueueLimit": 0
       },
-      "NamedFixedWindow": {
-        "Enabled": true,
-        "PermitLimit": 30,
+      "FixedWindowPolicy": {
+        "PermitLimit": 60,
         "WindowSeconds": 60,
         "QueueLimit": 0
       },
-      "NamedConcurrency": {
-        "Enabled": true,
+      "ConcurrencyPolicy": {
         "PermitLimit": 10,
         "QueueLimit": 0
       }
     },
     "RequestLogging": {
       "Enabled": true,
-      "IncludeRemoteIpAddress": true,
+      "CorrelationHeaderName": "X-Correlation-ID",
+      "IncludeQueryString": false,
       "IncludeUserName": true,
+      "IncludeRemoteIpAddress": true,
       "ExcludedPathPrefixes": [
-        "/health"
+        "/health",
+        "/metrics",
+        "/favicon.ico",
+        "/css",
+        "/js",
+        "/lib",
+        "/_framework"
       ]
     },
     "OpenTelemetry": {

--- a/tests/ProjectTemplate.Web.Tests/FallbackAuthorizationPolicyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/FallbackAuthorizationPolicyTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Web.Authentication.Options;
+using ProjectTemplate.Web.Tests.Extensions;
+using ProjectTemplate.Web.Tests.Infrastructure;
+
+namespace ProjectTemplate.Web.Tests;
+
+/// <summary>
+/// Provides integration coverage for the closed-by-default fallback authorization posture.
+/// </summary>
+public sealed class FallbackAuthorizationPolicyTests
+{
+    /// <summary>
+    /// Verifies that the configured authorization option is bound and the authenticated fallback policy is registered.
+    /// </summary>
+    [Fact]
+    public void FallbackPolicy_IsRegistered_WhenRequiredByConfiguration()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(
+            authenticationEnabled: true,
+            requireAuthenticatedUserByDefault: true);
+
+        ApplicationAuthorizationOptions applicationOptions = factory.Services
+            .GetRequiredService<IOptions<ApplicationAuthorizationOptions>>()
+            .Value;
+
+        AuthorizationOptions authorizationOptions = factory.Services
+            .GetRequiredService<IOptions<AuthorizationOptions>>()
+            .Value;
+
+        Assert.True(applicationOptions.RequireAuthenticatedUserByDefault);
+        Assert.NotNull(authorizationOptions.FallbackPolicy);
+        Assert.Contains(
+            authorizationOptions.FallbackPolicy.Requirements,
+            requirement => requirement is DenyAnonymousAuthorizationRequirement);
+    }
+
+    /// <summary>
+    /// Verifies that an unannotated controller action rejects an unauthenticated request when fallback authorization is enabled.
+    /// </summary>
+    [Fact]
+    public async Task UnannotatedControllerEndpoint_ReturnsUnauthorized_WhenFallbackPolicyIsEnabled()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(
+            authenticationEnabled: true,
+            requireAuthenticatedUserByDefault: true);
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/fallback",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that explicit anonymous metadata bypasses fallback authorization only for that endpoint.
+    /// </summary>
+    [Fact]
+    public async Task ExplicitAnonymousEndpoint_ReturnsOk_WhenFallbackPolicyIsEnabled()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(
+            authenticationEnabled: true,
+            requireAuthenticatedUserByDefault: true);
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/anonymous",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that an unannotated Razor Page is protected by the fallback policy.
+    /// </summary>
+    [Fact]
+    public async Task UnannotatedRazorPage_ChallengesAnonymousCaller_WhenFallbackPolicyIsEnabled()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(
+            authenticationEnabled: true,
+            requireAuthenticatedUserByDefault: true);
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        Assert.Equal("/Account/Login", response.Headers.Location.LocalPath);
+    }
+
+    /// <summary>
+    /// Verifies that applications can deliberately opt out of fallback authorization.
+    /// </summary>
+    [Fact]
+    public async Task UnannotatedControllerEndpoint_ReturnsOk_WhenFallbackPolicyIsDisabled()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(
+            authenticationEnabled: true,
+            requireAuthenticatedUserByDefault: false);
+        using HttpClient client = factory.CreateHttpsClient();
+
+        using HttpResponseMessage response = await client.GetAsync(
+            "/test/authentication/fallback",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Verifies that authentication-disabled applications cannot accidentally retain an authenticated fallback policy.
+    /// </summary>
+    [Fact]
+    public void ApplicationStartup_Fails_WhenAuthenticationIsDisabledAndFallbackRequiresAuthentication()
+    {
+        using ApplicationWebApplicationFactory factory = CreateFactory(
+            authenticationEnabled: false,
+            requireAuthenticatedUserByDefault: true);
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+            factory.Services
+                .GetRequiredService<IOptions<ApplicationAuthorizationOptions>>()
+                .Value);
+
+        Assert.Contains(
+            "ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault cannot be true when ProjectTemplate:Authentication:Enabled is false.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    private static ApplicationWebApplicationFactory CreateFactory(
+        bool authenticationEnabled,
+        bool requireAuthenticatedUserByDefault)
+    {
+        return new ApplicationWebApplicationFactory(new Dictionary<string, string?>
+        {
+            ["ProjectTemplate:Authentication:Enabled"] = authenticationEnabled.ToString(),
+            ["ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault"] = requireAuthenticatedUserByDefault.ToString()
+        });
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/FallbackAuthorizationPolicyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/FallbackAuthorizationPolicyTests.cs
@@ -141,6 +141,7 @@ public sealed class FallbackAuthorizationPolicyTests
         return new ApplicationWebApplicationFactory(new Dictionary<string, string?>
         {
             ["ProjectTemplate:Authentication:Enabled"] = authenticationEnabled.ToString(),
+            ["ProjectTemplate:Authentication:Cookie:Enabled"] = authenticationEnabled.ToString(),
             ["ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault"] = requireAuthenticatedUserByDefault.ToString()
         });
     }

--- a/tests/ProjectTemplate.Web.Tests/Infrastructure/ApplicationWebApplicationFactory.cs
+++ b/tests/ProjectTemplate.Web.Tests/Infrastructure/ApplicationWebApplicationFactory.cs
@@ -31,7 +31,17 @@ internal sealed class ApplicationWebApplicationFactory(IReadOnlyDictionary<strin
     {
         builder.UseEnvironment("Testing");
 
-        builder.ConfigureAppConfiguration((_, configurationBuilder) => configurationBuilder.AddInMemoryCollection(_configurationValues));
+        Dictionary<string, string?> testConfiguration = new()
+        {
+            ["ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault"] = "false"
+        };
+
+        foreach ((string key, string? value) in _configurationValues)
+        {
+            testConfiguration[key] = value;
+        }
+
+        builder.ConfigureAppConfiguration((_, configurationBuilder) => configurationBuilder.AddInMemoryCollection(testConfiguration));
 
         builder.ConfigureServices(services => services
                 .AddControllersWithViews()

--- a/tests/ProjectTemplate.Web.Tests/Infrastructure/ApplicationWebApplicationFactory.cs
+++ b/tests/ProjectTemplate.Web.Tests/Infrastructure/ApplicationWebApplicationFactory.cs
@@ -1,8 +1,50 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectTemplate.Web.Tests.TestControllers;
 
-namespace Project
+namespace ProjectTemplate.Web.Tests.Infrastructure;
+
+/// <summary>
+/// Provides a custom WebApplicationFactory for integration testing, allowing configuration values to be injected and
+/// the test environment to be set up with controllers from the specified assembly.
+/// </summary>
+/// <remarks>This factory sets the hosting environment to "Testing" and registers controllers from the assembly
+/// containing RateLimitingTestController. Use this class to create test server instances with custom configuration for
+/// integration tests.</remarks>
+/// <param name="configurationValues">A read-only dictionary containing configuration key-value pairs to be applied to the test application's
+/// configuration. Keys represent configuration paths; values may be null to clear a setting.</param>
+internal sealed class ApplicationWebApplicationFactory(IReadOnlyDictionary<string, string?> configurationValues) : WebApplicationFactory<Program>
+{
+    private readonly IReadOnlyDictionary<string, string?> _configurationValues = configurationValues;
+
+    /// <summary>
+    /// Configures the web host builder with test-specific settings, including environment, configuration, and services.
+    /// </summary>
+    /// <remarks>This method sets the environment to "Testing", adds in-memory configuration values, and
+    /// registers controllers from the test assembly. Override this method to customize the web host for integration
+    /// testing scenarios.</remarks>
+    /// <param name="builder">The <see cref="IWebHostBuilder"/> to configure with the testing environment, in-memory configuration values, and
+    /// required services.</param>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        Dictionary<string, string?> testConfiguration = new()
+        {
+            ["ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault"] = "false"
+        };
+
+        foreach ((string key, string? value) in _configurationValues)
+        {
+            testConfiguration[key] = value;
+        }
+
+        builder.ConfigureAppConfiguration((_, configurationBuilder) => configurationBuilder.AddInMemoryCollection(testConfiguration));
+
+        builder.ConfigureServices(services => services
+                .AddControllersWithViews()
+                .AddApplicationPart(typeof(AdvertisedBehaviorTestController).Assembly));
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/Infrastructure/ApplicationWebApplicationFactory.cs
+++ b/tests/ProjectTemplate.Web.Tests/Infrastructure/ApplicationWebApplicationFactory.cs
@@ -1,50 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectTemplate.Web.Tests.TestControllers;
 
-namespace ProjectTemplate.Web.Tests.Infrastructure;
-
-/// <summary>
-/// Provides a custom WebApplicationFactory for integration testing, allowing configuration values to be injected and
-/// the test environment to be set up with controllers from the specified assembly.
-/// </summary>
-/// <remarks>This factory sets the hosting environment to "Testing" and registers controllers from the assembly
-/// containing RateLimitingTestController. Use this class to create test server instances with custom configuration for
-/// integration tests.</remarks>
-/// <param name="configurationValues">A read-only dictionary containing configuration key-value pairs to be applied to the test application's
-/// configuration. Keys represent configuration paths; values may be null to clear a setting.</param>
-internal sealed class ApplicationWebApplicationFactory(IReadOnlyDictionary<string, string?> configurationValues) : WebApplicationFactory<Program>
-{
-    private readonly IReadOnlyDictionary<string, string?> _configurationValues = configurationValues;
-
-    /// <summary>
-    /// Configures the web host builder with test-specific settings, including environment, configuration, and services.
-    /// </summary>
-    /// <remarks>This method sets the environment to "Testing", adds in-memory configuration values, and
-    /// registers controllers from the test assembly. Override this method to customize the web host for integration
-    /// testing scenarios.</remarks>
-    /// <param name="builder">The <see cref="IWebHostBuilder"/> to configure with the testing environment, in-memory configuration values, and
-    /// required services.</param>
-    protected override void ConfigureWebHost(IWebHostBuilder builder)
-    {
-        builder.UseEnvironment("Testing");
-
-        Dictionary<string, string?> testConfiguration = new()
-        {
-            ["ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault"] = "false"
-        };
-
-        foreach ((string key, string? value) in _configurationValues)
-        {
-            testConfiguration[key] = value;
-        }
-
-        builder.ConfigureAppConfiguration((_, configurationBuilder) => configurationBuilder.AddInMemoryCollection(testConfiguration));
-
-        builder.ConfigureServices(services => services
-                .AddControllersWithViews()
-                .AddApplicationPart(typeof(AdvertisedBehaviorTestController).Assembly));
-    }
-}
+namespace Project

--- a/tests/ProjectTemplate.Web.Tests/TestControllers/AuthenticationTestController.cs
+++ b/tests/ProjectTemplate.Web.Tests/TestControllers/AuthenticationTestController.cs
@@ -23,6 +23,16 @@ public sealed class AuthenticationTestController : ControllerBase
     }
 
     /// <summary>
+    /// Returns an unannotated response governed by the fallback authorization policy.
+    /// </summary>
+    /// <returns>An <see cref="IActionResult"/> containing a fallback-policy result.</returns>
+    [HttpGet("fallback")]
+    public IActionResult Fallback()
+    {
+        return Ok(new { result = "fallback" });
+    }
+
+    /// <summary>
     /// Returns a protected response that requires an authenticated user.
     /// </summary>
     /// <returns>An <see cref="IActionResult"/> containing a protected result.</returns>


### PR DESCRIPTION
## Summary

- enables an authenticated-user fallback authorization policy by default
- adds `ProjectTemplate:Authorization:RequireAuthenticatedUserByDefault`
- generates a consistent opt-out when `--authProvider none` is selected
- rejects incompatible authentication-disabled/fallback-enabled configuration at startup
- preserves explicitly anonymous authentication and health-check endpoints
- adds integration coverage for unannotated controller actions, Razor Pages, explicit anonymous access, opt-out behavior, and startup validation
- updates authorization documentation for the closed-by-default posture

## Security impact

New routed endpoints without authorization metadata now inherit authenticated access in the default scaffold. Public routes must be declared explicitly through `[AllowAnonymous]`, `.AllowAnonymous()`, or an equivalent convention.

The authentication-disabled scaffold remains internally consistent by generating `RequireAuthenticatedUserByDefault: false`.

## Validation

Local `dotnet` validation could not be executed from the connector-only environment. The draft PR relies on the repository's CI build, formatting, test, coverage, template smoke-test, and CodeQL workflows for validation.

Closes #343