### PR TITLE
Suppress cross-ecosystem OWASP false positives

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -21,17 +21,18 @@ on:
   schedule:
     - cron: '30 9 * * 0'
 
-  # Re-scan when dependency manifests change
+  # Re-scan when dependency manifests or reviewed suppressions change.
   pull_request:
     paths:
       - '**/*.csproj'
       - '**/*.sln'
-      - '**/*.slnx' 
+      - '**/*.slnx'
       - '**/packages.config'
       - '**/packages.lock.json'
       - '**/packages.*.lock.json'
       - '**/Directory.Packages.props'
       - '**/Directory.Build.props'
+      - 'dependency-check-suppressions.xml'
 
 # Deny all token permissions unless granted by a job.
 permissions: {}
@@ -68,6 +69,7 @@ jobs:
           project: 'NetCoreApplicationTemplate'
           path: '.'
           format: 'SARIF'
+          others: '--suppression dependency-check-suppressions.xml'
 
       - name: Upload report artifact
         if: always()

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,27 +1,14 @@
 # This workflow uses actions that are not certified by GitHub. They are provided
-# by a third-party and are governed by separate terms of service, privacy
-# policy, and support documentation.
-#
-# OWASP Dependency-Check performs Software Composition Analysis (SCA): it scans
-# the project's NuGet/.NET dependencies for publicly disclosed vulnerabilities
-# (CVEs), mapping to OWASP Top 10 A06:2021 - Vulnerable and Outdated Components.
-# Results are uploaded as SARIF to the GitHub code-scanning dashboard.
-#
-# Note: the underlying `owasp/dependency-check-action` image runs with
-# `--noupdate` and ships with a pre-built NVD database, so no NVD API key or
-# secret is required. Database freshness tracks the image's build date.
+# by a third party and governed by separate terms, privacy policies, and support.
+# OWASP Dependency-Check scans the restored NuGet dependency graph and uploads
+# SARIF results to GitHub code scanning.
 
 name: OWASP Dependency-Check software composition analysis
 
 on:
-  # Manual trigger
   workflow_dispatch:
-
-  # Every Sunday morning
   schedule:
     - cron: '30 9 * * 0'
-
-  # Re-scan when dependency manifests or reviewed suppressions change.
   pull_request:
     paths:
       - '**/*.csproj'
@@ -34,7 +21,6 @@ on:
       - '**/Directory.Build.props'
       - 'dependency-check-suppressions.xml'
 
-# Deny all token permissions unless granted by a job.
 permissions: {}
 
 jobs:
@@ -44,7 +30,6 @@ jobs:
     timeout-minutes: 20
 
     permissions:
-      # Needed to upload SARIF results to the code-scanning dashboard.
       security-events: write
 
     steps:
@@ -58,8 +43,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Restore so the full transitive dependency graph (obj/project.assets.json)
-      # is available for Dependency-Check's NuGet analyzers to read.
       - name: Restore dependencies
         run: dotnet restore ./NetCoreApplicationTemplate.slnx --locked-mode
 
@@ -69,7 +52,7 @@ jobs:
           project: 'NetCoreApplicationTemplate'
           path: '.'
           format: 'SARIF'
-          others: '--suppression dependency-check-suppressions.xml'
+          others: '--suppression=/github/workspace/dependency-check-suppressions.xml'
 
       - name: Upload report artifact
         if: always()
@@ -78,9 +61,10 @@ jobs:
           name: dependency-check-report
           path: reports/
           retention-days: 5
+          if-no-files-found: warn
 
       - name: Upload results to code-scanning
-        if: always()
+        if: always() && hashFiles('reports/dependency-check-report.sarif') != ''
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: reports/dependency-check-report.sarif

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress until="2027-01-31Z">
+    <notes><![CDATA[
+      CVE-2026-39883 applies to the Go OpenTelemetry implementation and does not
+      affect the .NET OpenTelemetry.Exporter.OpenTelemetryProtocol NuGet package.
+      Limit this suppression to the exact NuGet package and CV

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,5 +3,4 @@
   <suppress until="2027-01-31Z">
     <notes><![CDATA[
       CVE-2026-39883 applies to the Go OpenTelemetry implementation and does not
-      affect the .NET OpenTelemetry.Exporter.OpenTelemetryProtocol NuGet package.
-      Limit this suppression to the exact NuGet package and CV
+      affect the .NET OpenTelemetry.Exporter

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2027-01-31Z">
-    <notes><![CDATA[
-      CVE-2026-39883 applies to the Go OpenTelemetry implementation and does not
-      affect the .NET OpenTelemetry.Exporter
+    <notes><![CDATA[CVE-2026-39883 applies to the Go OpenTelemetry implementation, not the .NET NuGet exporter.]]></notes>
+    <packageUrl regex="true">^pkg:nuget/OpenTelemetry\.Exporter\.OpenTelemetryProtocol@1\.16\.0$</packageUrl>
+    <cve>CVE-2026-39883</cve>
+  </suppress>
+  <suppress until="2027-01-31Z">
+    <notes><![CDATA[CVE-2012-2055 applies to GitHub Enterprise before March 4, 2012, not the ASP.NET OAuth client library.]]></notes>
+    <packageUrl regex="true">^pkg:nuget/AspNet\.Security\.OAuth\.GitHub@10\.0\.0$</packageUrl>
+    <cve>CVE-2012-2055</cve>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
## Summary

- adds a reviewed OWASP Dependency-Check suppression file
- suppresses `CVE-2026-39883` only for `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.16.0 because the CVE applies to the Go OpenTelemetry implementation, not the .NET NuGet package
- suppresses `CVE-2012-2055` only for `AspNet.Security.OAuth.GitHub` 10.0.0 because the CVE applies to GitHub Enterprise before March 4, 2012, not the OAuth client library
- adds expiration dates so both suppressions must be re-evaluated
- configures the OWASP workflow to load the reviewed suppression file
- re-runs dependency scanning when the suppression file changes

## Security impact

The change removes misleading high-severity alerts without broadly hiding either CVE. Each suppression is constrained to one exact Package URL and one CVE, preserving detection if the same CVE is associated with another dependency.

## Validation

- repository restore continues to use committed NuGet lock files and `--locked-mode`
- Dependency-Check receives the suppression file through its supported `--suppression` option
- the next OWASP SARIF upload should omit only the two reviewed false-positive package/CVE combinations