### PR TITLE
Remove obsolete controller and test placeholders

### DIFF
--- a/src/ProjectTemplate.Web/Controllers/Api/ApplicationInformationController.cs.cs
+++ b/src/ProjectTemplate.Web/Controllers/Api/ApplicationInformationController.cs.cs
@@ -1,2 +1,0 @@
-// This file is intentionally left without type declarations.
-// The active sample API controller lives in ApplicationInformationController.cs.


### PR DESCRIPTION
Addresses the NetCoreApplicationTemplate checklist items tracked in cdcavell/AsiBackbone#641.

## Summary

- removes the duplicate `ApplicationInformationController.cs.cs` compilation-unit placeholder
- removes the zero-byte `AnonymousEndpointContractTests.cs` placeholder
- leaves the active application-information controller unchanged
- leaves existing authorization and endpoint tests unchanged

## Template packaging

The template package includes the repository `src/**` and `tests/**` trees directly. Removing these source placeholders therefore keeps generated template content synchronized without a separate `.template.content` copy.

## Compatibility

No runtime behavior or public API changes are intended. Both removed files contained no type declarations or test implementation.

## Testing

Local .NET execution was unavailable in this environment. Repository CI should validate build, formatting, tests, template packaging, generated scaffold checks, and documentation gates.