### PR TITLE
Resolve remaining Snyk Kubernetes findings

### DIFF
--- a/examples/kubernetes/projecttemplate-web.yaml
+++ b/examples/kubernetes/projecttemplate-web.yaml
@@ -19,15 +19,15 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1654
-        runAsGroup: 1654
-        fsGroup: 1654
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: projecttemplate-web
           image: ghcr.io/cdcavell/netcoreapplicationtemplate:2.4.0
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary

Addresses the two remaining low-severity Snyk findings in `examples/kubernetes/projecttemplate-web.yaml` after the initial Kubernetes hardening update.

## Changes

- Changes the pod UID/GID from `1654` to the higher application-specific value `10001` to avoid Snyk's host UID collision warning.
- Changes `imagePullPolicy` from `IfNotPresent` to `Always` so Kubernetes checks the registry for the pinned image on each pod start.

## Notes

The image remains pinned to `2.4.0`; `Always` does not make the tag mutable, but it ensures the registry is consulted rather than relying indefinitely on a locally cached image.