### PR TITLE
Extend OWASP false-positive suppressions

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,4 +2,22 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2027-01-31Z">
     <notes><![CDATA[CVE-2026-39883 applies to the Go OpenTelemetry implementation, not the .NET NuGet exporter.]]></notes>
-    <packageUrl regex="true">^pkg:nuget/OpenTelemetry\.Exporter\.OpenTelemetryProtocol
+    <packageUrl regex="true">^pkg:nuget/OpenTelemetry\.Exporter\.OpenTelemetryProtocol@1\.16\.0$</packageUrl>
+    <cve>CVE-2026-39883</cve>
+  </suppress>
+  <suppress until="2027-01-31Z">
+    <notes><![CDATA[CVE-2026-39883 applies to the Go OpenTelemetry implementation, not the .NET hosting extensions package.]]></notes>
+    <packageUrl regex="true">^pkg:nuget/OpenTelemetry\.Extensions\.Hosting@1\.16\.0$</packageUrl>
+    <cve>CVE-2026-39883</cve>
+  </suppress>
+  <suppress until="2027-01-31Z">
+    <notes><![CDATA[CVE-2012-2055 applies to GitHub Enterprise before March 4, 2012, not the ASP.NET OAuth client library.]]></notes>
+    <packageUrl regex="true">^pkg:nuget/AspNet\.Security\.OAuth\.GitHub@10\.0\.0$</packageUrl>
+    <cve>CVE-2012-2055</cve>
+  </suppress>
+  <suppress until="2027-01-31Z">
+    <notes><![CDATA[CVE-2012-2055 applies to GitHub Enterprise before March 4, 2012, not Microsoft.SourceLink.GitHub.]]></notes>
+    <packageUrl regex="true">^pkg:nuget/Microsoft\.SourceLink\.GitHub@10\.0\.300$</packageUrl>
+    <cve>CVE-2012-2055</cve>
+  </suppress>
+</suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,12 +2,4 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2027-01-31Z">
     <notes><![CDATA[CVE-2026-39883 applies to the Go OpenTelemetry implementation, not the .NET NuGet exporter.]]></notes>
-    <packageUrl regex="true">^pkg:nuget/OpenTelemetry\.Exporter\.OpenTelemetryProtocol@1\.16\.0$</packageUrl>
-    <cve>CVE-2026-39883</cve>
-  </suppress>
-  <suppress until="2027-01-31Z">
-    <notes><![CDATA[CVE-2012-2055 applies to GitHub Enterprise before March 4, 2012, not the ASP.NET OAuth client library.]]></notes>
-    <packageUrl regex="true">^pkg:nuget/AspNet\.Security\.OAuth\.GitHub@10\.0\.0$</packageUrl>
-    <cve>CVE-2012-2055</cve>
-  </suppress>
-</suppressions>
+    <packageUrl regex="true">^pkg:nuget/OpenTelemetry\.Exporter\.OpenTelemetryProtocol


### PR DESCRIPTION
## Summary

- adds an exact `CVE-2026-39883` suppression for `OpenTelemetry.Extensions.Hosting` 1.16.0
- adds an exact `CVE-2012-2055` suppression for `Microsoft.SourceLink.GitHub` 10.0.300
- preserves the existing package-specific suppressions for `OpenTelemetry.Exporter.OpenTelemetryProtocol` and `AspNet.Security.OAuth.GitHub`
- keeps all four suppressions time-bounded through January 31, 2027

## Security impact

Each suppression remains constrained to one exact NuGet Package URL and one CVE. The change does not suppress either CVE globally and preserves detection if the same CVE is associated with any other package.

## Validation

- restored the complete suppression XML atomically after detecting a truncated intermediate write
- retained the existing Dependency-Check workflow configuration and SARIF upload guard
- the OWASP scan will rerun because the suppression file changed