### PR TITLE
fix(ci): correct dependency review action version comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
 


### PR DESCRIPTION
### Summary

Corrects the pinned version comment for `actions/dependency-review-action` in the CI workflow.

### Changes

* Updated the comment from `v4` to `v5.0.0`.
* Preserved the existing immutable action SHA.
* No workflow behavior or dependency-review configuration changed.

### Security impact

This resolves the zizmor `ref-version-mismatch` warning and keeps the workflow’s pinned action metadata accurate and auditable.
