### PR TITLE
Prepare release 2.5.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "NetCoreApplicationTemplate",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "upload_type": "software",
   "description": "A reusable ASP.NET Core application template for secure, maintainable, production-oriented .NET applications. It organizes startup composition, middleware ordering, structured logging, forwarded headers, security headers, rate limiting, centralized error handling, authentication and authorization foundations, EF Core data access patterns, CI validation, template packaging, and DocFX documentation.",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project are documented in this file.
 
 This project follows Semantic Versioning using the format `MAJOR.MINOR.PATCH`.
 
+## 2.5.0 - 2026-08-02
+
+### Added
+
+* Added `ProjectTemplate:DataAccess:Diagnostics` as an explicit EF Core diagnostics configuration surface.
+* Added `ProjectTemplate:DataAccess:Diagnostics:EnableDetailedErrors` for opt-in EF Core detailed error diagnostics.
+* Added `ProjectTemplate:DataAccess:Diagnostics:EnableEfCoreTraceBridge` for opt-in forwarding of EF Core simple logging through `ILogger<ApplicationDbContext>` at `Trace` level.
+* Added dedicated EF Core diagnostics documentation covering standard EF Core logging, detailed errors, the optional trace bridge, sensitive-data logging boundaries, and recommended operational use.
+* Added regression coverage verifying EF Core diagnostics behavior for both scoped `ApplicationDbContext` instances and contexts created through `IDbContextFactory<ApplicationDbContext>`.
+
+### Changed
+
+* Changed EF Core detailed errors from always enabled to explicitly opt-in, with `EnableDetailedErrors` defaulting to `false`.
+* Changed the custom EF Core `LogTo(...)` trace bridge from always enabled to explicitly opt-in, with `EnableEfCoreTraceBridge` defaulting to `false`.
+* Moved optional EF Core diagnostics configuration into the infrastructure data-access registration so scoped and factory-created contexts receive the same settings.
+* Preserved the `ApplicationSaveChangesInterceptor` independently of optional diagnostic settings so auditing, canonicalization, mutation manifests, and other save-pipeline behavior remain active when diagnostics are disabled.
+* Preserved EF Core's standard `Microsoft.Extensions.Logging` integration as the normal production logging path.
+* Updated OpenTelemetry ASP.NET Core and HTTP instrumentation to `1.17.0`.
+* Updated `SQLitePCLRaw.bundle_e_sqlite3` to `3.0.4`.
+* Updated GitHub Actions dependencies including checkout, .NET setup, CodeQL, OpenSSF Scorecard, Zizmor, and Docker registry authentication tooling.
+* Refreshed NuGet dependency lock files for the updated dependency graph.
+* Updated repository, package, template-packaging, citation, Zenodo, and Kubernetes example metadata for release `2.5.0`.
+
+### Security
+
+* Hardened the Kubernetes deployment example with a `RuntimeDefault` seccomp profile.
+* Configured the Kubernetes workload to run as a non-root application-specific UID/GID (`10001`).
+* Configured the Kubernetes container to drop all Linux capabilities.
+* Enabled a read-only container root filesystem while retaining explicitly writable data and logging volumes.
+* Added CPU and memory requests and limits to the Kubernetes example.
+* Disabled automatic Kubernetes service-account token mounting because the sample application does not require Kubernetes API access.
+* Changed the Kubernetes example to always check the registry for its version-pinned image on pod startup.
+* Kept EF Core sensitive-data logging disabled when either of the new diagnostic options is enabled; detailed errors and the trace bridge do not implicitly enable `EnableSensitiveDataLogging()`.
+
+### Compatibility
+
+* This is a backward-compatible minor release within the stable `2.x` package line.
+* The public NuGet package ID remains `NetCoreApplicationTemplate`.
+* The template short name remains `netcoreapp-template`.
+* The internal template and template-group identities remain unchanged.
+* Supported template options remain unchanged.
+* Existing projects generated from earlier releases are not modified automatically.
+* Both new EF Core diagnostic settings default to `false` when omitted.
+* Applications that do not opt into the new diagnostics retain normal EF Core `Microsoft.Extensions.Logging` behavior without the additional detailed-error or `LogTo(...)` diagnostic pipelines.
+* The existing save-changes interceptor and persistence pipeline remain active regardless of the optional diagnostics configuration.
+
+
 ## 2.4.0 - 2026-07-20
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "NetCoreApplicationTemplate"
-version: "2.4.0"
-date-released: "2026-07-20"
+version: "2.5.0"
+date-released: "2026-08-02"
 repository-code: "https://github.com/cdcavell/NetCoreApplicationTemplate"
 url: "https://cdcavell.github.io/NetCoreApplicationTemplate/"
 type: software

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <AssemblyVersion>2.4.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
+    <AssemblyVersion>2.5.0.0</AssemblyVersion>
+    <FileVersion>2.5.0.0</FileVersion>
     <InformationalVersion>$(Version)+$(RepositoryUrl)</InformationalVersion>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/NetCoreApplicationTemplate.Template.csproj
+++ b/NetCoreApplicationTemplate.Template.csproj
@@ -13,8 +13,8 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE-README.md</PackageReadmeFile>
     <PackageIcon>PACKAGE-ICON.png</PackageIcon>
-    <PackageReleaseNotes>Minor 2.4.0 release of the NetCoreApplicationTemplate dotnet new template. This release adds authenticated-by-default routed endpoints, secure authentication-cookie defaults, forwarded-header trust diagnostics, framework-neutral audit accountability context, privacy-safe canonical mutation manifests, opt-in audited transaction coordination, a durable audit-completion outbox, audit reconciliation, integrity health checks, and operational metrics while preserving the stable 2.x package and template identities.</PackageReleaseNotes>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <PackageReleaseNotes>Minor 2.5.0 release of the NetCoreApplicationTemplate dotnet new template. This release adds explicit opt-in EF Core diagnostics controls with production-oriented defaults, hardens the Kubernetes deployment example, updates observability and SQLite runtime dependencies, and refreshes GitHub Actions security tooling while preserving the stable 2.x package, template identities, and supported template options.</PackageReleaseNotes>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version>$(VersionPrefix)</Version>
     <PackageType>Template</PackageType>

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -20,13 +20,13 @@ This README is intended for NuGet package consumers. The full repository README 
 Install the template package from NuGet:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.4.0
+dotnet new install NetCoreApplicationTemplate::2.5.0
 ```
 
 For local package validation, install a packed package directly:
 
 ```text
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.4.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.5.0.nupkg
 ```
 
 ## Generate a project
@@ -88,7 +88,7 @@ dotnet test --configuration Release
 Install the newer package version with the same package identity:
 
 ```text
-dotnet new install NetCoreApplicationTemplate::2.4.0
+dotnet new install NetCoreApplicationTemplate::2.5.0
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A reusable, production-oriented ASP.NET Core application template with structure
 ## Current Release
 
 <!-- BEGIN LATEST_RELEASE -->
-Current release: __[Release 2.4.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.4.0)__
+Current release: __[Release 2.5.0](https://github.com/cdcavell/NetCoreApplicationTemplate/releases/tag/v2.5.0)__
 
-Tag: `v2.4.0`
+Tag: `v2.5.0`
 <!-- END LATEST_RELEASE -->
 
 ## Default Security Posture
@@ -84,13 +84,13 @@ Health routes are explicitly anonymous at the application layer for infrastructu
 Install the published package:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.4.0
+dotnet new install NetCoreApplicationTemplate::2.5.0
 ```
 
 For local package validation, install the packed package directly:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.4.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.5.0.nupkg
 ```
 
 Generate the default cookie-authenticated scaffold:
@@ -175,7 +175,7 @@ This project follows Semantic Versioning. Version metadata is managed centrally 
 Suggested citation:
 
 ```text
-Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.4.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
+Cavell, Christopher D. NetCoreApplicationTemplate. Version 2.5.0. Zenodo. MIT License. https://doi.org/10.5281/zenodo.20373042
 ```
 
 ## License

--- a/docs/articles/template-packaging.md
+++ b/docs/articles/template-packaging.md
@@ -16,7 +16,7 @@ Package-based validation is preferred because it verifies the actual distributio
 | Template identity | `CDCavell.NetCoreApplicationTemplate.CSharp` |
 | Template group identity | `CDCavell.NetCoreApplicationTemplate` |
 | Source replacement token | `ProjectTemplate` |
-| Current package version | `2.4.0` |
+| Current package version | `2.5.0` |
 
 The `2.0.0` release moved the public NuGet package ID to `NetCoreApplicationTemplate`. The internal template identity and group identity remain unchanged for template metadata continuity.
 
@@ -92,13 +92,13 @@ dotnet pack ./NetCoreApplicationTemplate.Template.csproj --configuration Release
 Install the published package from NuGet:
 
 ```powershell
-dotnet new install NetCoreApplicationTemplate::2.4.0
+dotnet new install NetCoreApplicationTemplate::2.5.0
 ```
 
 Install a locally packed package:
 
 ```powershell
-dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.4.0.nupkg
+dotnet new install ./artifacts/template-package/NetCoreApplicationTemplate.2.5.0.nupkg
 ```
 
 ## Create a New Project from the Template

--- a/examples/kubernetes/projecttemplate-web.yaml
+++ b/examples/kubernetes/projecttemplate-web.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: projecttemplate-web
-          image: ghcr.io/cdcavell/netcoreapplicationtemplate:2.4.0
+          image: ghcr.io/cdcavell/netcoreapplicationtemplate:2.5.0
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- bump shared assembly and template package version metadata to `2.5.0`
- update NuGet package release notes for the minor release
- update README, package README, and template-packaging examples to `2.5.0`
- update citation and Zenodo metadata with the August 2, 2026 release date
- update the hardened Kubernetes deployment example to the `2.5.0` container image
- include the manually prepared `CHANGELOG.md` entry for `2.5.0`
- preserve the existing package ID, template identity, short name, and supported template options

## Release focus

Release `2.5.0` captures the accumulated backward-compatible work since `2.4.0`, including:

- explicit opt-in EF Core detailed errors and trace-bridge diagnostics with production-oriented defaults
- preserved standard EF Core `Microsoft.Extensions.Logging` behavior and sensitive-data logging boundaries
- hardened Kubernetes deployment defaults including non-root execution, seccomp, dropped capabilities, read-only root filesystem, resource limits, disabled service-account token mounting, and registry refresh behavior
- OpenTelemetry and SQLite runtime dependency updates
- refreshed GitHub Actions, CodeQL, OpenSSF Scorecard, Zizmor, and Docker authentication tooling

## Validation

Repository CI should validate version consistency, package generation, build, tests, formatting, documentation, template smoke tests, security checks, and release workflow contracts before the draft is marked ready for review.