### PR TITLE
Add private vulnerability reporting link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Security fixes are applied to the current stable line unless otherwise noted in 
 
 Please report suspected security issues privately instead of opening a public GitHub issue.
 
-Use the repository owner's GitHub profile contact options or GitHub's private vulnerability reporting feature if it is enabled for this repository.
+Use [GitHub private vulnerability reporting](https://github.com/cdcavell/NetCoreApplicationTemplate/security/advisories/new) to submit a confidential report directly to the repository maintainer. If that form is unavailable, use the repository owner's GitHub profile contact options and do not include sensitive details in a public issue or discussion.
 
 When reporting a vulnerability, include:
 


### PR DESCRIPTION
## Summary

- adds a direct GitHub private vulnerability reporting link to `SECURITY.md`
- clarifies that suspected vulnerabilities must not be reported through public issues or discussions
- preserves the repository owner's profile contact options as a fallback when the private reporting form is unavailable

## Security impact

This makes the repository's confidential vulnerability reporting path explicit and directly discoverable to security researchers and automated policy checks.

## Validation

- confirmed `SECURITY.md` remains in the repository root
- confirmed the reporting link targets the repository's private advisory submission page
- confirmed no runtime, package, workflow, or generated-template behavior is changed
