### PR TITLE
Fix scorecard fuzzing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="FsCheck" Version="3.3.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />

--- a/tests/ProjectTemplate.Web.Tests/PersistenceStringPropertyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/PersistenceStringPropertyTests.cs
@@ -1,0 +1,58 @@
+using FsCheck;
+using FsCheck.Fluent;
+using ProjectTemplate.Infrastructure.Data;
+
+namespace ProjectTemplate.Web.Tests;
+
+/// <summary>
+/// Contains property-based tests for persistence string normalization behavior.
+/// </summary>
+public sealed class PersistenceStringPropertyTests
+{
+    /// <summary>
+    /// Verifies that required display-value normalization is idempotent for generated strings.
+    /// </summary>
+    [Fact]
+    public void NormalizeRequiredDisplayValue_IsIdempotentForGeneratedStrings()
+    {
+        Prop.ForAll<string>(value =>
+        {
+            string input = value ?? string.Empty;
+            string once = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(input);
+            string twice = PersistenceStringComparisonNormalizer.NormalizeRequiredDisplayValue(once);
+
+            return string.Equals(once, twice, StringComparison.Ordinal);
+        }).QuickCheckThrowOnFailure();
+    }
+
+    /// <summary>
+    /// Verifies that optional display-value normalization is idempotent for generated strings.
+    /// </summary>
+    [Fact]
+    public void NormalizeOptionalDisplayValue_IsIdempotentForGeneratedStrings()
+    {
+        Prop.ForAll<string>(value =>
+        {
+            string? once = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(value);
+            string? twice = PersistenceStringComparisonNormalizer.NormalizeOptionalDisplayValue(once);
+
+            return string.Equals(once, twice, StringComparison.Ordinal);
+        }).QuickCheckThrowOnFailure();
+    }
+
+    /// <summary>
+    /// Verifies that persistence canonicalization stabilizes after the first completed pass.
+    /// </summary>
+    [Fact]
+    public void Canonicalize_IsIdempotentForGeneratedStrings()
+    {
+        Prop.ForAll<string>(value =>
+        {
+            string input = value ?? string.Empty;
+            string once = PersistenceStringCanonicalizer.Canonicalize(input);
+            string twice = PersistenceStringCanonicalizer.Canonicalize(once);
+
+            return string.Equals(once, twice, StringComparison.Ordinal);
+        }).QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
+++ b/tests/ProjectTemplate.Web.Tests/ProjectTemplate.Web.Tests.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FsCheck" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />

--- a/tests/ProjectTemplate.Web.Tests/packages.lock.json
+++ b/tests/ProjectTemplate.Web.Tests/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "10.0.1",
         "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
       },
+      "FsCheck": {
+        "type": "Direct",
+        "requested": "[3.3.3, )",
+        "resolved": "3.3.3",
+        "contentHash": "FtJSNzekCwoVTJPLZwK2In1cr9PhIo6WAX/RSM7BL/jQERgnO0111+hdcN14pcog9BByJmqehBrMbjjKpHZULg==",
+        "dependencies": {
+          "FSharp.Core": "5.0.2"
+        }
+      },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
         "requested": "[10.0.10, )",
@@ -109,6 +118,11 @@
           "Microsoft.Identity.Client": "4.73.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.73.1"
         }
+      },
+      "FSharp.Core": {
+        "type": "Transitive",
+        "resolved": "5.0.2",
+        "contentHash": "DpcajqENgb3VXaHw1FKfVS+TWwEzck1PCajqLwBAVrtd1lfxd7T8JISVZBdV1mX9+2g48+tIgpNaVJWObdMrBw=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

* adds `FsCheck` through Central Package Management
* adds the `FsCheck` package reference to `ProjectTemplate.Web.Tests`
* introduces property-based tests for persistence string normalization and canonicalization
* verifies normalization operations remain idempotent across generated string inputs
* updates the applicable NuGet dependency lock file
* provides a C# property-testing integration recognized by the OpenSSF Scorecard `Fuzzing` check

## Security and Quality Impact

This change expands test coverage beyond fixed examples by generating varied string inputs, including empty values, whitespace, Unicode content, encoded characters, and unusual combinations.

The new property tests verify that:

```text
Normalize(Normalize(value)) == Normalize(value)
```

and:

```text
Canonicalize(Canonicalize(value)) == Canonicalize(value)
```

These invariants help detect unexpected behavior in persistence-bound string handling and reduce the risk of inconsistent normalization across repeated processing.

## OpenSSF Scorecard

OpenSSF recognizes FsCheck as a supported C# property-based testing integration. After this change is merged, a fresh Scorecard analysis should detect the repository’s fuzzing/property-testing coverage and resolve the existing `Fuzzing` finding.

## Behavioral Impact

* no application runtime behavior is changed
* no public API or configuration contract is changed
* no generated-template structure is changed
* the new dependency is limited to the test project

## Validation

* restored dependencies and updated the test project lock file
* verified locked-mode restore succeeds
* verified the solution builds successfully
* verified the new FsCheck property tests run through the existing xUnit test infrastructure
* confirmed existing unit and integration tests remain passing
