### PR TITLE
Harden authentication cookie Secure policy

### DIFF
--- a/docs/articles/authentication-hardening.md
+++ b/docs/articles/authentication-hardening.md
@@ -27,6 +27,28 @@ Before deployment, confirm:
 - Confirm login, callback, logout, and access-denied flows use the public origin.
 - Test security headers, HTTPS redirection, and callbacks behind the deployed proxy.
 
+## Authentication Cookie Secure Policy
+
+The local authentication cookie uses `CookieSecurePolicy.Always` by default. The cookie therefore receives the `Secure` attribute independently of the request scheme perceived by the application. Production deployments must serve authentication flows over HTTPS; a reverse-proxy or forwarded-header misconfiguration does not downgrade this cookie to a non-secure cookie.
+
+Local plain-HTTP authentication is available only through an explicit Development-only override:
+
+```json
+{
+  "ProjectTemplate": {
+    "Authentication": {
+      "Cookie": {
+        "AllowInsecureHttp": true
+      }
+    }
+  }
+}
+```
+
+Place this override only in local `appsettings.Development.json`, user secrets, or another Development-only configuration source. When enabled in Development, the cookie uses `CookieSecurePolicy.SameAsRequest`, so an HTTP request can receive the cookie without the `Secure` attribute.
+
+Startup validation rejects `ProjectTemplate:Authentication:Cookie:AllowInsecureHttp=true` in Testing, Staging, Production, or any environment other than Development. Do not use the override to compensate for TLS, proxy, forwarded-header, certificate, or callback configuration problems.
+
 ## Redirect, Callback, ACS, and Logout URLs
 
 - Register OIDC and OAuth redirect URIs exactly.

--- a/src/ProjectTemplate.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Extensions/AuthenticationServiceExtensions.cs
@@ -17,7 +17,8 @@ namespace ProjectTemplate.Web.Authentication.Extensions;
 public static class AuthenticationServiceExtensions
 {
     /// <summary>
-    /// Adds application authentication services based on configuration.
+    /// Adds application authentication services based on configuration using the secure cookie policy without an
+    /// environment-specific plain HTTP override.
     /// </summary>
     /// <param name="services">The service collection to add authentication services to.</param>
     /// <param name="configuration">The application configuration source.</param>
@@ -26,11 +27,27 @@ public static class AuthenticationServiceExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        return AddApplicationAuthentication(services, configuration, environment: null);
+    }
+
+    /// <summary>
+    /// Adds application authentication services based on configuration and the current hosting environment.
+    /// </summary>
+    /// <param name="services">The service collection to add authentication services to.</param>
+    /// <param name="configuration">The application configuration source.</param>
+    /// <param name="environment">The current hosting environment.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+    public static IServiceCollection AddApplicationAuthentication(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment? environment)
+    {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.AddTransient<IClaimsTransformation, ApplicationClaimsTransformation>();
-        services.AddSingleton<IValidateOptions<ApplicationAuthenticationOptions>, ApplicationAuthenticationOptionsValidator>();
+        services.AddSingleton<IValidateOptions<ApplicationAuthenticationOptions>>(
+            new ApplicationAuthenticationOptionsValidator(environment));
 
         services
             .AddOptions<ApplicationAuthenticationOptions>()
@@ -80,7 +97,10 @@ public static class AuthenticationServiceExtensions
                 options.Cookie.Name = ".ProjectTemplate.Web.Authentication";
                 options.Cookie.HttpOnly = true;
                 options.Cookie.SameSite = SameSiteMode.Lax;
-                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                options.Cookie.SecurePolicy = applicationAuthenticationOptions.Cookie.AllowInsecureHttp &&
+                    environment?.IsDevelopment() == true
+                        ? CookieSecurePolicy.SameAsRequest
+                        : CookieSecurePolicy.Always;
             });
 
         ApplicationAuthenticationOptions applicationAuthenticationOptions = configuration

--- a/src/ProjectTemplate.Web/Authentication/Options/ApplicationAuthenticationOptionsValidator.cs
+++ b/src/ProjectTemplate.Web/Authentication/Options/ApplicationAuthenticationOptionsValidator.cs
@@ -7,8 +7,11 @@ namespace ProjectTemplate.Web.Authentication.Options;
 /// <summary>
 /// Validates application authentication configuration during application startup.
 /// </summary>
-public sealed class ApplicationAuthenticationOptionsValidator : IValidateOptions<ApplicationAuthenticationOptions>
+public sealed class ApplicationAuthenticationOptionsValidator(IHostEnvironment? environment)
+    : IValidateOptions<ApplicationAuthenticationOptions>
 {
+    private readonly IHostEnvironment? _environment = environment;
+
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, ApplicationAuthenticationOptions options)
     {
@@ -28,7 +31,7 @@ public sealed class ApplicationAuthenticationOptionsValidator : IValidateOptions
             : ValidateOptionsResult.Fail(failures);
     }
 
-    private static void ValidateApplicationAuthentication(
+    private void ValidateApplicationAuthentication(
         ApplicationAuthenticationOptions options,
         ICollection<string> failures)
     {
@@ -65,6 +68,11 @@ public sealed class ApplicationAuthenticationOptionsValidator : IValidateOptions
         Require(
             options.Cookie.ExpireMinutes > 0,
             "ProjectTemplate:Authentication:Cookie:ExpireMinutes must be greater than zero when application authentication is enabled.",
+            failures);
+
+        Require(
+            !options.Cookie.AllowInsecureHttp || _environment?.IsDevelopment() == true,
+            "ProjectTemplate:Authentication:Cookie:AllowInsecureHttp may only be enabled in the Development environment.",
             failures);
     }
 

--- a/src/ProjectTemplate.Web/Authentication/Options/ApplicationAuthenticationOptionsValidator.cs
+++ b/src/ProjectTemplate.Web/Authentication/Options/ApplicationAuthenticationOptionsValidator.cs
@@ -50,6 +50,11 @@ public sealed class ApplicationAuthenticationOptionsValidator(IHostEnvironment? 
             "ProjectTemplate:Authentication:DefaultSignInScheme is required.",
             failures);
 
+        Require(
+            !options.Cookie.AllowInsecureHttp || _environment?.IsDevelopment() == true,
+            "ProjectTemplate:Authentication:Cookie:AllowInsecureHttp may only be enabled in the Development environment.",
+            failures);
+
         if (!options.Enabled)
         {
             return;
@@ -68,11 +73,6 @@ public sealed class ApplicationAuthenticationOptionsValidator(IHostEnvironment? 
         Require(
             options.Cookie.ExpireMinutes > 0,
             "ProjectTemplate:Authentication:Cookie:ExpireMinutes must be greater than zero when application authentication is enabled.",
-            failures);
-
-        Require(
-            !options.Cookie.AllowInsecureHttp || _environment?.IsDevelopment() == true,
-            "ProjectTemplate:Authentication:Cookie:AllowInsecureHttp may only be enabled in the Development environment.",
             failures);
     }
 

--- a/src/ProjectTemplate.Web/Authentication/Options/ApplicationCookieAuthenticationOptions.cs
+++ b/src/ProjectTemplate.Web/Authentication/Options/ApplicationCookieAuthenticationOptions.cs
@@ -39,4 +39,13 @@ public sealed class ApplicationCookieAuthenticationOptions
     /// Gets or sets a value indicating whether the cookie expiration should be renewed during active use.
     /// </summary>
     public bool SlidingExpiration { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether local Development environments may issue the authentication cookie for
+    /// plain HTTP requests.
+    /// </summary>
+    /// <remarks>
+    /// The default is <see langword="false" />. This override is rejected outside the Development environment.
+    /// </remarks>
+    public bool AllowInsecureHttp { get; set; }
 }

--- a/src/ProjectTemplate.Web/Program.cs
+++ b/src/ProjectTemplate.Web/Program.cs
@@ -34,7 +34,7 @@ try
     builder.Services.AddApplicationRequestLogging(builder.Configuration);
     builder.Services.AddApplicationOpenTelemetry(builder.Configuration, builder.Environment);
     builder.Services.AddApplicationProblemDetails(builder.Environment);
-    builder.Services.AddApplicationAuthentication(builder.Configuration);
+    builder.Services.AddApplicationAuthentication(builder.Configuration, builder.Environment);
     builder.Services.AddApplicationAuthorization(builder.Configuration);
     builder.Services.AddApplicationDataAccess(builder.Configuration);
 

--- a/tests/ProjectTemplate.Web.Tests/AuthenticationCookieSecurePolicyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthenticationCookieSecurePolicyTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;

--- a/tests/ProjectTemplate.Web.Tests/AuthenticationCookieSecurePolicyTests.cs
+++ b/tests/ProjectTemplate.Web.Tests/AuthenticationCookieSecurePolicyTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using ProjectTemplate.Web.Authentication.Extensions;
+using ProjectTemplate.Web.Authentication.Options;
+
+namespace ProjectTemplate.Web.Tests;
+
+public sealed class AuthenticationCookieSecurePolicyTests
+{
+    [Fact]
+    public void CookieSecurePolicy_DefaultsToAlways()
+    {
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            Environments.Production,
+            new Dictionary<string, string?>());
+
+        CookieAuthenticationOptions options = serviceProvider
+            .GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+            .Get(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        Assert.Equal(CookieSecurePolicy.Always, options.Cookie.SecurePolicy);
+    }
+
+    [Fact]
+    public void CookieSecurePolicy_DevelopmentOverride_UsesSameAsRequest()
+    {
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            Environments.Development,
+            new Dictionary<string, string?>
+            {
+                ["ProjectTemplate:Authentication:Cookie:AllowInsecureHttp"] = "true"
+            });
+
+        CookieAuthenticationOptions options = serviceProvider
+            .GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+            .Get(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        Assert.Equal(CookieSecurePolicy.SameAsRequest, options.Cookie.SecurePolicy);
+    }
+
+    [Fact]
+    public void CookieSecurePolicy_InsecureOverrideOutsideDevelopment_FailsValidation()
+    {
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            Environments.Production,
+            new Dictionary<string, string?>
+            {
+                ["ProjectTemplate:Authentication:Cookie:AllowInsecureHttp"] = "true"
+            });
+
+        OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+            serviceProvider
+                .GetRequiredService<IOptions<ApplicationAuthenticationOptions>>()
+                .Value);
+
+        Assert.Contains(
+            "ProjectTemplate:Authentication:Cookie:AllowInsecureHttp may only be enabled in the Development environment",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    private static ServiceProvider CreateServiceProvider(
+        string environmentName,
+        IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+        TestHostEnvironment environment = new(environmentName);
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddApplicationAuthentication(configuration, environment);
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+
+        public string ApplicationName { get; set; } = "ProjectTemplate.Web.Tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Summary

- change the local authentication cookie default from `CookieSecurePolicy.SameAsRequest` to `CookieSecurePolicy.Always`
- add an explicit `ProjectTemplate:Authentication:Cookie:AllowInsecureHttp` override for local Development only
- reject the insecure HTTP override during startup validation in every non-Development environment, even when application authentication is currently disabled
- pass the host environment into authentication registration so the policy is resolved deliberately
- document the HTTPS requirement, reverse-proxy behavior, and local plain-HTTP development path

## Tests

Added coverage for:

- secure cookies using `CookieSecurePolicy.Always` by default
- the explicit Development override using `CookieSecurePolicy.SameAsRequest`
- startup validation rejecting the override outside Development

## Validation

GitHub Actions CI passed:

- solution build and analyzer validation
- `dotnet format` verification
- full test suite
- coverage generation and repository threshold enforcement
- security-critical coverage thresholds
- dependency review
- CodeQL analysis
- template smoke tests on Ubuntu, Windows, and macOS
- Docker build, Compose startup, and health verification
- non-default no-auth/SQL Server scaffold validation

Fixes #372