### PR TITLE
Configure owasp dependency-check to output all reports formats

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           project: 'NetCoreApplicationTemplate'
           path: '.'
-          format: 'SARIF'
+          format: 'ALL'
           others: '--suppression=/github/workspace/dependency-check-suppressions.xml'
 
       - name: Upload report artifact


### PR DESCRIPTION
## Summary

- Configure owasp dependency-check to output all reports formats

## Validation

- [ ] Documentation-only change.
- [ ] Ran `dotnet build NetCoreApplicationTemplate.slnx --configuration Release`.
- [ ] Ran `dotnet test NetCoreApplicationTemplate.slnx --configuration Release`.
- [ ] Ran `dotnet format NetCoreApplicationTemplate.slnx --verify-no-changes --verbosity minimal`.
- [ ] Ran `dotnet tool run docfx -- .\docs\docfx.json`.
- [x] Not applicable / explained below.

## Notes

CI configuration only. No code changes made.
