### PR TITLE
Harden Kubernetes deployment example

### DIFF
--- a/examples/kubernetes/projecttemplate-web.yaml
+++ b/examples/kubernetes/projecttemplate-web.yaml
@@ -16,9 +16,17 @@ spec:
         app.kubernetes.io/name: projecttemplate-web
         app.kubernetes.io/part-of: netcoreapplicationtemplate
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1654
+        runAsGroup: 1654
+        fsGroup: 1654
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: projecttemplate-web
-          image: ghcr.io/cdcavell/netcoreapplicationtemplate:latest
+          image: ghcr.io/cdcavell/netcoreapplicationtemplate:2.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -44,9 +52,19 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
           volumeMounts:
             - name: app-data


### PR DESCRIPTION
## Summary

Hardens `examples/kubernetes/projecttemplate-web.yaml` to address the container configuration findings reported by Snyk.

## Changes

- Pins the container image to the current `2.4.0` release instead of using `latest`.
- Adds pod-level `RuntimeDefault` seccomp configuration.
- Runs the workload with the non-root .NET container UID/GID (`1654`).
- Drops all Linux capabilities.
- Enables a read-only root filesystem while preserving writable data and log mounts.
- Adds CPU and memory requests and limits.
- Disables automatic service-account token mounting because the sample application does not require Kubernetes API access.

## Findings addressed

- Container does not drop all default capabilities.
- Container has no CPU limit.
- Container is running without a memory limit.
- Container could be running with an outdated image.
- Container's Pod UID could clash with host UID.
- Container is running with writable root filesystem.